### PR TITLE
Add interactive stub for reservation

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,5 +1,22 @@
 module.exports = {
   SERVER_RESPONSES: {
     Internal_Server_Error: 'Internal Server Error'
+  },
+  over_id_quota: {
+    error: "EXCEEDED_ID_QUOTA",
+    message: "The amount requested would exceed the organization's ID quota",
+    details: {
+      id_quota: 5,
+      total_reserved: 0,
+      available: 5
+    }
+  },   
+  invalid_amount: {
+    error: "INVALID_AMOUNT",
+    message: "The amount query parameter needs to be above 0."
+  },
+  no_amount: {
+    error: "NO_AMOUNT",
+    message: "The amount query parameter is required and needs to be above 0."
   }
 }

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -1,8 +1,8 @@
-
 require('dotenv').config()
 const CveId = require('../../model/cve-id')
 const Org = require('../../model/org')
 const logger = require('../../middleware/logger')
+const CONSTANTS = require('../../constants')
 
 async function getCveId (req, res) {
   const id = req.params.id
@@ -234,8 +234,187 @@ async function modifyCveId (req, res) {
     })
 }
 
+async function reserveCveId (req, res) {
+  const sequential = req.query.sequential
+  const amount = req.query.amount
+  if (amount === undefined) {
+    return res.status(404).json(CONSTANTS.no_amount)
+  }
+  if (amount <= 0) {
+    return res.status(404).json(CONSTANTS.invalid_amount)
+  }
+  const available = 5
+  if (amount > available) {
+    return res.status(404).json(CONSTANTS.over_id_quota)
+  }
+  res.header('CVE-API-REMAINING-QUOTA', available - amount)
+  if (sequential) {
+    return res.status(200).json(sequential_ids.slice(0, amount))
+  }
+  return res.status(200).json(nonsequential_ids.slice(0, amount))
+}
+
+const sequential_ids = [
+  {
+    cve_id: "CVE-3000-0001",
+    cve_year: 3000,
+    owning_cna: "orgshortname",
+    state: "RESERVED",
+    requested_by: {
+      cna: "orgshortname",
+      user: "you"
+    },
+    time: {
+      created: "3000-06-24T21:08:42.937+00:00",
+      modified: "3000-06-24T21:12:46.576+00:00",
+      reserved: "3000-06-24T21:12:46.576+00:00",
+    }
+  },
+  {
+    cve_id: "CVE-3000-0002",
+    cve_year: 3000,
+    owning_cna: "orgshortname",
+    state: "RESERVED",
+    requested_by: {
+      cna: "orgshortname",
+      user: "you"
+    },
+    time: {
+      created: "3000-06-24T21:08:42.937+00:00",
+      modified: "3000-06-24T21:12:46.576+00:00",
+      reserved: "3000-06-24T21:12:46.576+00:00",
+    }
+  },
+  {
+    cve_id: "CVE-3000-0003",
+    cve_year: 3000,
+    owning_cna: "orgshortname",
+    state: "RESERVED",
+    requested_by: {
+      cna: "orgshortname",
+      user: "you"
+    },
+    time: {
+      created: "3000-06-24T21:08:42.937+00:00",
+      modified: "3000-06-24T21:12:46.576+00:00",
+      reserved: "3000-06-24T21:12:46.576+00:00",
+    }
+  },
+  {
+    cve_id: "CVE-3000-0004",
+    cve_year: 3000,
+    owning_cna: "orgshortname",
+    state: "RESERVED",
+    requested_by: {
+      cna: "orgshortname",
+      user: "you"
+    },
+    time: {
+      created: "3000-06-24T21:08:42.937+00:00",
+      modified: "3000-06-24T21:12:46.576+00:00",
+      reserved: "3000-06-24T21:12:46.576+00:00",
+    }
+  },
+  {
+    cve_id: "CVE-3000-0005",
+    cve_year: 3000,
+    owning_cna: "orgshortname",
+    state: "RESERVED",
+    requested_by: {
+      cna: "orgshortname",
+      user: "you"
+    },
+    time: {
+      created: "3000-06-24T21:08:42.937+00:00",
+      modified: "3000-06-24T21:12:46.576+00:00",
+      reserved: "3000-06-24T21:12:46.576+00:00",
+    }
+  }
+]
+
+const nonsequential_ids = [
+  {
+    cve_id: "CVE-3000-0500",
+    cve_year: 3000,
+    owning_cna: "orgshortname",
+    state: "RESERVED",
+    requested_by: {
+      cna: "orgshortname",
+      user: "you"
+    },
+    time: {
+      created: "3000-06-24T21:08:42.937+00:00",
+      modified: "3000-06-24T21:12:46.576+00:00",
+      reserved: "3000-06-24T21:12:46.576+00:00",
+    }
+  },
+  {
+    cve_id: "CVE-3000-0522",
+    cve_year: 3000,
+    owning_cna: "orgshortname",
+    state: "RESERVED",
+    requested_by: {
+      cna: "orgshortname",
+      user: "you"
+    },
+    time: {
+      created: "3000-06-24T21:08:42.937+00:00",
+      modified: "3000-06-24T21:12:46.576+00:00",
+      reserved: "3000-06-24T21:12:46.576+00:00",
+    }
+  },
+  {
+    cve_id: "CVE-3000-0558",
+    cve_year: 3000,
+    owning_cna: "orgshortname",
+    state: "RESERVED",
+    requested_by: {
+      cna: "orgshortname",
+      user: "you"
+    },
+    time: {
+      created: "3000-06-24T21:08:42.937+00:00",
+      modified: "3000-06-24T21:12:46.576+00:00",
+      reserved: "3000-06-24T21:12:46.576+00:00",
+    }
+  },
+  {
+    cve_id: "CVE-3000-0518",
+    cve_year: 3000,
+    owning_cna: "orgshortname",
+    state: "RESERVED",
+    requested_by: {
+      cna: "orgshortname",
+      user: "you"
+    },
+    time: {
+      created: "3000-06-24T21:08:42.937+00:00",
+      modified: "3000-06-24T21:12:46.576+00:00",
+      reserved: "3000-06-24T21:12:46.576+00:00",
+    }
+  },
+  {
+    cve_id: "CVE-3000-0591",
+    cve_year: 3000,
+    owning_cna: "orgshortname",
+    state: "RESERVED",
+    requested_by: {
+      cna: "orgshortname",
+      user: "you"
+    },
+    time: {
+      created: "3000-06-24T21:08:42.937+00:00",
+      modified: "3000-06-24T21:12:46.576+00:00",
+      reserved: "3000-06-24T21:12:46.576+00:00",
+    }
+  }
+]
+
+
+
 module.exports = {
   CVEID_GET_SINGLE: getCveId,
+  CVEID_RESERVE: reserveCveId,
   CVEID_GET_FILTER: getFilteredCveId,
   CVEID_STATE_REASIGN_SINGLE: modifyCveId
 }

--- a/src/controller/cve-id.controller/index.js
+++ b/src/controller/cve-id.controller/index.js
@@ -4,6 +4,7 @@ const middleware = require('../../middleware/middleware')
 const controller = require('./cve-id.controller')
 
 router.get('/cve-id', middleware.validateUser, controller.CVEID_GET_FILTER)
+router.post('/cve-id', middleware.validateUser, controller.CVEID_RESERVE)
 router.get('/cve-id/:id', middleware.validateUser, controller.CVEID_GET_SINGLE)
 router.post('/cve-id/:id', middleware.validateUser, controller.CVEID_STATE_REASIGN_SINGLE)
 


### PR DESCRIPTION
This endpoint pretends that all orgs have
an id quota of 5. No state is saved so that
a variety of edge case requests can be made
against it with predictable results to aid
development of tools that will interact with
this endpoint.

If a request is made that will go over the id
quota or any of the parameters are invalid,
clear error responses are returned.

Blatantly fake IDs are returned, but are the
proper amount according to the amount query
parameter. They also comply with being
sequential or nonsequential. Their structure
is also identical to what the production
service intends to return.