### PR TITLE
Fix port for NodeJS (3000, not 8081) in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,6 @@ RUN echo '{}' > /app/config/test.json
 COPY docker/default.json-docker /app/config/default.json
 
 # CMD npm run start:dev
-EXPOSE 8081
+EXPOSE 3000
 
 ENTRYPOINT '/app/entrypoint.sh'


### PR DESCRIPTION
Identify the Bug
- Dockerfile had wrong port number in EXPOSE, causing problem deploying in AWS ECS
Description of the Change
- Updated the Dockerfile with the correct port (3000)
Alternate Designs
- None
Possible Drawbacks
- None
Verification Process
- Does not affect docker startup via docker-compose
Release Notes
- N/A