### PR TITLE
Start Open API yml with endpoints from #44

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -11,10 +11,9 @@ info:
   license:
     name: Creative Commons Zero v1.0 Universal
     url: https://creativecommons.org/publicdomain/zero/1.0/legalcode
-  termsOfService: http://cve.mitre.org/api/terms
-# The following is notional
+  termsOfService: http://placeholder.cve.mitre.org/api/terms
 servers:
-  - url: https://api-dev.cve.org/v1
+  - url: https://api-dev.cve.mitre.org/v1
     description: Development and testing server
   - url: https://api.cve.mitre.org/v1
     description: Production server
@@ -29,6 +28,13 @@ components:
         # CVE ID format
         type: string
         pattern: 'CVE-\d{4}-\d+'
+    org-shortname:
+      name: shortname
+      in: path
+      description: The shortname for an organization in the system
+      required: true
+      schema:
+        type: string
     api-entity-header:
       name: CVE-API-CNA
       description: >
@@ -59,6 +65,9 @@ paths:
     get:
       summary: Retrieves all CVE IDs entity owns.
       parameters:
+        - "$ref": "#/components/parameters/api-entity-header"
+        - "$ref": "#/components/parameters/api-secret-header"
+        - "$ref": "#/components/parameters/api-user-header"
         - in: query
         name: state
         schema:
@@ -81,12 +90,25 @@ paths:
         description: "Get all CVE IDs created (reserved) after timestamp"
     post:
       summary: Reserves IDs for the entity.
+      parameters:
+        - "$ref": "#/components/parameters/api-entity-header"
+        - "$ref": "#/components/parameters/api-secret-header"
+        - "$ref": "#/components/parameters/api-user-header"
+        - in: query
+        name: 
+        schema:
+          type: string
+        description:
   /cve-id/{cve-id}:
     parameters:
       - "$ref": "#/components/parameters/cve-id-path"
     get:
       summary: Retrieves a CVE ID by ID, can be a CVE the entity doesn't own if in a PUBLIC or REJECT state.
       operationId: getCVEIdById
+      parameters:
+        - "$ref": "#/components/parameters/api-entity-header"
+        - "$ref": "#/components/parameters/api-secret-header"
+        - "$ref": "#/components/parameters/api-user-header"
       responses:
         200:
           description: >
@@ -99,7 +121,7 @@ paths:
         401:
           description: Not Authenticated
         404:
-            description: Not Found
+          description: Not Found
     post:
       summary: Endpoint for Admin purposes to change state and ownership of the CVE ID.
       operationId: submitCVEIdById
@@ -128,3 +150,122 @@ paths:
           description: Forbidden
         404:
           description: Not Found
+  /cve-id/{cve-id}:
+    parameters:
+      - "$ref": "#/components/parameters/cve-id-path"
+    get:
+      summary: Retrieves a CVE ID by ID, can be a CVE the entity doesn't own if in a PUBLIC or REJECT state.
+      operationId: getCVEIdById
+      parameters:
+        - "$ref": "#/components/parameters/api-entity-header"
+        - "$ref": "#/components/parameters/api-secret-header"
+        - "$ref": "#/components/parameters/api-user-header"
+      responses:
+        200:
+          description: >
+            The requested CVE ID is returned.
+          content:
+            application/json:
+              schema:
+                type: object
+                # add CVE-ID JSON format
+        401:
+          description: Not Authenticated
+        404:
+            description: Not Found
+    # Posts only accessible by Secretariat
+    post:
+      summary: Endpoint for Admin purposes to change state and ownership of the CVE ID.
+      operationId: submitCVEIdById
+      parameters:
+        - "$ref": "#/components/parameters/api-entity-header"
+        - "$ref": "#/components/parameters/api-secret-header"
+        - "$ref": "#/components/parameters/api-user-header"
+        - in: query
+        name: state
+        schema:
+          type: string
+        description: "Change state of CVE ID to either PUBLIC or REJECT"
+        - in: query
+        name: cna
+        schema:
+          type: string
+        description: "Change owning CNA of CVE ID to new CNA (shortname)"
+      responses:
+        200:
+          description: Success
+        400:
+          description: Bad Request
+        401:
+          description: Not Authenticated
+        403:
+          description: Forbidden
+        404:
+          description: Not Found
+  # User Registry service
+  /cna/:shortname/id_quota:
+    get:
+      summary: Allows an Org to see details about their id_quota.
+      operationId: getIdQuota
+      parameters:
+        - "$ref": "#/components/parameters/api-entity-header"
+        - "$ref": "#/components/parameters/api-secret-header"
+        - "$ref": "#/components/parameters/api-user-header"
+  # Will only be accessible to Secretariat
+  /cna/:shortname:
+    parameters:
+      - "$ref": "#/components/parameters/org-shortname"
+    post:
+      summary: Endpoint for Admin purposes to change organization details.
+      operationId: submitOrgByShortname
+      parameters:
+        - "$ref": "#/components/parameters/api-entity-header"
+        - "$ref": "#/components/parameters/api-secret-header"
+        - "$ref": "#/components/parameters/api-user-header"
+        -in: query
+        name: id_quota
+        schema:
+          type: integer
+        description: "Change the id_quota for an Org"
+        -in: query
+        name: active_roles.add
+        schema:
+          type: string
+        description: "Add a role to an Org (only CNA allowed for now)"
+        -in: query
+        name: active_roles.remove
+        schema:
+          type: string
+        description: "Remove a role from an Org (only CNA allowed for now)"
+        -in: query
+        name: shortname
+        schema:
+          type: string
+        description: "Change the shortname of an Org"
+        -in: query
+        name: name
+        schema:
+          type: string
+        description: "Change the human friendly name of an Org"
+  /cna/:shortname/user/:username:
+    post:
+      summary: Allows admin to change properties of users
+      operationId: submitUser
+      parameters:
+        - "$ref": "#/components/parameters/api-entity-header"
+        - "$ref": "#/components/parameters/api-secret-header"
+        - "$ref": "#/components/parameters/api-user-header"
+        -in: query
+        name: active
+        schema:
+          type: boolean
+        description: "Indicates whether the account should be active or not"
+  /cna/:shortname/user/:username/reset_secret:
+    post:
+      summary: Resets the user's API Secret
+      operationId: resetUserSecret
+      parameters:
+        - "$ref": "#/components/parameters/api-entity-header"
+        - "$ref": "#/components/parameters/api-secret-header"
+        - "$ref": "#/components/parameters/api-user-header"
+

--- a/openapi.yml
+++ b/openapi.yml
@@ -316,7 +316,44 @@ paths:
           description: "Change the human friendly name of an Org"
       responses:
         200:
-          description: Success
+          description: Updated organization object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: The presentation name of the organization.
+                  short_name:
+                    type: string
+                    description: The unique, referencable name of the organization that can be used to identify the organization.
+                  UUID:
+                    type: string
+                    format: uuid
+                    description: The unique ID that does not change despite short_name or name for the organization changing.
+                  authority:
+                    type: object
+                    properties:
+                      active_roles:
+                        type: array
+                        items:
+                          type: string
+                          enum: [CNA] # Future will include Root_CNA, ADP
+                  policies:
+                    type: object
+                    properties:
+                      id_quota:
+                        type: number
+                  time:
+                    type: object
+                    properties:
+                      created:
+                        type: string
+                        format: date-time
+                      modified:
+                        type: string
+                        format: date-time
         400:
           description: Bad Request
         401:
@@ -342,7 +379,34 @@ paths:
           description: "Indicates whether the account should be active or not"
       responses:
         200:
-          description: Success
+          description: The updated user object
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  username:
+                    type: string
+                    description: The unique (for the organization they belong to) name to reference the user's account.
+                  cna_short_name:
+                    type: string
+                    description: The unique, referencable name of the organization the user belongs to.
+                  UUID:
+                    type: string
+                    format: uuid
+                    description: The unique ID that does not change despite other changes to the account.
+                  active:
+                    type: boolean
+                    description: Indicates whether the user is active and able to execute functions amongst the system.
+                  time:
+                    type: object
+                    properties:
+                      created:
+                        type: string
+                        format: date-time
+                      modified:
+                        type: string
+                        format: date-time
         400:
           description: Bad Request
         401:

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,4 +1,4 @@
-# this API specification is draft and subject to change.
+# this API specification is a draft and subject to change.
 openapi: "3.0.2"
 info:
   title: CVE Services API
@@ -69,25 +69,38 @@ paths:
         - "$ref": "#/components/parameters/api-secret-header"
         - "$ref": "#/components/parameters/api-user-header"
         - in: query
-        name: state
-        schema:
-          type: string
-        description: "Filter by CVE state: RESERVED, PUBLIC, or REJECT"
+          name: state
+          schema:
+            type: string
+          description: "Filter by CVE state: RESERVED, PUBLIC, or REJECT"
         - in: query
-        name: cve_id_year
-        schema:
-          type: integer
-        description: "Filter by the year in the CVE ID (YYYY)"
+          name: cve_id_year
+          schema:
+            type: integer
+          description: "Filter by the year in the CVE ID (YYYY)"
         - in: query
-        name: time_created.lt
-        schema:
-          type: timestamp
-        description: "Get all CVE IDs created (reserved) before timestamp"
+          name: time_created.lt
+          schema:
+            type: string
+            format: date-time
+          description: "Get all CVE IDs created (reserved) before timestamp"
         - in: query
-        name: time_created.gt
-        schema:
-          type: timestamp
-        description: "Get all CVE IDs created (reserved) after timestamp"
+          name: time_created.gt
+          schema:
+            type: string
+            format: date-time
+          description: "Get all CVE IDs created (reserved) after timestamp"
+      responses:
+        200:
+          description: Success
+        400:
+          description: Bad Request
+        401:
+          description: Not Authenticated
+        403:
+          description: Forbidden
+        404:
+          description: Not Found
     post:
       summary: Reserves IDs for the entity.
       parameters:
@@ -95,50 +108,10 @@ paths:
         - "$ref": "#/components/parameters/api-secret-header"
         - "$ref": "#/components/parameters/api-user-header"
         - in: query
-        name: 
-        schema:
-          type: string
-        description:
-  /cve-id/{cve-id}:
-    parameters:
-      - "$ref": "#/components/parameters/cve-id-path"
-    get:
-      summary: Retrieves a CVE ID by ID, can be a CVE the entity doesn't own if in a PUBLIC or REJECT state.
-      operationId: getCVEIdById
-      parameters:
-        - "$ref": "#/components/parameters/api-entity-header"
-        - "$ref": "#/components/parameters/api-secret-header"
-        - "$ref": "#/components/parameters/api-user-header"
-      responses:
-        200:
-          description: >
-            The requested CVE ID is returned.
-          content:
-            application/json:
-              schema:
-                type: object
-                # add CVE-ID JSON format
-        401:
-          description: Not Authenticated
-        404:
-          description: Not Found
-    post:
-      summary: Endpoint for Admin purposes to change state and ownership of the CVE ID.
-      operationId: submitCVEIdById
-      parameters:
-        - "$ref": "#/components/parameters/api-entity-header"
-        - "$ref": "#/components/parameters/api-secret-header"
-        - "$ref": "#/components/parameters/api-user-header"
-        - in: query
-        name: state
-        schema:
-          type: string
-        description: "Change state of CVE ID to either PUBLIC or REJECT"
-        - in: query
-        name: cna
-        schema:
-          type: string
-        description: "Change owning CNA of CVE ID to new CNA (shortname)"
+          name: sequential
+          schema:
+            type: boolean
+          description: Indicates whether IDs should be sequential
       responses:
         200:
           description: Success
@@ -182,15 +155,15 @@ paths:
         - "$ref": "#/components/parameters/api-secret-header"
         - "$ref": "#/components/parameters/api-user-header"
         - in: query
-        name: state
-        schema:
-          type: string
-        description: "Change state of CVE ID to either PUBLIC or REJECT"
+          name: state
+          schema:
+            type: string
+          description: "Change state of CVE ID to either PUBLIC or REJECT"
         - in: query
-        name: cna
-        schema:
-          type: string
-        description: "Change owning CNA of CVE ID to new CNA (shortname)"
+          name: cna
+          schema:
+            type: string
+          description: "Change owning CNA of CVE ID to new CNA (shortname)"
       responses:
         200:
           description: Success
@@ -211,6 +184,17 @@ paths:
         - "$ref": "#/components/parameters/api-entity-header"
         - "$ref": "#/components/parameters/api-secret-header"
         - "$ref": "#/components/parameters/api-user-header"
+      responses:
+        200:
+          description: Success
+        400:
+          description: Bad Request
+        401:
+          description: Not Authenticated
+        403:
+          description: Forbidden
+        404:
+          description: Not Found
   # Will only be accessible to Secretariat
   /cna/:shortname:
     parameters:
@@ -222,31 +206,42 @@ paths:
         - "$ref": "#/components/parameters/api-entity-header"
         - "$ref": "#/components/parameters/api-secret-header"
         - "$ref": "#/components/parameters/api-user-header"
-        -in: query
-        name: id_quota
-        schema:
-          type: integer
-        description: "Change the id_quota for an Org"
-        -in: query
-        name: active_roles.add
-        schema:
-          type: string
-        description: "Add a role to an Org (only CNA allowed for now)"
-        -in: query
-        name: active_roles.remove
-        schema:
-          type: string
-        description: "Remove a role from an Org (only CNA allowed for now)"
-        -in: query
-        name: shortname
-        schema:
-          type: string
-        description: "Change the shortname of an Org"
-        -in: query
-        name: name
-        schema:
-          type: string
-        description: "Change the human friendly name of an Org"
+        - in: query
+          name: id_quota
+          schema:
+            type: integer
+          description: "Change the id_quota for an Org"
+        - in: query
+          name: active_roles.add
+          schema:
+            type: string
+          description: "Add a role to an Org (only CNA allowed for now)"
+        - in: query
+          name: active_roles.remove
+          schema:
+            type: string
+          description: "Remove a role from an Org (only CNA allowed for now)"
+        - in: query
+          name: shortname
+          schema:
+            type: string
+          description: "Change the shortname of an Org"
+        - in: query
+          name: name
+          schema:
+            type: string
+          description: "Change the human friendly name of an Org"
+      responses:
+        200:
+          description: Success
+        400:
+          description: Bad Request
+        401:
+          description: Not Authenticated
+        403:
+          description: Forbidden
+        404:
+          description: Not Found
   /cna/:shortname/user/:username:
     post:
       summary: Allows admin to change properties of users
@@ -255,11 +250,22 @@ paths:
         - "$ref": "#/components/parameters/api-entity-header"
         - "$ref": "#/components/parameters/api-secret-header"
         - "$ref": "#/components/parameters/api-user-header"
-        -in: query
-        name: active
-        schema:
-          type: boolean
-        description: "Indicates whether the account should be active or not"
+        - in: query
+          name: active
+          schema:
+            type: boolean
+          description: "Indicates whether the account should be active or not"
+      responses:
+        200:
+          description: Success
+        400:
+          description: Bad Request
+        401:
+          description: Not Authenticated
+        403:
+          description: Forbidden
+        404:
+          description: Not Found
   /cna/:shortname/user/:username/reset_secret:
     post:
       summary: Resets the user's API Secret
@@ -268,4 +274,21 @@ paths:
         - "$ref": "#/components/parameters/api-entity-header"
         - "$ref": "#/components/parameters/api-secret-header"
         - "$ref": "#/components/parameters/api-user-header"
+      responses:
+        200:
+          description: Success
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: KCXC9JD-08M4WGH-M9294W1-B6RTBTH
+        400:
+          description: Bad Request
+        401:
+          description: Not Authenticated
+        403:
+          description: Forbidden
+        404:
+          description: Not Found
+
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -6,12 +6,12 @@ info:
   version: 0.1.0
   contact:
     "name": "CVE Services API"
-    "url": http://cve.mitre.org/api
+    "url": https://cve.mitre.org/api
     "email": placeholder-cve-services-api@mitre.org
   license:
     name: Creative Commons Zero v1.0 Universal
     url: https://creativecommons.org/publicdomain/zero/1.0/legalcode
-  termsOfService: http://placeholder.cve.mitre.org/api/terms
+  termsOfService: https://placeholder.cve.mitre.org/api/terms
 servers:
   - url: https://api-dev.cve.mitre.org/v1
     description: Development and testing server

--- a/openapi.yml
+++ b/openapi.yml
@@ -25,7 +25,6 @@ components:
       description: The CVE ID for which the record is being submitted
       required: true
       schema:
-        # CVE ID format
         type: string
         pattern: 'CVE-\d{4}-\d+'
     org-shortname:
@@ -59,6 +58,41 @@ components:
       required: true
       schema:
         type: string
+  schemas:
+    cve-id:
+      properties:
+        cve-id:
+          type: string
+          pattern: 'CVE-\d{4}-\d+'
+        cve_year:
+          type: string
+          format: "YYYY"
+        owning_cna:
+          type: string
+          description: The shortname for the organization that owns the CVE-ID.
+        state:
+          type: string
+          enum: [RESERVED, PUBLIC, REJECT]
+        requested_by:
+          type: object
+          properties:
+            cna:
+              type: string
+              description: The shortname for the organization of the user that requested the ID.
+            user:
+              type: string
+              description: The username for the account that requested the ID.
+        time:
+          type: object
+          properties:
+            created:
+              type: string
+              format: date-time
+              description: The time the ID was created.
+            modified:
+              type: string
+              format: date-time
+              description: The last time the ID was modified.
 paths:
   # CVE ID Reservation service
   /cve-id:
@@ -92,7 +126,13 @@ paths:
           description: "Get all CVE IDs created (reserved) after timestamp"
       responses:
         200:
-          description: Success
+          description: A list of CVE-IDs the organization owns and fit within the query parameters given.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/cve-id'
         400:
           description: Bad Request
         401:
@@ -101,6 +141,8 @@ paths:
           description: Forbidden
         404:
           description: Not Found
+        500:
+          description: Internal Server Error
     post:
       summary: Reserves IDs for the entity.
       parameters:
@@ -112,9 +154,20 @@ paths:
           schema:
             type: boolean
           description: Indicates whether IDs should be sequential
+        - in: query
+          name: amount
+          schema:
+            type: integer
+          description: Amount of IDs desired
       responses:
         200:
-          description: Success
+          description: A list of the newly reserved CVE-IDs the account requested.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/cve-id'
         400:
           description: Bad Request
         401:
@@ -123,6 +176,8 @@ paths:
           description: Forbidden
         404:
           description: Not Found
+        500:
+          description: Internal Server Error
   /cve-id/{cve-id}:
     parameters:
       - "$ref": "#/components/parameters/cve-id-path"
@@ -140,12 +195,17 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                # add CVE-ID JSON format
+                $ref: '#/components/schemas/cve-id'
+        400:
+          description: Bad Request
         401:
           description: Not Authenticated
+        403:
+          description: Forbidden
         404:
-            description: Not Found
+          description: Not Found
+        500:
+          description: Internal Server Error
     # Posts only accessible by Secretariat
     post:
       summary: Endpoint for Admin purposes to change state and ownership of the CVE ID.
@@ -166,7 +226,12 @@ paths:
           description: "Change owning CNA of CVE ID to new CNA (shortname)"
       responses:
         200:
-          description: Success
+          description: >
+            The updated CVE ID is returned.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/cve-id'
         400:
           description: Bad Request
         401:
@@ -175,6 +240,8 @@ paths:
           description: Forbidden
         404:
           description: Not Found
+        500:
+          description: Internal Server Error
   # User Registry service
   /cna/:shortname/id_quota:
     get:
@@ -186,7 +253,21 @@ paths:
         - "$ref": "#/components/parameters/api-user-header"
       responses:
         200:
-          description: Success
+          description: Returns details of the organization's id_quota
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id_quota:
+                    type: number
+                    description: The number of IDs the organization is allowed to have in the RESERVED state at one time.
+                  total_reserved:
+                    type: number
+                    description: The total of IDs across all years that the organization has in the RESERVED state.
+                  available:
+                    type: number
+                    description: id_quota - total_reserved
         400:
           description: Bad Request
         401:
@@ -195,6 +276,8 @@ paths:
           description: Forbidden
         404:
           description: Not Found
+        500:
+          description: Internal Server Error
   # Will only be accessible to Secretariat
   /cna/:shortname:
     parameters:
@@ -242,6 +325,8 @@ paths:
           description: Forbidden
         404:
           description: Not Found
+        500:
+          description: Internal Server Error
   /cna/:shortname/user/:username:
     post:
       summary: Allows admin to change properties of users
@@ -266,6 +351,8 @@ paths:
           description: Forbidden
         404:
           description: Not Found
+        500:
+          description: Internal Server Error
   /cna/:shortname/user/:username/reset_secret:
     post:
       summary: Resets the user's API Secret
@@ -290,5 +377,7 @@ paths:
           description: Forbidden
         404:
           description: Not Found
+        500:
+          description: Internal Server Error
 
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,130 @@
+# this API specification is draft and subject to change.
+openapi: "3.0.2"
+info:
+  title: CVE Services API
+  description: The CVE services API which supports automation tooling for the CVE Project.
+  version: 0.1.0
+  contact:
+    "name": "CVE Services API"
+    "url": http://cve.mitre.org/api
+    "email": placeholder-cve-services-api@mitre.org
+  license:
+    name: Creative Commons Zero v1.0 Universal
+    url: https://creativecommons.org/publicdomain/zero/1.0/legalcode
+  termsOfService: http://cve.mitre.org/api/terms
+# The following is notional
+servers:
+  - url: https://api-dev.cve.org/v1
+    description: Development and testing server
+  - url: https://api.cve.mitre.org/v1
+    description: Production server
+components:
+  parameters:
+    cve-id-path:
+      name: cve-id
+      in: path
+      description: The CVE ID for which the record is being submitted
+      required: true
+      schema:
+        # CVE ID format
+        type: string
+        pattern: 'CVE-\d{4}-\d+'
+    api-entity-header:
+      name: CVE-API-CNA
+      description: >
+        The shortname for the entity (e.g., CNA, ADP) that is authenticated or requesting authentication. \[TODO:: Is there a pattern for the format?\]
+      in: header
+      required: true
+      schema:
+        type: string
+    api-user-header:
+      name: CVE-API-SUBMITTER
+      description: >
+        The username for the account that is making the request.
+      in: header
+      required: true
+      schema:
+        type: string
+    api-secret-header:
+      name: CVE-API-SECRET
+      description: >
+        The User's secret. \[TODO:: Is there a pattern for the format?\]
+      in: header
+      required: true
+      schema:
+        type: string
+paths:
+  # CVE ID Reservation service
+  /cve-id:
+    get:
+      summary: Retrieves all CVE IDs entity owns.
+      parameters:
+        - in: query
+        name: state
+        schema:
+          type: string
+        description: "Filter by CVE state: RESERVED, PUBLIC, or REJECT"
+        - in: query
+        name: cve_id_year
+        schema:
+          type: integer
+        description: "Filter by the year in the CVE ID (YYYY)"
+        - in: query
+        name: time_created.lt
+        schema:
+          type: timestamp
+        description: "Get all CVE IDs created (reserved) before timestamp"
+        - in: query
+        name: time_created.gt
+        schema:
+          type: timestamp
+        description: "Get all CVE IDs created (reserved) after timestamp"
+    post:
+      summary: Reserves IDs for the entity.
+  /cve-id/{cve-id}:
+    parameters:
+      - "$ref": "#/components/parameters/cve-id-path"
+    get:
+      summary: Retrieves a CVE ID by ID, can be a CVE the entity doesn't own if in a PUBLIC or REJECT state.
+      operationId: getCVEIdById
+      responses:
+        200:
+          description: >
+            The requested CVE ID is returned.
+          content:
+            application/json:
+              schema:
+                type: object
+                # add CVE-ID JSON format
+        401:
+          description: Not Authenticated
+        404:
+            description: Not Found
+    post:
+      summary: Endpoint for Admin purposes to change state and ownership of the CVE ID.
+      operationId: submitCVEIdById
+      parameters:
+        - "$ref": "#/components/parameters/api-entity-header"
+        - "$ref": "#/components/parameters/api-secret-header"
+        - "$ref": "#/components/parameters/api-user-header"
+        - in: query
+        name: state
+        schema:
+          type: string
+        description: "Change state of CVE ID to either PUBLIC or REJECT"
+        - in: query
+        name: cna
+        schema:
+          type: string
+        description: "Change owning CNA of CVE ID to new CNA (shortname)"
+      responses:
+        200:
+          description: Success
+        400:
+          description: Bad Request
+        401:
+          description: Not Authenticated
+        403:
+          description: Forbidden
+        404:
+          description: Not Found

--- a/openapi.yml
+++ b/openapi.yml
@@ -63,7 +63,7 @@ components:
       properties:
         cve-id:
           type: string
-          pattern: 'CVE-\d{4}-\d+'
+          pattern: '^CVE-\d{4}-\d+$'
         cve_year:
           type: string
           format: "YYYY"
@@ -93,6 +93,10 @@ components:
               type: string
               format: date-time
               description: The last time the ID was modified.
+            reserved:
+              type: string
+              format: date-time
+              description: The date the ID was reserved.
 paths:
   # CVE ID Reservation service
   /cve-id:
@@ -405,6 +409,9 @@ paths:
                         type: string
                         format: date-time
                       modified:
+                        type: string
+                        format: date-time
+                      reserved:
                         type: string
                         format: date-time
         400:


### PR DESCRIPTION
This PR adds an openapi.yml file to the project. The file serves to document the endpoints for the API. With this in place, we plan to build live project documentation and encourage the community to utilize it when building tools to interact with the services API.