### PR TITLE
app gets db host, port from environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,9 @@ typings/
 apidoc
 # Mac Files
 .DS_Store
+
+# top-level text file for writing good Git commit messages
+commit-message.txt
+
+# visual studio code development
+.vscode/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,8 +17,9 @@ COPY test-utils /app/test-utils
 COPY config /app/config
 RUN echo '{}' > /app/config/dev.json
 RUN echo '{}' > /app/config/test.json
+
 # Change db hostname from localhost to docdb for use inside docker
 COPY docker/default.json-docker /app/config/default.json
-#CMD node index.js
+
 CMD npm run start:dev
 EXPOSE 8081

--- a/docker/README.md
+++ b/docker/README.md
@@ -36,7 +36,7 @@ the database yet):
 
 ## Using Mongo Express
 
-You can use [Mongo Exoress](https://github.com/mongo-express/mongo-express)
+You can use [Mongo Express](https://github.com/mongo-express/mongo-express)
 (a mongo web UI) to view mongo from your browser.
 To start Mongo Express you can start it with the following command:
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,14 +4,15 @@
 
 Use the following steps to build and run cve-services (Node.js app
 and Mongo) in docker containers.  Note that the current configuration is
-set to run the services in development mode.
+set to run the services in development mode. Note that these commands
+must be run from the `docker/` directory.
 
 1. Build the images:
   `docker-compose build`
 2. Run the containers:
   `docker-compose up`
 
-# Try It Out
+## Try It Out
 
 To make a REST request to the running CVE services, use the following
 `curl` command:
@@ -23,17 +24,17 @@ the database yet):
 
   []
 
-# To shell into the web app server
+## To shell into the web app server
 
   `docker-compose exec cveawg /bin/sh`
 
-# To use curl to add a CNA:
+## To use curl to add a CNA
 
   `curl -X POST -H "Content-Type: application/json" \
      -d '{"name": "MITRE Corporation","short_name": "mitre"}' \
      http://localhost:3000/api/cna`
 
-# Using Mongo Express
+## Using Mongo Express
 
 You can use [Mongo Exoress](https://github.com/mongo-express/mongo-express)
 (a mongo web UI) to view mongo from your browser.
@@ -45,5 +46,4 @@ To start Mongo Express you can start it with the following command:
 You can use Mongo Express to view the Mongo data by using the
 following URL and viewing the *cve_dev* database:
 
-  http://localhost:8081/
-
+  <http://localhost:8081/>

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,28 +1,28 @@
 version: '3'
 
 services:
-    docdb:
-        image: mongo
-        container_name: mongo
-        env_file: .docker-env
-        ports:
-            - "27017:27017"
-        networks:
-            - cve-services
+  docdb:
+    image: mongo
+    container_name: mongo
+    env_file: .docker-env
+    ports:
+      - "27017:27017"
+    networks:
+      - cve-services
 
-    cveawg:
-        container_name: cveawg
-        user: node # The user to run as in the container
-        build:
-            context: ../
-            dockerfile: docker/Dockerfile
-        depends_on:
-            - docdb
-        env_file: .docker-env
-        ports:
-            - "3000:3000"
-        networks:
-            - cve-services
+  cveawg:
+    container_name: cveawg
+    user: node # The user to run as in the container
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+    depends_on:
+      - docdb
+    env_file: .docker-env
+    ports:
+      - "3000:3000"
+    networks:
+      - cve-services
 
 networks:
   cve-services:

--- a/src/index.js
+++ b/src/index.js
@@ -39,21 +39,17 @@ global.mongoose = mongoose
 configureRoutes(app)
 //* ********API Routes Setup END*********** */
 
-// Construct MongoDB connection string
-let dbConnectionStr
-if (process.env.NODE_ENV === 'development') {
-  dbConnectionStr = config.has('development.username') && config.has('development.userpass')
-    ? `mongodb://${config.get('development.username')}:${config.get('development.userpass')}@${config.get('development.host')}:${config.get('development.port')}/${config.get('development.database')}`
-    : `mongodb://${config.get('development.host')}:${config.get('development.port')}/${config.get('development.database')}`
-} else if (process.env.NODE_ENV === 'test') {
-  dbConnectionStr = config.has('test.username') && config.has('test.userpass')
-    ? `mongodb://${config.get('test.username')}:${config.get('test.userpass')}@${config.get('test.host')}:${config.get('test.port')}/${config.get('test.database')}`
-    : `mongodb://${config.get('test.host')}:${config.get('test.port')}/${config.get('test.database')}`
-} else if (process.env.NODE_ENV === 'production') {
-  dbConnectionStr = config.has('production.username') && config.has('production.userpass')
-    ? `mongodb://${config.get('production.username')}:${config.get('production.userpass')}@${config.get('production.host')}:${config.get('production.port')}/${config.get('production.database')}`
-    : `mongodb://${config.get('production.host')}:${config.get('production.port')}/${config.get('production.database')}`
-}
+// construct MongoDB connection string
+// assumes that host, port, database are always defined in default config, but
+// that username and password may not be
+const appEnv = process.env.NODE_ENV;
+const dbUser = config.has(`${appEnv}.username`) ? config.get(`${appEnv}.username`) : false;
+const dbPassword = config.has(`${appEnv}.userpass`) ? config.get(`${appEnv}.userpass`) : false;
+const dbHost = process.env.MONGO_HOST ? process.env.MONGO_HOST : config.get(`${appEnv}.host`);
+const dbPort = process.env.MONGO_PORT ? process.env.MONGO_PORT : config.get(`${appEnv}.port`);
+const dbName = config.get(`${appEnv}.database`);
+const dbLoginPrepend = (dbUser && dbPassword) ? `${dbUser}:${dbPassword}@` : '';
+const dbConnectionStr = `mongodb://${dbLoginPrepend}${dbHost}:${dbPort}/${dbName}`
 
 // Connect to MongoDB database
 mongoose.connect(dbConnectionStr, {

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -85,10 +85,18 @@ app.route('/api/test/cve-id/:id')
 
 //* ********API Routes Setup END*********** */
 
-// Construct MongoDB connection string
-const dbConnectionStr = config.has('test.username') && config.has('test.userpass')
-  ? `mongodb://${config.get('test.username')}:${config.get('test.userpass')}@${config.get('test.host')}:${config.get('test.port')}/${config.get('test.database')}`
-  : `mongodb://${config.get('test.host')}:${config.get('test.port')}/${config.get('test.database')}`
+// construct MongoDB connection string
+// assumes that host, port, database are always defined in default config, but
+// that username and password may not be
+// TODO: can we not repeat `src/index.js` and `test-utils/index.js`
+const appEnv = 'test';
+const dbUser = config.has(`${appEnv}.username`) ? config.get(`${appEnv}.username`) : false;
+const dbPassword = config.has(`${appEnv}.userpass`) ? config.get(`${appEnv}.userpass`) : false;
+const dbHost = process.env.MONGO_HOST ? process.env.MONGO_HOST : config.get(`${appEnv}.host`);
+const dbPort = process.env.MONGO_PORT ? process.env.MONGO_PORT : config.get(`${appEnv}.port`);
+const dbName = config.get(`${appEnv}.database`);
+const dbLoginPrepend = (dbUser && dbPassword) ? `${dbUser}:${dbPassword}@` : '';
+const dbConnectionStr = `mongodb://${dbLoginPrepend}${dbHost}:${dbPort}/${dbName}`
 
 // Connect to MongoDB database
 mongoose.connect(dbConnectionStr, {


### PR DESCRIPTION
Issue Endorsed by Maintainers
- Yes
Description of the Change
- `src/index.js` now looks for MongoDB host and port values in the environment
- This is necessary for AWS deployment of the application and database
- Values from `config/` are still used as a fallback
Alternate Designs
- As application complexity grows, a separate `src/config.js` may help manage technical debt
Possible Drawbacks
- Creating the Mongoose database endpoint URL now has a few configurations which may not be apparent to developers: (1) with or without username and password, (2) host/port from environment or from a config file, (3) Node environment choice (test, development, production)
Verification Process
- The application works normally with these changes
- Injecting incorrect host or port information into the docker environment causes errors in the mongoose connection in the application
Release Notes
- None
