### PR TITLE
Correct port in default.json from 8081 to 3000

### DIFF
--- a/docker/default.json-docker
+++ b/docker/default.json-docker
@@ -15,7 +15,7 @@
     "database": "cve_prod",
     "host": ""
   },
-  "port": 8081,
+  "port": 3000,
 	"database": {
 		"host": "docdb",
 		"port": 27017,


### PR DESCRIPTION
Identify the Bug
- Incorrect port in default.json (should be 3000, not 8081) for docker configuration; not an issue with docker-compose; IS a problem in AWS ECS
Description of the Change
- Update docker/default.json-docker
Alternate Designs
- N/A
Possible Drawbacks
- N/A
Verification Process
- Run in ECS and check port
Release Notes
- N/A