### PR TITLE
IDR (priority and sequential reservation), IDR misc changes, and pre-populate script

### DIFF
--- a/datadump/pre-population/cve-ids-range.json
+++ b/datadump/pre-population/cve-ids-range.json
@@ -3,8 +3,8 @@
     "cve_year": 1999,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 5000,
+            "start": 5000,
             "end": 5000
         },
         "general": {
@@ -18,8 +18,8 @@
     "cve_year": 2000,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 5000,
+            "start": 5000,
             "end": 5000
         },
         "general": {
@@ -33,8 +33,8 @@
     "cve_year": 2001,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 5000,
+            "start": 5000,
             "end": 5000
         },
         "general": {
@@ -48,8 +48,8 @@
     "cve_year": 2002,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 5000,
+            "start": 5000,
             "end": 5000
         },
         "general": {
@@ -63,8 +63,8 @@
     "cve_year": 2003,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 5000,
+            "start": 5000,
             "end": 5000
         },
         "general": {
@@ -78,8 +78,8 @@
     "cve_year": 2004,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 20000,
+            "start": 20000,
             "end": 20000
         },
         "general": {
@@ -93,8 +93,8 @@
     "cve_year": 2005,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 10000,
+            "start": 10000,
             "end": 10000
         },
         "general": {
@@ -108,8 +108,8 @@
     "cve_year": 2006,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 20000,
+            "start": 20000,
             "end": 20000
         },
         "general": {
@@ -123,8 +123,8 @@
     "cve_year": 2007,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 20000,
+            "start": 20000,
             "end": 20000
         },
         "general": {
@@ -138,8 +138,8 @@
     "cve_year": 2008,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 20000,
+            "start": 20000,
             "end": 20000
         },
         "general": {
@@ -153,8 +153,8 @@
     "cve_year": 2009,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 10000,
+            "start": 10000,
             "end": 10000
         },
         "general": {
@@ -168,8 +168,8 @@
     "cve_year": 2010,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 10000,
+            "start": 10000,
             "end": 10000
         },
         "general": {
@@ -183,8 +183,8 @@
     "cve_year": 2011,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 10000,
+            "start": 10000,
             "end": 10000
         },
         "general": {
@@ -198,8 +198,8 @@
     "cve_year": 2012,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 10000,
+            "start": 10000,
             "end": 10000
         },
         "general": {
@@ -213,8 +213,8 @@
     "cve_year": 2013,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 10000,
+            "start": 10000,
             "end": 10000
         },
         "general": {
@@ -228,8 +228,8 @@
     "cve_year": 2014,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 150000,
+            "start": 150000,
             "end": 150000
         },
         "general": {
@@ -243,8 +243,8 @@
     "cve_year": 2015,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 20000,
+            "start": 20000,
             "end": 20000
         },
         "general": {
@@ -258,8 +258,8 @@
     "cve_year": 2016,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 20000,
+            "start": 20000,
             "end": 20000
         },
         "general": {
@@ -273,8 +273,8 @@
     "cve_year": 2017,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 30000,
+            "start": 30000,
             "end": 30000
         },
         "general": {
@@ -288,8 +288,8 @@
     "cve_year": 2018,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 30000,
+            "start": 30000,
             "end": 30000
         },
         "general": {
@@ -303,8 +303,8 @@
     "cve_year": 2019,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 30000,
+            "start": 30000,
             "end": 30000
         },
         "general": {

--- a/datadump/pre-population/cve-ids-range.json
+++ b/datadump/pre-population/cve-ids-range.json
@@ -1,0 +1,347 @@
+[
+  {
+    "cve_year": 1999,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 5000
+        },
+        "general": {
+            "top_id": 5000,
+            "start": 5000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2000,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 5000
+        },
+        "general": {
+            "top_id": 5000,
+            "start": 5000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2001,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 5000
+        },
+        "general": {
+            "top_id": 5000,
+            "start": 5000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2002,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 5000
+        },
+        "general": {
+            "top_id": 5000,
+            "start": 5000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2003,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 5000
+        },
+        "general": {
+            "top_id": 5000,
+            "start": 5000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2004,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 20000
+        },
+        "general": {
+            "top_id": 20000,
+            "start": 20000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2005,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 10000
+        },
+        "general": {
+            "top_id": 10000,
+            "start": 10000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2006,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 20000
+        },
+        "general": {
+            "top_id": 20000,
+            "start": 20000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2007,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 20000
+        },
+        "general": {
+            "top_id": 20000,
+            "start": 20000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2008,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 20000
+        },
+        "general": {
+            "top_id": 20000,
+            "start": 20000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2009,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 10000
+        },
+        "general": {
+            "top_id": 10000,
+            "start": 10000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2010,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 10000
+        },
+        "general": {
+            "top_id": 10000,
+            "start": 10000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2011,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 10000
+        },
+        "general": {
+            "top_id": 10000,
+            "start": 10000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2012,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 10000
+        },
+        "general": {
+            "top_id": 10000,
+            "start": 10000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2013,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 10000
+        },
+        "general": {
+            "top_id": 10000,
+            "start": 10000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2014,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 150000
+        },
+        "general": {
+            "top_id": 150000,
+            "start": 150000,
+            "end": 450000
+        }
+    }
+  },
+  {
+    "cve_year": 2015,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 20000
+        },
+        "general": {
+            "top_id": 20000,
+            "start": 20000,
+            "end": 999999
+        }
+    }
+  },
+  {
+    "cve_year": 2016,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 20000
+        },
+        "general": {
+            "top_id": 20000,
+            "start": 20000,
+            "end": 550000
+        }
+    }
+  },
+  {
+    "cve_year": 2017,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 30000
+        },
+        "general": {
+            "top_id": 30000,
+            "start": 30000,
+            "end": 999999
+        }
+    }
+  },
+  {
+    "cve_year": 2018,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 30000
+        },
+        "general": {
+            "top_id": 30000,
+            "start": 30000,
+            "end": 550000
+        }
+    }
+  },
+  {
+    "cve_year": 2019,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 30000
+        },
+        "general": {
+            "top_id": 30000,
+            "start": 30000,
+            "end": 999999
+        }
+    }
+  },
+  {
+    "cve_year": 2020,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 35000
+        },
+        "general": {
+            "top_id": 35000,
+            "start": 35000,
+            "end": 50000000
+        }
+    }
+  },
+  {
+    "cve_year": 2021,
+    "ranges": {
+        "priority": {
+            "top_id": 0,
+            "start": 0,
+            "end": 35000
+        },
+        "general": {
+            "top_id": 35000,
+            "start": 35000,
+            "end": 50000000
+        }
+    }
+  }
+]

--- a/openapi.yml
+++ b/openapi.yml
@@ -61,7 +61,7 @@ components:
   schemas:
     cve-id:
       properties:
-        cve-id:
+        cve_id:
           type: string
           pattern: '^CVE-\d{4}-\d+$'
         cve_year:

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -34,11 +34,11 @@ module.exports = {
       priority: {
         top_id: 0,
         start: 0,
-        end: 35000
+        end: 20000
       },
       general: {
-        top_id: 35000,
-        start: 35000,
+        top_id: 20000,
+        start: 20000,
         end: 50000000
       }
     }

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -8,20 +8,20 @@ module.exports = {
     Org_policies_id_quota_max: 1000,
     Org_policies_id_quota_max_message: 'Org.polocies.id_quota cannot exceed maximum threshold.'
   },
-  over_id_quota: {
+  OVER_ID_QUOTA: {
     error: 'EXCEEDED_ID_QUOTA',
     message: "The amount requested would exceed the organization's ID quota",
     details: {
-      id_quota: 5,
-      total_reserved: 0,
-      available: 5
+      id_quota: 1000,
+      total_reserved: 1000,
+      available: 0
     }
   },
-  invalid_amount: {
+  INVALID_AMOUNT: {
     error: 'INVALID_AMOUNT',
     message: 'The amount query parameter needs to be above 0.'
   },
-  no_amount: {
+  NO_AMOUNT: {
     error: 'NO_AMOUNT',
     message: 'The amount query parameter is required and needs to be above 0.'
   },
@@ -30,5 +30,20 @@ module.exports = {
     'SECRETARIAT',
     'ROOT_CNA',
     'ADP'
-  ]
+  ],
+  DEFAULT_CVE_ID_RANGE: {
+    cve_year: 2020,
+    ranges: {
+      priority: {
+        top_id: 0,
+        start: 0,
+        end: 20000
+      },
+      general: {
+        top_id: 20000,
+        start: 20000,
+        end: 50000000000
+      }
+    }
+  }
 }

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -9,14 +9,10 @@ module.exports = {
     Org_policies_id_quota_max_message: 'Org.polocies.id_quota cannot exceed maximum threshold.'
   },
   DEFAULT_ID_QUOTA: 1000,
+  DEFAULT_AVAILABLE_POOL: 100,
   OVER_ID_QUOTA: {
     error: 'EXCEEDED_ID_QUOTA',
-    message: "The amount requested would exceed the organization's ID quota",
-    details: {
-      id_quota: 1000,
-      total_reserved: 1000,
-      available: 0
-    }
+    message: "The amount requested would exceed the organization's ID quota. No more IDs can be reserved until the number of IDs in the Reserved state goes below the ID quota or the ID quota is raised. If you feel you are receiving this message in error, please contact support."
   },
   INVALID_AMOUNT: {
     error: 'INVALID_AMOUNT',

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -8,6 +8,7 @@ module.exports = {
     Org_policies_id_quota_max: 1000,
     Org_policies_id_quota_max_message: 'Org.polocies.id_quota cannot exceed maximum threshold.'
   },
+  DEFAULT_ID_QUOTA: 1000,
   OVER_ID_QUOTA: {
     error: 'EXCEEDED_ID_QUOTA',
     message: "The amount requested would exceed the organization's ID quota",
@@ -37,12 +38,12 @@ module.exports = {
       priority: {
         top_id: 0,
         start: 0,
-        end: 20000
+        end: 35000
       },
       general: {
-        top_id: 20000,
-        start: 20000,
-        end: 50000000000
+        top_id: 35000,
+        start: 35000,
+        end: 50000000
       }
     }
   }

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -490,7 +490,7 @@ async function createCveIdRange (req, res) {
     return res.status(403).json({ message: 'The Cve Id Range for year ' + year + ' cannot be created by other than the Secretariat.' })
   }
 
-  const result = await CveIdRange.findOne({ cve_year: year })
+  let result = await CveIdRange.findOne({ cve_year: year })
 
   if (result) {
     logger.info('CVE Id Range document for year ' + year + ' already exists.')
@@ -499,7 +499,8 @@ async function createCveIdRange (req, res) {
 
   const defaultDoc = CONSTANTS.DEFAULT_CVE_ID_RANGE
   defaultDoc.cve_year = year
-  await CveIdRange.findOneAndUpdate({ cve_year: year }, defaultDoc, { upsert: true })
+  result = await CveIdRange.findOneAndUpdate({ cve_year: year }, { upsert: true, new: true })
+  console.log(result)
 
   logger.info('CVE Id Range document for year ' + year + ' was created.')
   return res.status(200).json({ message: 'CVE Id Range document for year ' + year + ' was created.' })

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -357,15 +357,18 @@ async function priorityReservation (year, amount, cveId, shortName, cnaShortName
 
     // priority id block is full, reserve id in sequential block
     if (!result) {
+      // OK
       isFull = true
-      logger.info('Priority id block is full for year ' + year + ', reserving id in sequential block')
+      logger.info('Priority id block is full for year ' + year + ', reserving id in sequential block.')
       await sequentialReservation(year, amount, cveId, shortName, cnaShortName, requester, availableIds, res)
     }
   } else {
+    // OK
     logger.info('CVE IDs for year ' + year + ' cannot be reserved at this time.')
     return res.status(403).json({ message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
   }
 
+  // OK
   if (!isFull) {
     const id = generateIds(year, result.ranges.priority, amount)
 
@@ -380,7 +383,7 @@ async function priorityReservation (year, amount, cveId, shortName, cnaShortName
       user: requester
     }
 
-    // Create a CveId document
+    // Create a CveId document (reserve the CVE ID)
     await CveId.findOneAndUpdate().byCveId(id).updateOne(cveId).setOptions({ upsert: true })
 
     res.header('CVE-API-REMAINING-QUOTA', availableIds - amount)
@@ -391,6 +394,7 @@ async function priorityReservation (year, amount, cveId, shortName, cnaShortName
 
 async function sequentialReservation (year, amount, cveId, shortName, cnaShortName, requester, availableIds, res) {
   let result = await CveIdRange.findOne({ cve_year: year })
+  let isFull = false
 
   // Cve Id Range for 'year' exists
   if (result) {
@@ -399,39 +403,49 @@ async function sequentialReservation (year, amount, cveId, shortName, cnaShortNa
 
     // The cve id block is full
     if (!result) {
+      // OK
+      isFull = true
       logger.error('The cve id block is full for year ' + year + '. No more ids can be reserved at this time.')
-      return res.status(403).json({ message: 'The cve id block is full for year ' + year + '. Please contact the Secretariat.' })
+      return res.status(403).json({ message: 'The cve id block is full for year ' + year + '. Please contact an administrator.' })
     }
   } else {
+    // OK
     logger.info('CVE IDs for year ' + year + ' cannot be reserved at this time.')
     return res.status(403).json({ message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
   }
 
-  const ids = generateIds(year, result.ranges.general, amount)
-  const cveIdDocuments = []
-  // return res.status(200).json({ ids: ids })
+  // OK
+  if (!isFull) {
+    const ids = generateIds(year, result.ranges.general, amount)
+    const cveIdDocuments = []
+    // return res.status(200).json({ ids: ids })
 
-  ids.forEach(id => {
-    cveId = new CveId()
-    cveId.cve_id = id
-    cveId.cve_year = year
-    cveId.state = 'RESERVED'
-    cveId.owning_cna = shortName // the org who gets assigned the reserved CVE IDs
-    cveId.reserved = Date.now()
-    cveId.requested_by = {
-      cna: cnaShortName, // the org who requested the CVE IDs
-      user: requester
-    }
+    ids.forEach(id => {
+      cveId = new CveId()
+      cveId.cve_id = id
+      cveId.cve_year = year
+      cveId.state = 'RESERVED'
+      cveId.owning_cna = shortName // the org who gets assigned the reserved CVE IDs
+      cveId.reserved = Date.now()
+      cveId.requested_by = {
+        cna: cnaShortName, // the org who requested the CVE IDs
+        user: requester
+      }
 
-    cveIdDocuments.push(cveId)
-  })
+      cveIdDocuments.push(cveId)
+    })
 
-  // Create multiple CveId documents
-  await CveId.insertMany(cveIdDocuments)
+    // Create multiple CveId documents (reserve the CVE IDs)
+    await CveId.insertMany(cveIdDocuments)
 
-  res.header('CVE-API-REMAINING-QUOTA', availableIds - amount)
-  logger.info({ message: 'Sequential CVE IDs were reserved for \'' + shortName + '\' org on behalf of \'' + cnaShortName + '\' org.', cve_ids: ids })
-  return res.status(200).json({ message: 'The following CVE IDs were reserved.', reserved: ids })
+    res.header('CVE-API-REMAINING-QUOTA', availableIds - amount)
+    logger.info({ message: 'Sequential CVE IDs were reserved for \'' + shortName + '\' org on behalf of \'' + cnaShortName + '\' org.', cve_ids: ids })
+    return res.status(200).json({ message: 'The following CVE IDs were reserved.', reserved: ids })
+  }
+}
+
+async function nonSequentialReservation (year, amount, cveId, shortName, cnaShortName, requester, availableIds, res) {
+  //
 }
 
 function generateIds (year, ranges, amount) {
@@ -446,10 +460,6 @@ function generateIds (year, ranges, amount) {
   return ids
 }
 
-async function nonSequentialReservation (year, amount, cveId, shortName, cnaShortName, requester, availableIds, res) {
-  //
-}
-
 async function createCveIdRange (req, res) {
   const year = req.params.year
   const cnaShortName = req.header('CVE-API-CNA')
@@ -457,7 +467,7 @@ async function createCveIdRange (req, res) {
   const isSecretariat = await util.isSecretariat(cnaShortName)
   if (!isSecretariat) {
     logger.info({ message: 'The Cve Id Range cannot be created by other than the secretariat.' })
-    return res.status(403).json({ message: 'The Cve Id Range for year ' + year + ' cannot be created by other than the secretariat.' })
+    return res.status(403).json({ message: 'The Cve Id Range for year ' + year + ' cannot be created by other than the Secretariat.' })
   }
 
   const result = await CveIdRange.findOne({ cve_year: year })

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -344,7 +344,6 @@ async function reserveCveId (req, res) {
       await sequentialReservation(year, amount, cveId, shortName, cnaShortName, requester, payload.available, res)
     } else if (batchType === 'non-sequential' || batchType === 'nonsequential') {
       await nonSequentialReservation(year, amount, cveId, shortName, cnaShortName, requester, payload.availableIds, res)
-      return res.status(200).json({ message: batchType })
     } else {
       return res.status(400).json({ message: 'Invalid value for query parameter \'batch_type\'' })
     }

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -124,13 +124,13 @@ async function getFilteredCveId (req, res) {
   }
 
   if (timestamps.timeReserved.length > 0) {
-    query['time.reserved'] = {}
+    query.reserved = {}
 
     for (let i = 0; i < timestamps.timeReserved.length; i++) {
       if (timestamps.dateOperator[i] === 'lt') {
-        query['time.reserved'].$lt = timestamps.timeReserved[i]
+        query.reserved.$lt = timestamps.timeReserved[i]
       } else {
-        query['time.reserved'].$gt = timestamps.timeReserved[i]
+        query.reserved.$gt = timestamps.timeReserved[i]
       }
     }
   }
@@ -243,10 +243,12 @@ async function modifyCveId (req, res) {
 async function reserveCveId (req, res) {
   const requester = req.header('CVE-API-SUBMITTER')
   const cnaShortName = req.header('CVE-API-CNA')
+  let returned = false
   let batchType
   let amount
   let shortName
   let year
+  let cveId
 
   Object.keys(req.query).forEach(k => {
     const key = k.toLowerCase()
@@ -260,75 +262,91 @@ async function reserveCveId (req, res) {
     } else if (key === 'cve_year') {
       year = req.query.cve_year.replace(/["']/g, '')
     } else {
-      return res.status(400).json({ message: 'Invalid query parameter \'' + key + '\'' })
+      if (!returned) {
+        returned = true
+        return res.status(400).json({ message: 'Invalid query parameter \'' + key + '\'' })
+      }
     }
   })
 
-  if (shortName === undefined) {
-    return res.status(400).json({ message: 'Provide the cna\'s short name to allocate CVE IDs.' })
-  }
-
   const isSecretariat = await util.isSecretariat(cnaShortName)
-  if (cnaShortName !== shortName && !isSecretariat) {
+  if (cnaShortName !== shortName && !isSecretariat && !returned) {
+    returned = true
     return res.status(403).json({ message: 'CVE IDs can only be reserved by the owning CNA or by the Secretariat.' })
   }
 
-  if (year === undefined) {
-    return res.status(400).json({ message: 'Provide a year to allocate CVE IDs.' })
+  if (shortName === undefined && !returned) {
+    returned = true
+    return res.status(400).json({ message: 'Provide the cna\'s short name to reserve CVE IDs.' })
   }
 
-  if (amount === undefined) {
-    return res.status(404).json(CONSTANTS.NO_AMOUNT)
+  if (year === undefined && !returned) {
+    returned = true
+    return res.status(400).json({ message: 'Provide a year to reserve CVE IDs.' })
   }
 
-  if (amount <= 0) {
+  if (amount === undefined && !returned) {
+    returned = true
+    return res.status(400).json(CONSTANTS.NO_AMOUNT)
+  }
+
+  if (amount <= 0 && !returned) {
+    returned = true
     return res.status(404).json(CONSTANTS.INVALID_AMOUNT)
   }
 
-  if (amount > 1 && batchType === undefined) {
+  if (amount > 1 && batchType === undefined && !returned) {
+    returned = true
     return res.status(400).json({ message: 'A batch type (i.e. sequential, non-sequential) must be specified when allocating more than one CVE ID.' })
   }
 
   let result = await Org.findOne().byShortName(shortName)
-  if (!result) {
+  if (!result && !returned) {
+    returned = true
     logger.info(shortName + ' CNA does not exist.')
     return res.status(404).json({ message: shortName + ' CNA does not exist.' })
   }
 
-  const payload = {
-    id_quota: result.policies.id_quota
+  let payload
+
+  if (!returned) {
+    payload = {
+      id_quota: result.policies.id_quota
+    }
+
+    result = await CveId.countDocuments({ owning_cna: shortName, cve_year: year, state: 'RESERVED' })
+    payload.total_reserved = result
+    payload.available = (payload.id_quota - payload.total_reserved)
   }
 
-  result = await CveId.countDocuments({ owning_cna: shortName, cve_year: year, state: 'RESERVED' })
-  payload.total_reserved = result
-  payload.available = (payload.id_quota - payload.total_reserved)
-
-  if (payload.available < 0) {
+  if (!returned && payload.available < 0) {
+    returned = true
     logger.error({ message: ' An error occurred: Total reserved exceeded id_quota.', payload: payload })
     return res.status(400).json({ message: 'Total reserved exceeded id_quota, contact an administrator.' })
   }
 
-  if (amount > payload.available) {
+  if (!returned && amount > payload.available) {
+    returned = true
     CONSTANTS.OVER_ID_QUOTA.details = payload
     return res.status(404).json(CONSTANTS.OVER_ID_QUOTA)
   }
 
-  const date = new Date()
-  let cveId
-
-  // priority
-  if (batchType === undefined) {
-    await priorityReservation(year, amount, date, cveId, shortName, cnaShortName, requester, payload.available, res)
-  } else if (batchType === 'sequential') {
-    await sequentialReservation(year, amount, date, cveId, shortName, cnaShortName, requester, payload.available, res)
-  } else if (batchType === 'non-sequential' || batchType === 'nonsequential') {
-    return res.status(200).json({ message: batchType })
-  } else {
-    return res.status(400).json({ message: 'Invalid value for query parameter \'batch_type\'' })
+  if (!returned) {
+    // priority
+    if (batchType === undefined) {
+      await priorityReservation(year, amount, cveId, shortName, cnaShortName, requester, payload.available, res)
+    } else if (batchType === 'sequential') {
+      await sequentialReservation(year, amount, cveId, shortName, cnaShortName, requester, payload.available, res)
+    } else if (batchType === 'non-sequential' || batchType === 'nonsequential') {
+      await nonSequentialReservation(year, amount, cveId, shortName, cnaShortName, requester, payload.availableIds, res)
+      return res.status(200).json({ message: batchType })
+    } else {
+      return res.status(400).json({ message: 'Invalid value for query parameter \'batch_type\'' })
+    }
   }
 }
 
-async function priorityReservation (year, amount, date, cveId, shortName, cnaShortName, requester, availableIds, res) {
+async function priorityReservation (year, amount, cveId, shortName, cnaShortName, requester, availableIds, res) {
   let result = await CveIdRange.findOne({ cve_year: year })
   let isFull = false
 
@@ -341,7 +359,7 @@ async function priorityReservation (year, amount, date, cveId, shortName, cnaSho
     if (!result) {
       isFull = true
       logger.info('Priority id block is full for year ' + year + ', reserving id in sequential block')
-      await sequentialReservation(year, amount, date, cveId, shortName, cnaShortName, requester, availableIds, res)
+      await sequentialReservation(year, amount, cveId, shortName, cnaShortName, requester, availableIds, res)
     }
   } else {
     logger.info('CVE IDs for year ' + year + ' cannot be reserved at this time.')
@@ -371,7 +389,7 @@ async function priorityReservation (year, amount, date, cveId, shortName, cnaSho
   }
 }
 
-async function sequentialReservation (year, amount, date, cveId, shortName, cnaShortName, requester, availableIds, res) {
+async function sequentialReservation (year, amount, cveId, shortName, cnaShortName, requester, availableIds, res) {
   let result = await CveIdRange.findOne({ cve_year: year })
 
   // Cve Id Range for 'year' exists
@@ -426,6 +444,10 @@ function generateIds (year, ranges, amount) {
   }
 
   return ids
+}
+
+async function nonSequentialReservation (year, amount, cveId, shortName, cnaShortName, requester, availableIds, res) {
+  //
 }
 
 async function createCveIdRange (req, res) {

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -307,15 +307,14 @@ async function reserveCveId (req, res) {
     return res.status(404).json(CONSTANTS.OVER_ID_QUOTA)
   }
 
-  res.header('CVE-API-REMAINING-QUOTA', payload.available - amount)
   const date = new Date()
   let cveId
 
   // priority
   if (batchType === undefined) {
-    await priorityReservation(year, amount, date, cveId, shortName, cnaShortName, requester, res)
+    await priorityReservation(year, amount, date, cveId, shortName, cnaShortName, requester, payload.available, res)
   } else if (batchType === 'sequential') {
-    await sequentialReservation(year, amount, date, cveId, shortName, cnaShortName, requester, res)
+    await sequentialReservation(year, amount, date, cveId, shortName, cnaShortName, requester, payload.available, res)
   } else if (batchType === 'non-sequential' || batchType === 'nonsequential') {
     return res.status(200).json({ message: batchType })
   } else {
@@ -323,7 +322,7 @@ async function reserveCveId (req, res) {
   }
 }
 
-async function priorityReservation (year, amount, date, cveId, shortName, cnaShortName, requester, res) {
+async function priorityReservation (year, amount, date, cveId, shortName, cnaShortName, requester, availableIds, res) {
   let result = await CveIdRange.findOne({ cve_year: year })
   let isFull = false
 
@@ -336,16 +335,8 @@ async function priorityReservation (year, amount, date, cveId, shortName, cnaSho
     if (!result) {
       isFull = true
       logger.info('Priority id block is full for year ' + year + ', reserving id in sequential block')
-      await sequentialReservation(year, amount, date, cveId, shortName, cnaShortName, requester, res)
+      await sequentialReservation(year, amount, date, cveId, shortName, cnaShortName, requester, availableIds, res)
     }
-  } else if (date.getFullYear() === parseInt(year) || (date.getFullYear() + 1 === parseInt(year) && date.getMonth() > 7)) {
-    // Create Cve ID Range doc for 'year' if year === current year or year === next year and month is September or later
-    const defaultDoc = CONSTANTS.DEFAULT_CVE_ID_RANGE
-    defaultDoc.cve_year = year
-    defaultDoc.ranges.priority.top_id = defaultDoc.ranges.priority.top_id + amount
-    result = await CveIdRange.findOneAndUpdate({ cve_year: year }, defaultDoc, { upsert: true, new: true })
-
-    logger.info('CVE Id Range document for year ' + year + ' was created.')
   } else {
     logger.info('CVE IDs for year ' + year + ' cannot be reserved at this time.')
     return res.status(403).json({ message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
@@ -368,12 +359,13 @@ async function priorityReservation (year, amount, date, cveId, shortName, cnaSho
     // Create a CveId document
     await CveId.findOneAndUpdate().byCveId(id).updateOne(cveId).setOptions({ upsert: true })
 
+    res.header('CVE-API-REMAINING-QUOTA', availableIds - amount)
     logger.info({ message: 'A priority CVE ID was reserved for \'' + shortName + '\' org on behalf of \'' + cnaShortName + '\' org.', cve_id: id })
     return res.status(200).json({ message: 'The following CVE IDs were reserved.', reserved: id })
   }
 }
 
-async function sequentialReservation (year, amount, date, cveId, shortName, cnaShortName, requester, res) {
+async function sequentialReservation (year, amount, date, cveId, shortName, cnaShortName, requester, availableIds, res) {
   let result = await CveIdRange.findOne({ cve_year: year })
 
   // Cve Id Range for 'year' exists
@@ -386,14 +378,6 @@ async function sequentialReservation (year, amount, date, cveId, shortName, cnaS
       logger.error('The cve id block is full for year ' + year + '. No more ids can be reserved at this time.')
       return res.status(403).json({ message: 'The cve id block is full for year ' + year + '. Please contact the Secretariat.' })
     }
-  } else if (date.getFullYear() === parseInt(year) || (date.getFullYear() + 1 === parseInt(year) && date.getMonth() > 7)) {
-    // Create Cve ID Range doc for 'year' if year === current year or year === next year and month is September or later
-    const defaultDoc = CONSTANTS.DEFAULT_CVE_ID_RANGE
-    defaultDoc.cve_year = year
-    defaultDoc.ranges.general.top_id = defaultDoc.ranges.general.top_id + amount
-    result = await CveIdRange.findOneAndUpdate({ cve_year: year }, defaultDoc, { upsert: true, new: true })
-
-    logger.info('CVE Id Range document for year ' + year + ' was created.')
   } else {
     logger.info('CVE IDs for year ' + year + ' cannot be reserved at this time.')
     return res.status(403).json({ message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
@@ -421,6 +405,7 @@ async function sequentialReservation (year, amount, date, cveId, shortName, cnaS
   // Create multiple CveId documents
   await CveId.insertMany(cveIdDocuments)
 
+  res.header('CVE-API-REMAINING-QUOTA', availableIds - amount)
   logger.info({ message: 'Sequential CVE IDs were reserved for \'' + shortName + '\' org on behalf of \'' + cnaShortName + '\' org.', cve_ids: ids })
   return res.status(200).json({ message: 'The following CVE IDs were reserved.', reserved: ids })
 }

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -268,7 +268,8 @@ async function reserveCveId (req, res) {
     return res.status(400).json({ message: 'Provide the cna\'s short name to allocate CVE IDs.' })
   }
 
-  if (shortName !== cnaShortName && cnaShortName !== process.env.SECRETARIAT) {
+  const isSecretariat = await util.isSecretariat(cnaShortName)
+  if (cnaShortName !== shortName && !isSecretariat) {
     return res.status(403).json({ message: 'CVE IDs can only be reserved by the owning CNA or by the Secretariat.' })
   }
 
@@ -427,9 +428,35 @@ function generateIds (year, ranges, amount) {
   return ids
 }
 
+async function createCveIdRange (req, res) {
+  const year = req.params.year
+  const cnaShortName = req.header('CVE-API-CNA')
+
+  const isSecretariat = await util.isSecretariat(cnaShortName)
+  if (!isSecretariat) {
+    logger.info({ message: 'The Cve Id Range cannot be created by other than the secretariat.' })
+    return res.status(403).json({ message: 'The Cve Id Range for year ' + year + ' cannot be created by other than the secretariat.' })
+  }
+
+  const result = await CveIdRange.findOne({ cve_year: year })
+
+  if (result) {
+    logger.info('CVE Id Range document for year ' + year + ' already exists.')
+    return res.status(400).json({ message: 'CVE Id Range document for year ' + year + ' was not created because it already exists.' })
+  }
+
+  const defaultDoc = CONSTANTS.DEFAULT_CVE_ID_RANGE
+  defaultDoc.cve_year = year
+  await CveIdRange.findOneAndUpdate({ cve_year: year }, defaultDoc, { upsert: true })
+
+  logger.info('CVE Id Range document for year ' + year + ' was created.')
+  return res.status(200).json({ message: 'CVE Id Range document for year ' + year + ' was created.' })
+}
+
 module.exports = {
   CVEID_GET_SINGLE: getCveId,
   CVEID_RESERVE: reserveCveId,
   CVEID_GET_FILTER: getFilteredCveId,
-  CVEID_STATE_REASIGN_SINGLE: modifyCveId
+  CVEID_STATE_REASIGN_SINGLE: modifyCveId,
+  CVEID_RANGE_CREATE: createCveIdRange
 }

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -1,5 +1,6 @@
 require('dotenv').config()
 const CveId = require('../../model/cve-id')
+const CveIdRange = require('../../model/cve-id-range')
 const Org = require('../../model/org')
 const logger = require('../../middleware/logger')
 const CONSTANTS = require('../../constants')
@@ -235,180 +236,206 @@ async function modifyCveId (req, res) {
 }
 
 async function reserveCveId (req, res) {
-  const sequential = req.query.sequential
-  const amount = req.query.amount
+  const requester = req.header('CVE-API-SUBMITTER')
+  const cnaShortName = req.header('CVE-API-CNA')
+  let batchType
+  let amount
+  let shortName
+  let year
+
+  Object.keys(req.query).forEach(k => {
+    const key = k.toLowerCase()
+
+    if (key === 'amount') {
+      amount = req.query.amount.replace(/["']/g, '')
+    } else if (key === 'batch_type') {
+      batchType = req.query.batch_type.replace(/["']/g, '').toLowerCase()
+    } else if (key === 'short_name') {
+      shortName = req.query.short_name.replace(/["']/g, '').toLowerCase()
+    } else if (key === 'cve_year') {
+      year = req.query.cve_year.replace(/["']/g, '')
+    } else {
+      return res.status(400).json({ message: 'Invalid query parameter \'' + key + '\'' })
+    }
+  })
+
+  if (shortName === undefined) {
+    return res.status(400).json({ message: 'Provide the cna\'s short name to allocate CVE IDs.' })
+  }
+
+  if (shortName !== cnaShortName && cnaShortName !== process.env.SECRETARIAT) {
+    return res.status(403).json({ message: 'CVE IDs can only be reserved by the owning CNA or by the Secretariat.' })
+  }
+
+  if (year === undefined) {
+    return res.status(400).json({ message: 'Provide a year to allocate CVE IDs.' })
+  }
+
   if (amount === undefined) {
-    return res.status(404).json(CONSTANTS.no_amount)
+    return res.status(404).json(CONSTANTS.NO_AMOUNT)
   }
+
   if (amount <= 0) {
-    return res.status(404).json(CONSTANTS.invalid_amount)
+    return res.status(404).json(CONSTANTS.INVALID_AMOUNT)
   }
-  const available = 5
-  if (amount > available) {
-    return res.status(404).json(CONSTANTS.over_id_quota)
+
+  if (amount > 1 && batchType === undefined) {
+    return res.status(400).json({ message: 'A batch type (i.e. sequential, non-sequential) must be specified when allocating more than one CVE ID.' })
   }
-  res.header('CVE-API-REMAINING-QUOTA', available - amount)
-  if (sequential) {
-    return res.status(200).json(sequentialIds.slice(0, amount))
+
+  let result = await Org.findOne().byShortName(shortName)
+  if (!result) {
+    logger.info(shortName + ' CNA does not exist.')
+    return res.status(404).json({ message: shortName + ' CNA does not exist.' })
   }
-  return res.status(200).json(nonsequentialIds.slice(0, amount))
+
+  const payload = {
+    id_quota: result.policies.id_quota
+  }
+
+  result = await CveId.countDocuments({ owning_cna: shortName, cve_year: year, state: 'RESERVED' })
+  payload.total_reserved = result
+  payload.available = (payload.id_quota - payload.total_reserved)
+
+  if (payload.available < 0) {
+    logger.error({ message: ' An error occurred: Total reserved exceeded id_quota.', payload: payload })
+    return res.status(400).json({ message: 'Total reserved exceeded id_quota, contact an administrator.' })
+  }
+
+  if (amount > payload.available) {
+    CONSTANTS.OVER_ID_QUOTA.details = payload
+    return res.status(404).json(CONSTANTS.OVER_ID_QUOTA)
+  }
+
+  res.header('CVE-API-REMAINING-QUOTA', payload.available - amount)
+  const date = new Date()
+  let cveId
+
+  // priority
+  if (batchType === undefined) {
+    await priorityReservation(year, amount, date, cveId, shortName, cnaShortName, requester, res)
+  } else if (batchType === 'sequential') {
+    await sequentialReservation(year, amount, date, cveId, shortName, cnaShortName, requester, res)
+  } else if (batchType === 'non-sequential' || batchType === 'nonsequential') {
+    return res.status(200).json({ message: batchType })
+  } else {
+    return res.status(400).json({ message: 'Invalid value for query parameter \'batch_type\'' })
+  }
 }
 
-const sequentialIds = [
-  {
-    cve_id: 'CVE-3000-0001',
-    cve_year: 3000,
-    owning_cna: 'orgshortname',
-    state: 'RESERVED',
-    requested_by: {
-      cna: 'orgshortname',
-      user: 'you'
-    },
-    time: {
-      created: '3000-06-24T21:08:42.937+00:00',
-      modified: '3000-06-24T21:12:46.576+00:00',
-      reserved: '3000-06-24T21:12:46.576+00:00'
-    }
-  },
-  {
-    cve_id: 'CVE-3000-0002',
-    cve_year: 3000,
-    owning_cna: 'orgshortname',
-    state: 'RESERVED',
-    requested_by: {
-      cna: 'orgshortname',
-      user: 'you'
-    },
-    time: {
-      created: '3000-06-24T21:08:42.937+00:00',
-      modified: '3000-06-24T21:12:46.576+00:00',
-      reserved: '3000-06-24T21:12:46.576+00:00'
-    }
-  },
-  {
-    cve_id: 'CVE-3000-0003',
-    cve_year: 3000,
-    owning_cna: 'orgshortname',
-    state: 'RESERVED',
-    requested_by: {
-      cna: 'orgshortname',
-      user: 'you'
-    },
-    time: {
-      created: '3000-06-24T21:08:42.937+00:00',
-      modified: '3000-06-24T21:12:46.576+00:00',
-      reserved: '3000-06-24T21:12:46.576+00:00'
-    }
-  },
-  {
-    cve_id: 'CVE-3000-0004',
-    cve_year: 3000,
-    owning_cna: 'orgshortname',
-    state: 'RESERVED',
-    requested_by: {
-      cna: 'orgshortname',
-      user: 'you'
-    },
-    time: {
-      created: '3000-06-24T21:08:42.937+00:00',
-      modified: '3000-06-24T21:12:46.576+00:00',
-      reserved: '3000-06-24T21:12:46.576+00:00'
-    }
-  },
-  {
-    cve_id: 'CVE-3000-0005',
-    cve_year: 3000,
-    owning_cna: 'orgshortname',
-    state: 'RESERVED',
-    requested_by: {
-      cna: 'orgshortname',
-      user: 'you'
-    },
-    time: {
-      created: '3000-06-24T21:08:42.937+00:00',
-      modified: '3000-06-24T21:12:46.576+00:00',
-      reserved: '3000-06-24T21:12:46.576+00:00'
-    }
-  }
-]
+async function priorityReservation (year, amount, date, cveId, shortName, cnaShortName, requester, res) {
+  let result = await CveIdRange.findOne({ cve_year: year })
+  let isFull = false
 
-const nonsequentialIds = [
-  {
-    cve_id: 'CVE-3000-0500',
-    cve_year: 3000,
-    owning_cna: 'orgshortname',
-    state: 'RESERVED',
-    requested_by: {
-      cna: 'orgshortname',
-      user: 'you'
-    },
-    time: {
-      created: '3000-06-24T21:08:42.937+00:00',
-      modified: '3000-06-24T21:12:46.576+00:00',
-      reserved: '3000-06-24T21:12:46.576+00:00'
+  // Cve Id Range for 'year' exists
+  if (result) {
+    const endRange = parseInt(result.ranges.priority.end)
+    result = await CveIdRange.findOneAndUpdate({ cve_year: year, 'ranges.priority.top_id': { $lt: endRange } }, { $inc: { 'ranges.priority.top_id': amount } }, { new: true })
+
+    // priority id block is full, reserve id in sequential block
+    if (!result) {
+      isFull = true
+      logger.info('Priority id block is full for year ' + year + ', reserving id in sequential block')
+      await sequentialReservation(year, amount, date, cveId, shortName, cnaShortName, requester, res)
     }
-  },
-  {
-    cve_id: 'CVE-3000-0522',
-    cve_year: 3000,
-    owning_cna: 'orgshortname',
-    state: 'RESERVED',
-    requested_by: {
-      cna: 'orgshortname',
-      user: 'you'
-    },
-    time: {
-      created: '3000-06-24T21:08:42.937+00:00',
-      modified: '3000-06-24T21:12:46.576+00:00',
-      reserved: '3000-06-24T21:12:46.576+00:00'
-    }
-  },
-  {
-    cve_id: 'CVE-3000-0558',
-    cve_year: 3000,
-    owning_cna: 'orgshortname',
-    state: 'RESERVED',
-    requested_by: {
-      cna: 'orgshortname',
-      user: 'you'
-    },
-    time: {
-      created: '3000-06-24T21:08:42.937+00:00',
-      modified: '3000-06-24T21:12:46.576+00:00',
-      reserved: '3000-06-24T21:12:46.576+00:00'
-    }
-  },
-  {
-    cve_id: 'CVE-3000-0518',
-    cve_year: 3000,
-    owning_cna: 'orgshortname',
-    state: 'RESERVED',
-    requested_by: {
-      cna: 'orgshortname',
-      user: 'you'
-    },
-    time: {
-      created: '3000-06-24T21:08:42.937+00:00',
-      modified: '3000-06-24T21:12:46.576+00:00',
-      reserved: '3000-06-24T21:12:46.576+00:00'
-    }
-  },
-  {
-    cve_id: 'CVE-3000-0591',
-    cve_year: 3000,
-    owning_cna: 'orgshortname',
-    state: 'RESERVED',
-    requested_by: {
-      cna: 'orgshortname',
-      user: 'you'
-    },
-    time: {
-      created: '3000-06-24T21:08:42.937+00:00',
-      modified: '3000-06-24T21:12:46.576+00:00',
-      reserved: '3000-06-24T21:12:46.576+00:00'
-    }
+  } else if (date.getFullYear() === parseInt(year) || (date.getFullYear() + 1 === parseInt(year) && date.getMonth() > 7)) {
+    // Create Cve ID Range doc for 'year' if year === current year or year === next year and month is September or later
+    const defaultDoc = CONSTANTS.DEFAULT_CVE_ID_RANGE
+    defaultDoc.cve_year = year
+    defaultDoc.ranges.priority.top_id = defaultDoc.ranges.priority.top_id + amount
+    result = await CveIdRange.findOneAndUpdate({ cve_year: year }, defaultDoc, { upsert: true, new: true })
+
+    logger.info('CVE Id Range document for year ' + year + ' was created.')
+  } else {
+    logger.info('CVE IDs for year ' + year + ' cannot be reserved at this time.')
+    return res.status(403).json({ message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
   }
-]
+
+  if (!isFull) {
+    const id = generateIds(year, result.ranges.priority, amount)
+
+    cveId = new CveId()
+    cveId.cve_id = id[0]
+    cveId.cve_year = year
+    cveId.state = 'RESERVED'
+    cveId.owning_cna = shortName // the org who gets assigned the reserved CVE IDs
+    cveId.reserved = Date.now()
+    cveId.requested_by = {
+      cna: cnaShortName, // the org who requested the CVE IDs
+      user: requester
+    }
+
+    // Create a CveId document
+    await CveId.findOneAndUpdate().byCveId(id).updateOne(cveId).setOptions({ upsert: true })
+
+    logger.info({ message: 'A priority CVE ID was reserved for \'' + shortName + '\' org on behalf of \'' + cnaShortName + '\' org.', cve_id: id })
+    return res.status(200).json({ message: 'The following CVE IDs were reserved.', reserved: id })
+  }
+}
+
+async function sequentialReservation (year, amount, date, cveId, shortName, cnaShortName, requester, res) {
+  let result = await CveIdRange.findOne({ cve_year: year })
+
+  // Cve Id Range for 'year' exists
+  if (result) {
+    const endRange = parseInt(result.ranges.general.end)
+    result = await CveIdRange.findOneAndUpdate({ cve_year: year, 'ranges.general.top_id': { $lt: endRange } }, { $inc: { 'ranges.general.top_id': amount } }, { new: true })
+
+    // The cve id block is full
+    if (!result) {
+      logger.error('The cve id block is full for year ' + year + '. No more ids can be reserved at this time.')
+      return res.status(403).json({ message: 'The cve id block is full for year ' + year + '. Please contact the Secretariat.' })
+    }
+  } else if (date.getFullYear() === parseInt(year) || (date.getFullYear() + 1 === parseInt(year) && date.getMonth() > 7)) {
+    // Create Cve ID Range doc for 'year' if year === current year or year === next year and month is September or later
+    const defaultDoc = CONSTANTS.DEFAULT_CVE_ID_RANGE
+    defaultDoc.cve_year = year
+    defaultDoc.ranges.general.top_id = defaultDoc.ranges.general.top_id + amount
+    result = await CveIdRange.findOneAndUpdate({ cve_year: year }, defaultDoc, { upsert: true, new: true })
+
+    logger.info('CVE Id Range document for year ' + year + ' was created.')
+  } else {
+    logger.info('CVE IDs for year ' + year + ' cannot be reserved at this time.')
+    return res.status(403).json({ message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
+  }
+
+  const ids = generateIds(year, result.ranges.general, amount)
+  const cveIdDocuments = []
+  // return res.status(200).json({ ids: ids })
+
+  ids.forEach(id => {
+    cveId = new CveId()
+    cveId.cve_id = id
+    cveId.cve_year = year
+    cveId.state = 'RESERVED'
+    cveId.owning_cna = shortName // the org who gets assigned the reserved CVE IDs
+    cveId.reserved = Date.now()
+    cveId.requested_by = {
+      cna: cnaShortName, // the org who requested the CVE IDs
+      user: requester
+    }
+
+    cveIdDocuments.push(cveId)
+  })
+
+  // Create multiple CveId documents
+  await CveId.insertMany(cveIdDocuments)
+
+  logger.info({ message: 'Sequential CVE IDs were reserved for \'' + shortName + '\' org on behalf of \'' + cnaShortName + '\' org.', cve_ids: ids })
+  return res.status(200).json({ message: 'The following CVE IDs were reserved.', reserved: ids })
+}
+
+function generateIds (year, ranges, amount) {
+  const start = ranges.top_id - amount + 1
+  const end = ranges.top_id
+  const ids = []
+
+  for (let i = start; i < end + 1; i++) {
+    ids.push('CVE-' + year + '-' + String(i).padStart(4, '0'))
+  }
+
+  return ids
+}
 
 module.exports = {
   CVEID_GET_SINGLE: getCveId,

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -59,6 +59,7 @@ async function getFilteredCveId (req, res) {
     dateOperator: []
   }
   let returned = false
+  const isSecretariat = await util.isSecretariat(req.header('CVE-API-CNA'))
 
   Object.keys(req.query).forEach(k => {
     const key = k.toLowerCase()
@@ -113,7 +114,6 @@ async function getFilteredCveId (req, res) {
 
   let query = {}
 
-  const isSecretariat = await util.isSecretariat(req.header('CVE-API-CNA'))
   if (!isSecretariat) {
     query = {
       owning_cna: req.header('CVE-API-CNA')
@@ -450,7 +450,7 @@ async function sequentialReservation (year, amount, cveId, shortName, cnaShortNa
 }
 
 async function nonSequentialReservation (year, amount, cveId, shortName, cnaShortName, requester, availableIds, res) {
-  //
+  return res.status(400).json({ message: 'This endpoint is still in development. Please come back later...' })
 }
 
 function generateIds (year, ranges, amount) {

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -111,8 +111,13 @@ async function getFilteredCveId (req, res) {
     }
   }
 
-  const query = {
-    owning_cna: req.header('CVE-API-CNA')
+  let query = {}
+
+  const isSecretariat = await util.isSecretariat(req.header('CVE-API-CNA'))
+  if (!isSecretariat) {
+    query = {
+      owning_cna: req.header('CVE-API-CNA')
+    }
   }
 
   if (year) {

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -410,29 +410,22 @@ async function sequentialReservation (year, amount, cveId, shortName, cnaShortNa
   }
 
   if (!returned) {
-    const endRange = parseInt(result.ranges.general.end)
     const topId = parseInt(result.ranges.general.top_id)
     amount = parseInt(amount)
     result = await CveIdRange.findOneAndUpdate({ $and: [{ cve_year: year }, { 'ranges.general.end': { $gt: (topId + amount - 1) } }] }, { $inc: { 'ranges.general.top_id': amount } }, { new: true })
 
     // The cve id block is full for sequential CVE IDs
     if (!result) {
-      const available = await CveId.countDocuments({ cve_year: year, state: 'AVAILABLE' })
-
       isFull = true
-      const payload = {
-        requested_ids: amount,
-        available_sequential_ids: endRange - topId,
-        available_nonsequential_ids: available
-      }
+      let message = 'The request for reserving ' + amount + ' cve ids could not be satisfied because there are not enough ids in the CVE ID sequential block.'
 
       if (isPriority) {
-        payload.available_priority_ids = 0
+        message = 'The request for reserving ' + amount + ' cve ids could not be satisfied because there are not enough ids in the CVE ID priority block or sequential block.'
       }
 
       returned = true
       logger.error('The cve id sequential block is full for year ' + year + '. No more sequential ids can be reserved at this time.')
-      return res.status(403).json({ message: 'The request for reserving ' + amount + ' cve id(s) could not be satisfied.', reason: payload })
+      return res.status(403).json({ message: message })
     }
   }
 
@@ -490,7 +483,7 @@ async function createCveIdRange (req, res) {
     return res.status(403).json({ message: 'The Cve Id Range for year ' + year + ' cannot be created by other than the Secretariat.' })
   }
 
-  let result = await CveIdRange.findOne({ cve_year: year })
+  const result = await CveIdRange.findOne({ cve_year: year })
 
   if (result) {
     logger.info('CVE Id Range document for year ' + year + ' already exists.')
@@ -499,8 +492,7 @@ async function createCveIdRange (req, res) {
 
   const defaultDoc = CONSTANTS.DEFAULT_CVE_ID_RANGE
   defaultDoc.cve_year = year
-  result = await CveIdRange.findOneAndUpdate({ cve_year: year }, { upsert: true, new: true })
-  console.log(result)
+  await CveIdRange.findOneAndUpdate({ cve_year: year }, defaultDoc, { upsert: true })
 
   logger.info('CVE Id Range document for year ' + year + ' was created.')
   return res.status(200).json({ message: 'CVE Id Range document for year ' + year + ' was created.' })

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -327,7 +327,7 @@ async function reserveCveId (req, res) {
   if (!returned && payload.available < 0) {
     returned = true
     logger.error({ message: ' An error occurred: Total reserved exceeded id_quota.', payload: payload })
-    return res.status(400).json({ message: 'Total reserved exceeded id_quota, contact an administrator.' })
+    return res.status(400).json({ message: 'Total ids reserved exceeded ID quota. Please contact support.' })
   }
 
   if (!returned && amount > payload.available) {
@@ -341,9 +341,9 @@ async function reserveCveId (req, res) {
     if (batchType === undefined) {
       await priorityReservation(year, amount, cveId, shortName, cnaShortName, requester, payload.available, res)
     } else if (batchType === 'sequential') {
-      await sequentialReservation(year, amount, cveId, shortName, cnaShortName, requester, payload.available, res)
+      await sequentialReservation(year, amount, cveId, shortName, cnaShortName, requester, payload.available, false, res)
     } else if (batchType === 'non-sequential' || batchType === 'nonsequential') {
-      await nonSequentialReservation(year, amount, cveId, shortName, cnaShortName, requester, payload.availableIds, res)
+      await nonSequentialReservation(year, amount, cveId, shortName, cnaShortName, requester, payload.available, res)
     } else {
       return res.status(400).json({ message: 'Invalid value for query parameter \'batch_type\'' })
     }
@@ -352,28 +352,29 @@ async function reserveCveId (req, res) {
 
 async function priorityReservation (year, amount, cveId, shortName, cnaShortName, requester, availableIds, res) {
   let result = await CveIdRange.findOne({ cve_year: year })
+  let returned = false
   let isFull = false
 
-  // Cve Id Range for 'year' exists
-  if (result) {
-    const endRange = parseInt(result.ranges.priority.end)
-    result = await CveIdRange.findOneAndUpdate({ cve_year: year, 'ranges.priority.top_id': { $lt: endRange } }, { $inc: { 'ranges.priority.top_id': amount } }, { new: true })
-
-    // priority id block is full, reserve id in sequential block
-    if (!result) {
-      // OK
-      isFull = true
-      logger.info('Priority id block is full for year ' + year + ', reserving id in sequential block.')
-      await sequentialReservation(year, amount, cveId, shortName, cnaShortName, requester, availableIds, res)
-    }
-  } else {
-    // OK
+  // Cve Id Range for 'year' does not exists
+  if (!result) {
+    returned = true
     logger.info('CVE IDs for year ' + year + ' cannot be reserved at this time.')
     return res.status(403).json({ message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
   }
 
-  // OK
-  if (!isFull) {
+  if (!returned) {
+    const endRange = parseInt(result.ranges.priority.end)
+    result = await CveIdRange.findOneAndUpdate({ $and: [{ cve_year: year }, { 'ranges.priority.top_id': { $lt: endRange } }] }, { $inc: { 'ranges.priority.top_id': amount } }, { new: true })
+
+    // priority id block is full, reserve id in sequential block
+    if (!result) {
+      isFull = true
+      logger.info('Priority id block is full for year ' + year + ', reserving id in sequential block.')
+      await sequentialReservation(year, amount, cveId, shortName, cnaShortName, requester, availableIds, true, res)
+    }
+  }
+
+  if (!isFull && !returned) {
     const id = generateIds(year, result.ranges.priority, amount)
 
     cveId = new CveId()
@@ -396,33 +397,48 @@ async function priorityReservation (year, amount, cveId, shortName, cnaShortName
   }
 }
 
-async function sequentialReservation (year, amount, cveId, shortName, cnaShortName, requester, availableIds, res) {
+async function sequentialReservation (year, amount, cveId, shortName, cnaShortName, requester, availableIds, isPriority, res) {
   let result = await CveIdRange.findOne({ cve_year: year })
+  let returned = false
   let isFull = false
 
-  // Cve Id Range for 'year' exists
-  if (result) {
-    const endRange = parseInt(result.ranges.general.end)
-    result = await CveIdRange.findOneAndUpdate({ cve_year: year, 'ranges.general.top_id': { $lt: endRange } }, { $inc: { 'ranges.general.top_id': amount } }, { new: true })
-
-    // The cve id block is full
-    if (!result) {
-      // OK
-      isFull = true
-      logger.error('The cve id block is full for year ' + year + '. No more ids can be reserved at this time.')
-      return res.status(403).json({ message: 'The cve id block is full for year ' + year + '. Please contact an administrator.' })
-    }
-  } else {
-    // OK
+  // Cve Id Range for 'year' does not exists
+  if (!result) {
+    returned = true
     logger.info('CVE IDs for year ' + year + ' cannot be reserved at this time.')
     return res.status(403).json({ message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
   }
 
-  // OK
-  if (!isFull) {
+  if (!returned) {
+    const endRange = parseInt(result.ranges.general.end)
+    const topId = parseInt(result.ranges.general.top_id)
+    amount = parseInt(amount)
+    result = await CveIdRange.findOneAndUpdate({ $and: [{ cve_year: year }, { 'ranges.general.end': { $gt: (topId + amount - 1) } }] }, { $inc: { 'ranges.general.top_id': amount } }, { new: true })
+
+    // The cve id block is full for sequential CVE IDs
+    if (!result) {
+      const available = await CveId.countDocuments({ cve_year: year, state: 'AVAILABLE' })
+
+      isFull = true
+      const payload = {
+        requested_ids: amount,
+        available_sequential_ids: endRange - topId,
+        available_nonsequential_ids: available
+      }
+
+      if (isPriority) {
+        payload.available_priority_ids = 0
+      }
+
+      returned = true
+      logger.error('The cve id sequential block is full for year ' + year + '. No more sequential ids can be reserved at this time.')
+      return res.status(403).json({ message: 'The request for reserving ' + amount + ' cve id(s) could not be satisfied.', reason: payload })
+    }
+  }
+
+  if (!isFull && !returned) {
     const ids = generateIds(year, result.ranges.general, amount)
     const cveIdDocuments = []
-    // return res.status(200).json({ ids: ids })
 
     ids.forEach(id => {
       cveId = new CveId()
@@ -449,7 +465,52 @@ async function sequentialReservation (year, amount, cveId, shortName, cnaShortNa
 }
 
 async function nonSequentialReservation (year, amount, cveId, shortName, cnaShortName, requester, availableIds, res) {
-  return res.status(400).json({ message: 'This endpoint is still in development. Please come back later...' })
+  let isFull = false
+  let returned = false
+  amount = parseInt(amount)
+  const availableLimit = Math.max(3 * amount, CONSTANTS.DEFAULT_AVAILABLE_POOL)
+  let result = await CveIdRange.findOne({ cve_year: year })
+  console.log('availableLimit: ' + availableLimit)
+
+  // Cve Id Range for 'year' does not exists
+  if (!result) {
+    returned = true
+    logger.info('CVE IDs for year ' + year + ' cannot be reserved at this time.')
+    return res.status(403).json({ message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
+  }
+
+  if (!returned) {
+    const available = await CveIdRange.countDocuments({ cve_year: year, state: 'AVAILABLE' }).limit(availableLimit)
+    console.log('available: ' + available)
+    console.log('amount: ' + amount)
+
+    // Case 1: Not enough IDs in the 'AVAILABLE' pool
+    // Reserve more ids
+    if (available < availableLimit) {
+      const endRange = parseInt(result.ranges.general.end)
+      const topId = parseInt(result.ranges.general.top_id)
+      let increment = availableLimit - available + amount
+      console.log('increment: ' + increment)
+
+      if (endRange <= (topId + increment)) {
+        increment = endRange - topId
+        console.log('increment: ' + increment)
+      }
+
+      // { $gt: increment }
+      result = await CveIdRange.findOneAndUpdate({ $and: [{ cve_year: year }, { 'ranges.general.end': { $gt: increment } }] }, { $inc: { 'ranges.general.top_id': increment } }, { new: true })
+      // }
+
+      console.log(result)
+    }
+  }
+
+  // Case 2: Enough IDs in the 'AVAILABLE' pool
+  if (!isFull && !returned) {
+    return res.status(400).json({ message: 'This endpoint is still in development. Please come back later...' })
+  }
+
+  // return res.status(400).json({ message: 'This endpoint is still in development. Please come back later...' })
 }
 
 function generateIds (year, ranges, amount) {

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -465,52 +465,7 @@ async function sequentialReservation (year, amount, cveId, shortName, cnaShortNa
 }
 
 async function nonSequentialReservation (year, amount, cveId, shortName, cnaShortName, requester, availableIds, res) {
-  let isFull = false
-  let returned = false
-  amount = parseInt(amount)
-  const availableLimit = Math.max(3 * amount, CONSTANTS.DEFAULT_AVAILABLE_POOL)
-  let result = await CveIdRange.findOne({ cve_year: year })
-  console.log('availableLimit: ' + availableLimit)
-
-  // Cve Id Range for 'year' does not exists
-  if (!result) {
-    returned = true
-    logger.info('CVE IDs for year ' + year + ' cannot be reserved at this time.')
-    return res.status(403).json({ message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
-  }
-
-  if (!returned) {
-    const available = await CveIdRange.countDocuments({ cve_year: year, state: 'AVAILABLE' }).limit(availableLimit)
-    console.log('available: ' + available)
-    console.log('amount: ' + amount)
-
-    // Case 1: Not enough IDs in the 'AVAILABLE' pool
-    // Reserve more ids
-    if (available < availableLimit) {
-      const endRange = parseInt(result.ranges.general.end)
-      const topId = parseInt(result.ranges.general.top_id)
-      let increment = availableLimit - available + amount
-      console.log('increment: ' + increment)
-
-      if (endRange <= (topId + increment)) {
-        increment = endRange - topId
-        console.log('increment: ' + increment)
-      }
-
-      // { $gt: increment }
-      result = await CveIdRange.findOneAndUpdate({ $and: [{ cve_year: year }, { 'ranges.general.end': { $gt: increment } }] }, { $inc: { 'ranges.general.top_id': increment } }, { new: true })
-      // }
-
-      console.log(result)
-    }
-  }
-
-  // Case 2: Enough IDs in the 'AVAILABLE' pool
-  if (!isFull && !returned) {
-    return res.status(400).json({ message: 'This endpoint is still in development. Please come back later...' })
-  }
-
-  // return res.status(400).json({ message: 'This endpoint is still in development. Please come back later...' })
+  return res.status(400).json({ message: 'This endpoint is still in development. Please come back later...' })
 }
 
 function generateIds (year, ranges, amount) {

--- a/src/controller/cve-id.controller/index.js
+++ b/src/controller/cve-id.controller/index.js
@@ -7,5 +7,6 @@ router.get('/cve-id', middleware.validateUser, controller.CVEID_GET_FILTER)
 router.post('/cve-id', middleware.validateUser, controller.CVEID_RESERVE)
 router.get('/cve-id/:id', middleware.validateUser, controller.CVEID_GET_SINGLE)
 router.post('/cve-id/:id', middleware.validateUser, controller.CVEID_STATE_REASIGN_SINGLE)
+router.post('/cve-id-range/:year', middleware.validateUser, controller.CVEID_RANGE_CREATE)
 
 module.exports = router

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -98,12 +98,7 @@ async function getOrgIdQuota (req, res) {
           returnPayload.total_reserved = result
           returnPayload.available = (returnPayload.id_quota - returnPayload.total_reserved)
 
-          if (returnPayload.available < 0) {
-            logger.error({ message: ' An error occurred: Total reserved exceeded id_quota.', payload: returnPayload })
-            return res.status(400).json({ message: 'Total ids reserved exceeded ID quota. Please contact support.' })
-          }
-
-          logger.info({ message: 'The CVE ID quota returned to the user.', payload: returnPayload })
+          logger.info({ message: 'The CVE ID quota returned to the user.', details: returnPayload })
           return res.status(200).json(returnPayload)
         })
     })

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -100,7 +100,7 @@ async function getOrgIdQuota (req, res) {
 
           if (returnPayload.available < 0) {
             logger.error({ message: ' An error occurred: Total reserved exceeded id_quota.', payload: returnPayload })
-            return res.status(400).json({ message: 'Total reserved exceeded id_quota, contact an administrator.' })
+            return res.status(400).json({ message: 'Total ids reserved exceeded ID quota. Please contact support.' })
           }
 
           logger.info({ message: 'The CVE ID quota returned to the user.', payload: returnPayload })

--- a/src/index-populate.js
+++ b/src/index-populate.js
@@ -4,15 +4,18 @@ const mongoose = require('mongoose')
 const uuid = require('uuid')
 const app = express()
 const logger = require('./middleware/logger')
+const CveIdRange = require('./model/cve-id-range')
 const CveId = require('./model/cve-id')
 const Org = require('./model/org')
 const User = require('./model/user')
+const uuidAPIKey = require('uuid-apikey')
+const cveIdRangeData = require('../datadump/pre-population/cve-ids-range')
 const cveIdData = require('../datadump/pre-population/cve-ids')
 const orgData = require('../datadump/pre-population/orgs')
 const userData = require(('../datadump/pre-population/users'))
 const CONSTANTS = require('./constants')
-const uuidAPIKey = require('uuid-apikey')
-// const apiKeyFile = 'user-secret.txt'
+const fs = require('fs')
+const apiKeyFile = 'user-secret.txt'
 require('dotenv').config() // This enables us to read from the .env file.
 
 // Body Parser Middleware
@@ -62,11 +65,11 @@ db.once('open', async () => {
 
   // Ask user to confirm pre-population, which will prep MongoDB by removing the Cve-Id, Org, and User collections
   const prompt = require('prompt-sync')({ sigint: true })
-  let userInput = prompt(`Are you sure you wish to pre-populate the database for the ${appEnv} environment? Doing so will drop the 'Cve-Id', 'Org' and 'User' collections in the ${dbName} database. (y/n) `)
+  let userInput = prompt(`Are you sure you wish to pre-populate the database for the ${appEnv} environment? Doing so will drop the 'Cve-Id-Range', 'Cve-Id', 'Org' and 'User' collections in the ${dbName} database. (y/n) `)
 
   while (userInput.toLowerCase() !== 'n' && userInput.toLowerCase() !== 'y') {
     console.log('Unrecognized Input')
-    userInput = prompt(`Do you wish to pre-populate the database for the ${appEnv} environment? Doing so will drop the 'Cve-Id', 'Org' and 'User' collections in the ${dbName} database. (y/n) `)
+    userInput = prompt(`Do you wish to pre-populate the database for the ${appEnv} environment? Doing so will drop the 'Cve-Id-Range', 'Cve-Id', 'Org' and 'User' collections in the ${dbName} database. (y/n) `)
   }
 
   // droping Cve-Id, Org, and User collections
@@ -76,6 +79,10 @@ db.once('open', async () => {
     collections.forEach(collection => {
       names.push(collection.name)
     })
+
+    if (names.includes('Cve-Id-Range')) {
+      await db.dropCollection('Cve-Id-Range')
+    }
 
     if (names.includes('Cve-Id')) {
       await db.dropCollection('Cve-Id')
@@ -95,8 +102,9 @@ db.once('open', async () => {
       names.push(collection.name)
     })
 
-    if (!names.includes('Cve-Id') && !names.includes('Org') && !names.includes('User')) {
-      // Populating Cve-Id, Org and User collections
+    if (!names.includes('Cve-Id-Range') && !names.includes('Cve-Id') && !names.includes('Org') && !names.includes('User')) {
+      // Populating Cve-Id-Range, Cve-Id, Org and User collections
+      await populateCveIdRangeCollection()
       await populateCveIdCollection()
       await populateOrgCollection()
       await populateUserCollection()
@@ -109,6 +117,11 @@ db.once('open', async () => {
   mongoose.connection.close()
 })
 
+async function populateCveIdRangeCollection () {
+  await CveIdRange.insertMany(cveIdRangeData)
+  logger.info('Cve-Id-Range collection populated')
+}
+
 // Populating Cve-Id collection
 async function populateCveIdCollection () {
   cveIdData.forEach(cveId => {
@@ -116,7 +129,7 @@ async function populateCveIdCollection () {
   })
 
   await CveId.insertMany(cveIdData)
-  logger.info('CveId collection populated')
+  logger.info('Cve-Id collection populated')
 }
 
 // Populating Org collection
@@ -140,15 +153,54 @@ async function populateOrgCollection () {
 
 // Populating User collection
 async function populateUserCollection () {
-  const keyUUIDPair = uuidAPIKey.create()
   const color = require('kleur')
+  let secretUUID
+  let secreteKey
 
-  // provide secret to user
-  console.log(color.bold().black().bgWhite('Use the following API secret for all users:') + ' ' + color.bold().black().italic().bgGreen(keyUUIDPair.apiKey))
+  if (process.env.NODE_ENV === 'development') {
+    secretUUID = 'd31e22fa-1a58-4899-9a86-2741d97b98d4'
+    secreteKey = 'TCF25YM-39C4H6D-KA32EGF-V5XSHN3'
+
+    // provide secret to user
+    console.log(color.bold().black().bgWhite('Use the following API secret for all users:') + ' ' + color.bold().black().italic().bgGreen(secreteKey))
+  } else {
+    // delete file for user secrets if one already exists
+    fs.unlink(apiKeyFile, err => {
+      if (err && err.code !== 'ENOENT') {
+        logger.error('File Delete Error: Something went wrong!')
+        logger.error(err)
+        // close MongoDB connection
+        mongoose.connection.close()
+      }
+    })
+
+    console.log(color.bold().black().bgWhite('The users\' API secret can be found in:') + ' ' + color.bold().black().italic().bgGreen(apiKeyFile))
+  }
 
   userData.forEach(user => {
+    if (process.env.NODE_ENV === 'development') {
+      user.secret = secretUUID
+    } else {
+      const pair = uuidAPIKey.create()
+      user.secret = pair.uuid
+
+      const payload = {
+        username: user.username,
+        secret: pair.apiKey
+      }
+
+      // write pair.apiKey to apiKey file
+      fs.writeFile(apiKeyFile, JSON.stringify(payload) + '\n', { flag: 'a' }, (err) => {
+        if (err) {
+          logger.error('File Write Error: Something went wrong!')
+          logger.error(err)
+          // close MongoDB connection
+          mongoose.connection.close()
+        }
+      })
+    }
+
     user.UUID = uuid.v4()
-    user.secret = keyUUIDPair.uuid
   })
 
   await User.insertMany(userData)

--- a/src/model/cve-id-range.js
+++ b/src/model/cve-id-range.js
@@ -1,0 +1,41 @@
+const mongoose = require('mongoose')
+
+const schema = {
+  _id: false,
+  cve_year: String,
+  ranges: {
+    priority: {
+      top_id: {
+        type: Number,
+        default: 0
+      },
+      start: {
+        type: Number,
+        default: 0
+      },
+      end: {
+        type: Number,
+        default: 20000
+      }
+    },
+    general: {
+      top_id: {
+        type: Number,
+        default: 20000
+      },
+      start: {
+        type: Number,
+        default: 20000
+      },
+      end: {
+        type: Number,
+        default: 50000000000
+      }
+    }
+  }
+}
+
+const CveIdRangeSchema = new mongoose.Schema(schema, { collection: 'Cve-Id-Range' })
+
+const CveIdRange = mongoose.model('Cve-Id-Range', CveIdRangeSchema)
+module.exports = CveIdRange

--- a/src/model/cve-id-range.js
+++ b/src/model/cve-id-range.js
@@ -15,7 +15,8 @@ const schema = {
       },
       end: {
         type: Number,
-        default: 35000
+        default: 35000,
+        max: 35000
       }
     },
     general: {
@@ -29,7 +30,8 @@ const schema = {
       },
       end: {
         type: Number,
-        default: 50000000
+        default: 50000000,
+        max: 50000000
       }
     }
   }

--- a/src/model/cve-id-range.js
+++ b/src/model/cve-id-range.js
@@ -15,27 +15,31 @@ const schema = {
       },
       end: {
         type: Number,
-        default: 20000
+        default: 35000
       }
     },
     general: {
       top_id: {
         type: Number,
-        default: 20000
+        default: 35000
       },
       start: {
         type: Number,
-        default: 20000
+        default: 35000
       },
       end: {
         type: Number,
-        default: 50000000000
+        default: 50000000
       }
     }
   }
 }
 
 const CveIdRangeSchema = new mongoose.Schema(schema, { collection: 'Cve-Id-Range' })
+
+CveIdRangeSchema.query.byCveYear = function (cveYear) {
+  return this.where({ cve_year: new RegExp('^' + cveYear + '$') }) // match cve_year exactly
+}
 
 const CveIdRange = mongoose.model('Cve-Id-Range', CveIdRangeSchema)
 module.exports = CveIdRange

--- a/src/model/cve-id-range.js
+++ b/src/model/cve-id-range.js
@@ -15,23 +15,21 @@ const schema = {
       },
       end: {
         type: Number,
-        default: 35000,
-        max: 35000
+        default: 20000
       }
     },
     general: {
       top_id: {
         type: Number,
-        default: 35000
+        default: 20000
       },
       start: {
         type: Number,
-        default: 35000
+        default: 20000
       },
       end: {
         type: Number,
-        default: 50000000,
-        max: 50000000
+        default: 50000000
       }
     }
   }

--- a/src/model/cve-id.js
+++ b/src/model/cve-id.js
@@ -11,16 +11,20 @@ const schema = {
     cna: String,
     user: String
   },
+  reserved: Date,
   time: {
     created: Date,
-    modified: Date,
-    reserved: Date
+    modified: Date
   }
 }
 
 if (process.env.POPULATE === 'true') {
   CveIdSchema = new mongoose.Schema(schema, { collection: 'Cve-Id' })
 } else {
+  if (process.env.NODE_ENV === 'test') {
+    schema.reserved = { type: Date, default: Date.now }
+  }
+
   CveIdSchema = new mongoose.Schema(schema, { collection: 'Cve-Id', timestamps: { createdAt: 'time.created', updatedAt: 'time.modified' } })
 }
 

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -91,6 +91,14 @@ app.route('/api/test/cve-id')
 app.route('/api/test/cve-id/:id')
   .post(cveIdController.CVEID_STATE_REASIGN_SINGLE)
 
+// reserve cve id(s)
+app.route('/api/test/cve-id')
+  .post(cveIdController.CVEID_RESERVE)
+
+// create a cve id range document
+app.route('/api/test/cve-id-range/:year')
+  .post(cveIdController.CVEID_RANGE_CREATE)
+
 //* ********API Routes Setup END*********** */
 
 // construct MongoDB connection string

--- a/test/unit-tests/cve-id/cveIdTest.js
+++ b/test/unit-tests/cve-id/cveIdTest.js
@@ -18,6 +18,10 @@ const cveReject = require('./mockObjects.cve-id').cveReject
 const CveId = require('../../../src/model/cve-id')
 const User = require('../../../src/model/user')
 const Org = require('../../../src/model/org')
+const cveIdDummy1 = require('./mockObjects.cve-id').cveDummy1
+const cveIdDummy2 = require('./mockObjects.cve-id').cveDummy2
+const cveIdDummy3 = require('./mockObjects.cve-id').cveDummy3
+const cveIdDummy4 = require('./mockObjects.cve-id').cveDummy4
 const cveId = 'CVE-2017-4024'
 const cveIdYear = cveId.substring(4, 8)
 const nonExistentCveId = 'CVE-2017-35437'
@@ -30,6 +34,26 @@ describe('Test ID Reservator Endpoints', () => {
     await CveId.findOneAndUpdate()
       .byCveId(cveId)
       .updateOne(cveReserved)
+      .setOptions({ upsert: true })
+
+    await CveId.findOneAndUpdate()
+      .byCveId(cveIdDummy1.cve_id)
+      .updateOne(cveIdDummy1)
+      .setOptions({ upsert: true })
+
+    await CveId.findOneAndUpdate()
+      .byCveId(cveIdDummy2.cve_id)
+      .updateOne(cveIdDummy2)
+      .setOptions({ upsert: true })
+
+    await CveId.findOneAndUpdate()
+      .byCveId(cveIdDummy3.cve_id)
+      .updateOne(cveIdDummy3)
+      .setOptions({ upsert: true })
+
+    await CveId.findOneAndUpdate()
+      .byCveId(cveIdDummy4.cve_id)
+      .updateOne(cveIdDummy4)
       .setOptions({ upsert: true })
 
     await CveId.findOneAndRemove().byCveId(nonExistentCveId)
@@ -187,7 +211,7 @@ describe('Test ID Reservator Endpoints', () => {
       // perform the request to the api
       chai.request(server)
         .get('/api/test/cve-id?id=CVE-2010-1234&year=2010')
-        .set(owningOrg)
+        .set(owningOrgHeader)
         .end((err, res) => {
           if (err) {
             done(err)
@@ -206,7 +230,7 @@ describe('Test ID Reservator Endpoints', () => {
       // perform the request to the api
       chai.request(server)
         .get('/api/test/cve-id?time_reserved.gt=\'2020-06-24T23:12:46\'&time_reserved.gt=\'2020-07-03\'')
-        .set(owningOrg)
+        .set(owningOrgHeader)
         .end((err, res) => {
           if (err) {
             done(err)
@@ -225,7 +249,7 @@ describe('Test ID Reservator Endpoints', () => {
       // perform the request to the api
       chai.request(server)
         .get('/api/test/cve-id?time_reserved.lt=\'2020-06-24T23:12:46\'&time_reserved.lt=\'2020-07-03\'')
-        .set(owningOrg)
+        .set(owningOrgHeader)
         .end((err, res) => {
           if (err) {
             done(err)
@@ -244,7 +268,7 @@ describe('Test ID Reservator Endpoints', () => {
       // perform the request to the api
       chai.request(server)
         .get('/api/test/cve-id?time_reserved.gt=\'2020-06-24T23:12\'')
-        .set(owningOrg)
+        .set(owningOrgHeader)
         .end((err, res) => {
           if (err) {
             done(err)
@@ -263,7 +287,7 @@ describe('Test ID Reservator Endpoints', () => {
       // perform the request to the api
       chai.request(server)
         .get('/api/test/cve-id?state=public&cve_id_year=2010')
-        .set(owningOrg)
+        .set(owningOrgHeader)
         .end((err, res) => {
           if (err) {
             done(err)
@@ -404,7 +428,7 @@ describe('Test ID Reservator Endpoints', () => {
         })
     })
 
-    it('No query parameters are provided', (done) => {
+    it('The requester is not the Secretariat and no query parameters are provided', (done) => {
       // perform the request to the api
       chai.request(server)
         .get('/api/test/cve-id')
@@ -414,10 +438,37 @@ describe('Test ID Reservator Endpoints', () => {
             done(err)
           }
 
+          console.log(res.body.length)
+
           // assert expected response
           expect(res).to.have.status(200)
-          expect(res).to.have.property('body').and.to.be.an('array').and.to.have.lengthOf(1)
-          expect(res.body[0]).to.have.property('cve_id').and.to.equal(cveId)
+          expect(res).to.have.property('body').and.to.be.a('array').and.to.have.lengthOf(2)
+          expect(res.body[0]).to.nested.include({ cve_id: cveId }).and.to.nested.include({ owning_cna: cveReserved.owning_cna })
+          expect(res.body[1]).to.nested.include({ cve_id: cveIdDummy1.cve_id }).and.to.nested.include({ owning_cna: cveIdDummy1.owning_cna })
+          done()
+        })
+    })
+
+    it('The requester is the Secretariat and no query parameters are provided', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .get('/api/test/cve-id')
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          console.log(res.body.length)
+
+          // assert expected response
+          expect(res).to.have.status(200)
+          expect(res).to.have.property('body').and.to.be.a('array').and.to.have.lengthOf(5)
+          expect(res.body[0]).to.nested.include({ cve_id: cveId }).and.to.nested.include({ owning_cna: cveReserved.owning_cna })
+          expect(res.body[1]).to.nested.include({ cve_id: cveIdDummy1.cve_id }).and.to.nested.include({ owning_cna: cveIdDummy1.owning_cna })
+          expect(res.body[2]).to.nested.include({ cve_id: cveIdDummy2.cve_id }).and.to.nested.include({ owning_cna: cveIdDummy2.owning_cna })
+          expect(res.body[3]).to.nested.include({ cve_id: cveIdDummy3.cve_id }).and.to.nested.include({ owning_cna: cveIdDummy3.owning_cna })
+          expect(res.body[4]).to.nested.include({ cve_id: cveIdDummy4.cve_id }).and.to.nested.include({ owning_cna: cveIdDummy4.owning_cna })
           done()
         })
     })
@@ -566,6 +617,10 @@ describe('Test ID Reservator Endpoints', () => {
 
   after(async () => {
     await CveId.findOneAndRemove().byCveId(cveId)
+    await CveId.findOneAndRemove().byCveId()
+    await CveId.findOneAndRemove().byCveId()
+    await CveId.findOneAndRemove().byCveId()
+    await CveId.findOneAndRemove().byCveId()
     await CveId.findOneAndRemove().byCveId(nonExistentCveId)
     await User.findOneAndRemove().byUserNameAndCnaShortName(secretariatUser.username, secretariatUser.cna_short_name)
     await User.findOneAndRemove().byUserNameAndCnaShortName(owningOrgUser.username, owningOrgUser.cna_short_name)

--- a/test/unit-tests/cve-id/cveIdTest.js
+++ b/test/unit-tests/cve-id/cveIdTest.js
@@ -438,8 +438,6 @@ describe('Test ID Reservator Endpoints', () => {
             done(err)
           }
 
-          console.log(res.body.length)
-
           // assert expected response
           expect(res).to.have.status(200)
           expect(res).to.have.property('body').and.to.be.a('array').and.to.have.lengthOf(2)
@@ -458,8 +456,6 @@ describe('Test ID Reservator Endpoints', () => {
           if (err) {
             done(err)
           }
-
-          console.log(res.body.length)
 
           // assert expected response
           expect(res).to.have.status(200)

--- a/test/unit-tests/cve-id/cveIdTest.js
+++ b/test/unit-tests/cve-id/cveIdTest.js
@@ -25,7 +25,7 @@ let timestampBeforeReserved
 let timestampAfterReserved
 let timestampReserved
 
-describe('Test ID Reservator', () => {
+describe('Test ID Reservator Endpoints', () => {
   before(async () => {
     await CveId.findOneAndUpdate()
       .byCveId(cveId)
@@ -301,7 +301,7 @@ describe('Test ID Reservator', () => {
               expect(res).to.have.property('body').and.to.be.an('array').and.to.have.lengthOf(1)
               expect(res.body[0]).to.have.property('cve_id').and.to.equal(cveId)
               expect(res.body[0]).to.have.property('state').and.to.equal('PUBLIC')
-              timestampReserved = res.body[0].time.reserved
+              timestampReserved = res.body[0].reserved
               done()
             })
         })
@@ -359,7 +359,7 @@ describe('Test ID Reservator', () => {
           expect(res).to.have.status(200)
           expect(res).to.have.property('body').and.to.be.an('array').and.to.have.lengthOf(1)
           expect(res.body[0]).to.have.property('cve_id').and.to.equal(cveId)
-          expect(res.body[0].time).to.have.nested.property('reserved').and.to.equal(timestampReserved)
+          expect(res.body[0]).to.have.property('reserved').and.to.equal(timestampReserved)
           done()
         })
     })
@@ -378,7 +378,7 @@ describe('Test ID Reservator', () => {
           expect(res).to.have.status(200)
           expect(res).to.have.property('body').and.to.be.an('array').and.to.have.lengthOf(1)
           expect(res.body[0]).to.have.property('cve_id').and.to.equal(cveId)
-          expect(res.body[0].time).to.have.nested.property('reserved').and.to.equal(timestampReserved)
+          expect(res.body[0]).to.have.property('reserved').and.to.equal(timestampReserved)
           done()
         })
     })
@@ -398,7 +398,7 @@ describe('Test ID Reservator', () => {
           expect(res).to.have.property('body').and.to.be.an('array').and.to.have.lengthOf(1)
           expect(res.body[0]).to.have.property('cve_id').and.to.equal(cveId)
           expect(res.body[0]).to.have.property('cve_year').and.to.equal('2017')
-          expect(res.body[0].time).to.have.nested.property('reserved').and.to.equal(timestampReserved)
+          expect(res.body[0]).to.have.property('reserved').and.to.equal(timestampReserved)
           expect(res.body[0]).to.have.property('state').and.to.equal('PUBLIC')
           done()
         })

--- a/test/unit-tests/cve-id/mockObjects.cve-id.js
+++ b/test/unit-tests/cve-id/mockObjects.cve-id.js
@@ -26,7 +26,7 @@ const secretariatOrg = {
   },
   name: 'The MITRE Corporation',
   policies: {
-    id_quota: 5
+    id_quota: 0
   },
   short_name: 'mitre'
 }
@@ -50,7 +50,7 @@ const owningOrg = {
   },
   name: 'Cisco',
   policies: {
-    id_quota: 5
+    id_quota: 1000
   },
   short_name: 'cisco'
 }
@@ -75,7 +75,7 @@ const org = {
   },
   name: 'Siemens',
   policies: {
-    id_quota: 5
+    id_quota: 500
   },
   short_name: 'siemens'
 }

--- a/test/unit-tests/cve-id/mockObjects.cve-id.js
+++ b/test/unit-tests/cve-id/mockObjects.cve-id.js
@@ -138,6 +138,50 @@ const cvePublic = {
   }
 }
 
+const cveDummy1 = {
+  cve_id: 'CVE-2019-5012',
+  cve_year: '2019',
+  state: 'RESERVED',
+  owning_cna: 'cisco',
+  requested_by: {
+    cna: 'cisco',
+    user: 'alopez'
+  }
+}
+
+const cveDummy2 = {
+  cve_id: 'CVE-2018-5111',
+  cve_year: '2018',
+  state: 'REJECT',
+  owning_cna: 'mitre',
+  requested_by: {
+    cna: 'mitre',
+    user: 'cpadro'
+  }
+}
+
+const cveDummy3 = {
+  cve_id: 'CVE-2020-2004',
+  cve_year: '2020',
+  state: 'PUBLIC',
+  owning_cna: 'mitre',
+  requested_by: {
+    cna: 'mitre',
+    user: 'cpadro'
+  }
+}
+
+const cveDummy4 = {
+  cve_id: 'CVE-2020-20026',
+  cve_year: '2020',
+  state: 'PUBLIC',
+  owning_cna: 'siemens',
+  requested_by: {
+    cna: 'mitre',
+    user: 'cpadro'
+  }
+}
+
 const cveReservedForOrgWithZeroIdQuota = {
   cve_id: 'CVE-2019-4026',
   cve_year: '2019',
@@ -163,5 +207,9 @@ module.exports = {
   cveReserved,
   cveReject,
   cvePublic,
-  cveReservedForOrgWithZeroIdQuota
+  cveReservedForOrgWithZeroIdQuota,
+  cveDummy1,
+  cveDummy2,
+  cveDummy3,
+  cveDummy4
 }

--- a/test/unit-tests/cve-id/reserveCveIdTest.js
+++ b/test/unit-tests/cve-id/reserveCveIdTest.js
@@ -17,11 +17,26 @@ const owningOrgUser = require('./mockObjects.cve-id').owningOrgUser
 const org = require('./mockObjects.cve-id').org
 const orgUser = require('./mockObjects.cve-id').orgUser
 const nonExistentOrg = require('./mockObjects.cve-id').nonExistentOrg
-const cveIdR = new CveIdRange(CONSTANTS.DEFAULT_CVE_ID_RANGE)
+const year20 = 2020
+const year21 = 2021
+const year22 = 2022
 
 describe('Test ID Reservator', () => {
   before(async () => {
     await CveId.deleteMany({})
+
+    let cveIdR = new CveIdRange(CONSTANTS.DEFAULT_CVE_ID_RANGE)
+    cveIdR.cve_year = year20
+
+    await CveIdRange.findOneAndUpdate()
+      .byCveYear(cveIdR.cve_year)
+      .updateOne(cveIdR)
+      .setOptions({ upsert: true })
+
+    cveIdR = CveIdRange(CONSTANTS.DEFAULT_CVE_ID_RANGE)
+    cveIdR.cve_year = year21
+    cveIdR.ranges.priority.top_id = cveIdR.ranges.priority.end
+    cveIdR.ranges.general.top_id = cveIdR.ranges.general.end
 
     await CveIdRange.findOneAndUpdate()
       .byCveYear(cveIdR.cve_year)
@@ -63,7 +78,7 @@ describe('Test ID Reservator', () => {
     it('Invalid query parameter', (done) => {
       // perform the request to the api
       chai.request(server)
-        .post('/api/test/cve-id?year=' + cveIdR.cve_year)
+        .post('/api/test/cve-id?year=' + year20)
         .set(orgHeader)
         .end((err, res) => {
           if (err) {
@@ -82,7 +97,7 @@ describe('Test ID Reservator', () => {
     it('Requester is not the owning Org or the Secretariat', (done) => {
       // perform the request to the api
       chai.request(server)
-        .post('/api/test/cve-id?cve_year=' + cveIdR.cve_year + '&amount=1')
+        .post('/api/test/cve-id?cve_year=' + year20 + '&amount=1')
         .set(orgHeader)
         .end((err, res) => {
           if (err) {
@@ -101,7 +116,7 @@ describe('Test ID Reservator', () => {
     it('Shortname query parameter is undefined', (done) => {
       // perform the request to the api
       chai.request(server)
-        .post('/api/test/cve-id?cve_year=' + cveIdR.cve_year + '&amount=1')
+        .post('/api/test/cve-id?cve_year=' + year20 + '&amount=1')
         .set(secretariatHeader)
         .end((err, res) => {
           if (err) {
@@ -139,7 +154,7 @@ describe('Test ID Reservator', () => {
     it('Amount query parameter is undefined', (done) => {
       // perform the request to the api
       chai.request(server)
-        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=' + cveIdR.cve_year)
+        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=' + year20)
         .set(secretariatHeader)
         .end((err, res) => {
           if (err) {
@@ -158,7 +173,7 @@ describe('Test ID Reservator', () => {
     it('Amount query parameter is <= 0', (done) => {
       // perform the request to the api
       chai.request(server)
-        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=' + cveIdR.cve_year + '&amount=0')
+        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=' + year20 + '&amount=0')
         .set(secretariatHeader)
         .end((err, res) => {
           if (err) {
@@ -177,7 +192,7 @@ describe('Test ID Reservator', () => {
     it('Amount query parameter is > 1 and batchType is undefined', (done) => {
       // perform the request to the api
       chai.request(server)
-        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=' + cveIdR.cve_year + '&amount=5')
+        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=' + year20 + '&amount=5')
         .set(secretariatHeader)
         .end((err, res) => {
           if (err) {
@@ -196,7 +211,7 @@ describe('Test ID Reservator', () => {
     it('Org does not exist', (done) => {
       // perform the request to the api
       chai.request(server)
-        .post('/api/test/cve-id?short_name=' + nonExistentOrg.short_name + '&cve_year=' + cveIdR.cve_year + '&amount=1')
+        .post('/api/test/cve-id?short_name=' + nonExistentOrg.short_name + '&cve_year=' + year20 + '&amount=1')
         .set(secretariatHeader)
         .end((err, res) => {
           if (err) {
@@ -215,7 +230,7 @@ describe('Test ID Reservator', () => {
     it('Amount query parameter is > that id_quota', (done) => {
       // perform the request to the api
       chai.request(server)
-        .post('/api/test/cve-id?short_name=' + org.short_name + '&cve_year=' + cveIdR.cve_year + '&amount=700&batch_type=sequential')
+        .post('/api/test/cve-id?short_name=' + org.short_name + '&cve_year=' + year20 + '&amount=700&batch_type=sequential')
         .set(secretariatHeader)
         .end((err, res) => {
           if (err) {
@@ -233,46 +248,200 @@ describe('Test ID Reservator', () => {
   })
 
   context('Priority Reservation', () => {
-    // it('Invalid query parameter', (done) => {
-    //     // perform the request to the api
-    //     chai.request(server)
-    //       .post('/api/test/cve-id?year=' + cveIdR.cve_year)
-    //       .set(orgHeader)
-    //       .end((err, res) => {
-    //         if (err) {
-    //           done(err)
-    //         }
-  
-    //         // assert expected response
-    //         expect(res).to.have.status(400)
-    //         expect(res).to.have.property('body').and.to.be.a('object')
-    //         expect(res.body).to.have.property('message').and.to.be.a('string')
-    //         expect(res.body.message).to.equal('Invalid query parameter \'year\'')
-    //         done()
-    //       })
-    //   })
-  }
+    it('CveId Range document for year 2025 does not exist', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=2025&amount=1')
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(403)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('CVE IDs for year 2025 cannot be reserved at this time.')
+          done()
+        })
+    })
+
+    it('CveId Range document for year 2021 is full', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=' + year21 + '&amount=1')
+        .set(owningOrgHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(403)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('The cve id block is full for year ' + year21 + '. Please contact an administrator.')
+          done()
+        })
+    })
+
+    // Cve ID is reserved
+    it('Cve ID is reserved', (done) => {
+      const top = CONSTANTS.DEFAULT_CVE_ID_RANGE.ranges.priority.top_id
+      const count = String(top + 1).padStart(4, '0')
+
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=' + year20 + '&amount=1')
+        .set(owningOrgHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(200)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('The following CVE IDs were reserved.')
+          expect(res.body.reserved).to.be.a('array').that.include(`CVE-${year20}-${count}`)
+          done()
+        })
+    })
+  })
 
   context('Sequential Reservation', () => {
-    // it('Invalid query parameter', (done) => {
-    //     // perform the request to the api
-    //     chai.request(server)
-    //       .post('/api/test/cve-id?year=' + cveIdR.cve_year)
-    //       .set(orgHeader)
-    //       .end((err, res) => {
-    //         if (err) {
-    //           done(err)
-    //         }
-  
-    //         // assert expected response
-    //         expect(res).to.have.status(400)
-    //         expect(res).to.have.property('body').and.to.be.a('object')
-    //         expect(res.body).to.have.property('message').and.to.be.a('string')
-    //         expect(res.body.message).to.equal('Invalid query parameter \'year\'')
-    //         done()
-    //       })
-    //   })
-  }
+    it('CveId Range document for year 2025 does not exist', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=2025&amount=5&batch_type=sequential')
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(403)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('CVE IDs for year 2025 cannot be reserved at this time.')
+          done()
+        })
+    })
+
+    it('CveId Range document for year 2021 is full', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=' + year21 + '&amount=10&batch_type=sequential')
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(403)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('The cve id block is full for year ' + year21 + '. Please contact an administrator.')
+          done()
+        })
+    })
+
+    // Cve IDs are reserved
+    it('Cve IDs are reserved', (done) => {
+      const top = CONSTANTS.DEFAULT_CVE_ID_RANGE.ranges.general.top_id
+      const count = [String(top + 1).padStart(4, '0'), String(top + 2).padStart(4, '0'), String(top + 3).padStart(4, '0'), String(top + 4).padStart(4, '0'), String(top + 5).padStart(4, '0')]
+      const cves = [`CVE-${year20}-${count[0]}`, `CVE-${year20}-${count[1]}`, `CVE-${year20}-${count[2]}`, `CVE-${year20}-${count[3]}`, `CVE-${year20}-${count[4]}`]
+
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=' + year20 + '&amount=5&batch_type=sequential')
+        .set(owningOrgHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(200)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('The following CVE IDs were reserved.')
+          expect(res.body.reserved).to.be.a('array').that.include(cves[0])
+          expect(res.body.reserved).that.include(cves[1])
+          expect(res.body.reserved).that.include(cves[2])
+          expect(res.body.reserved).that.include(cves[3])
+          expect(res.body.reserved).that.include(cves[4])
+          done()
+        })
+    })
+  })
+
+  // context('Non-Sequential Reservation', () => {
+
+  // })
+
+  context(`Create CveId Range for year ${year22}`, () => {
+    it('Requester is not the Secretariat', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id-range/' + year22)
+        .set(orgHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(403)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('The Cve Id Range for year ' + year22 + ' cannot be created by other than the Secretariat.')
+          done()
+        })
+    })
+
+    it(`CveId Range is created for year ${year22}`, (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id-range/' + year22)
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(200)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('CVE Id Range document for year ' + year22 + ' was created.')
+          done()
+        })
+    })
+
+    it(`CveId Range already exists for year ${year22}`, (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id-range/' + year22)
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(400)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('CVE Id Range document for year ' + year22 + ' was not created because it already exists.')
+          done()
+        })
+    })
+  })
 
   after(async () => {
     await CveId.deleteMany({})

--- a/test/unit-tests/cve-id/reserveCveIdTest.js
+++ b/test/unit-tests/cve-id/reserveCveIdTest.js
@@ -1,0 +1,287 @@
+const server = require('../../../test-utils/index')
+const chai = require('chai')
+const expect = chai.expect
+chai.use(require('chai-http'))
+const CveIdRange = require('../../../src/model/cve-id-range')
+const CveId = require('../../../src/model/cve-id')
+const User = require('../../../src/model/user')
+const Org = require('../../../src/model/org')
+const CONSTANTS = require('../../../src/constants')
+const secretariatHeader = require('./mockObjects.cve-id').secretariatHeader
+const owningOrgHeader = require('./mockObjects.cve-id').owningOrgHeader
+const orgHeader = require('./mockObjects.cve-id').orgHeader
+const secretariatOrg = require('./mockObjects.cve-id').secretariatOrg
+const secretariatUser = require('./mockObjects.cve-id').secretariatUser
+const owningOrg = require('./mockObjects.cve-id').owningOrg
+const owningOrgUser = require('./mockObjects.cve-id').owningOrgUser
+const org = require('./mockObjects.cve-id').org
+const orgUser = require('./mockObjects.cve-id').orgUser
+const nonExistentOrg = require('./mockObjects.cve-id').nonExistentOrg
+const cveIdR = new CveIdRange(CONSTANTS.DEFAULT_CVE_ID_RANGE)
+
+describe('Test ID Reservator', () => {
+  before(async () => {
+    await CveId.deleteMany({})
+
+    await CveIdRange.findOneAndUpdate()
+      .byCveYear(cveIdR.cve_year)
+      .updateOne(cveIdR)
+      .setOptions({ upsert: true })
+
+    await User.findOneAndUpdate()
+      .byUserNameAndCnaShortName(secretariatUser.username, secretariatUser.cna_short_name)
+      .updateOne(secretariatUser)
+      .setOptions({ upsert: true })
+
+    await User.findOneAndUpdate()
+      .byUserNameAndCnaShortName(owningOrgUser.username, owningOrgUser.cna_short_name)
+      .updateOne(owningOrgUser)
+      .setOptions({ upsert: true })
+
+    await User.findOneAndUpdate()
+      .byUserNameAndCnaShortName(orgUser.username, orgUser.cna_short_name)
+      .updateOne(orgUser)
+      .setOptions({ upsert: true })
+
+    await Org.findOneAndUpdate()
+      .byShortName(secretariatOrg.short_name)
+      .updateOne(secretariatOrg)
+      .setOptions({ upsert: true })
+
+    await Org.findOneAndUpdate()
+      .byShortName(owningOrg.short_name)
+      .updateOne(owningOrg)
+      .setOptions({ upsert: true })
+
+    await Org.findOneAndUpdate()
+      .byShortName(org.short_name)
+      .updateOne(org)
+      .setOptions({ upsert: true })
+  })
+
+  context('Business Logic', () => {
+    it('Invalid query parameter', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?year=' + cveIdR.cve_year)
+        .set(orgHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(400)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('Invalid query parameter \'year\'')
+          done()
+        })
+    })
+
+    it('Requester is not the owning Org or the Secretariat', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?cve_year=' + cveIdR.cve_year + '&amount=1')
+        .set(orgHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(403)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('CVE IDs can only be reserved by the owning CNA or by the Secretariat.')
+          done()
+        })
+    })
+
+    it('Shortname query parameter is undefined', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?cve_year=' + cveIdR.cve_year + '&amount=1')
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(400)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('Provide the cna\'s short name to reserve CVE IDs.')
+          done()
+        })
+    })
+
+    it('Year query parameter is undefined', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&amount=1')
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(400)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('Provide a year to reserve CVE IDs.')
+          done()
+        })
+    })
+
+    it('Amount query parameter is undefined', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=' + cveIdR.cve_year)
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(400)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal(CONSTANTS.NO_AMOUNT.message)
+          done()
+        })
+    })
+
+    it('Amount query parameter is <= 0', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=' + cveIdR.cve_year + '&amount=0')
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(404)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal(CONSTANTS.INVALID_AMOUNT.message)
+          done()
+        })
+    })
+
+    it('Amount query parameter is > 1 and batchType is undefined', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?short_name=' + owningOrg.short_name + '&cve_year=' + cveIdR.cve_year + '&amount=5')
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(400)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('A batch type (i.e. sequential, non-sequential) must be specified when allocating more than one CVE ID.')
+          done()
+        })
+    })
+
+    it('Org does not exist', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?short_name=' + nonExistentOrg.short_name + '&cve_year=' + cveIdR.cve_year + '&amount=1')
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(404)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal(nonExistentOrg.short_name + ' CNA does not exist.')
+          done()
+        })
+    })
+
+    it('Amount query parameter is > that id_quota', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cve-id?short_name=' + org.short_name + '&cve_year=' + cveIdR.cve_year + '&amount=700&batch_type=sequential')
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(404)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal(CONSTANTS.OVER_ID_QUOTA.message)
+          done()
+        })
+    })
+  })
+
+  context('Priority Reservation', () => {
+    // it('Invalid query parameter', (done) => {
+    //     // perform the request to the api
+    //     chai.request(server)
+    //       .post('/api/test/cve-id?year=' + cveIdR.cve_year)
+    //       .set(orgHeader)
+    //       .end((err, res) => {
+    //         if (err) {
+    //           done(err)
+    //         }
+  
+    //         // assert expected response
+    //         expect(res).to.have.status(400)
+    //         expect(res).to.have.property('body').and.to.be.a('object')
+    //         expect(res.body).to.have.property('message').and.to.be.a('string')
+    //         expect(res.body.message).to.equal('Invalid query parameter \'year\'')
+    //         done()
+    //       })
+    //   })
+  }
+
+  context('Sequential Reservation', () => {
+    // it('Invalid query parameter', (done) => {
+    //     // perform the request to the api
+    //     chai.request(server)
+    //       .post('/api/test/cve-id?year=' + cveIdR.cve_year)
+    //       .set(orgHeader)
+    //       .end((err, res) => {
+    //         if (err) {
+    //           done(err)
+    //         }
+  
+    //         // assert expected response
+    //         expect(res).to.have.status(400)
+    //         expect(res).to.have.property('body').and.to.be.a('object')
+    //         expect(res.body).to.have.property('message').and.to.be.a('string')
+    //         expect(res.body.message).to.equal('Invalid query parameter \'year\'')
+    //         done()
+    //       })
+    //   })
+  }
+
+  after(async () => {
+    await CveId.deleteMany({})
+    await CveIdRange.deleteMany({})
+    await User.findOneAndRemove().byUserNameAndCnaShortName(secretariatUser.username, secretariatUser.cna_short_name)
+    await User.findOneAndRemove().byUserNameAndCnaShortName(owningOrgUser.username, owningOrgUser.cna_short_name)
+    await User.findOneAndRemove().byUserNameAndCnaShortName(orgUser.username, orgUser.cna_short_name)
+    await Org.findOneAndRemove().byShortName(secretariatOrg.short_name)
+    await Org.findOneAndRemove().byShortName(owningOrg.short_name)
+    await Org.findOneAndRemove().byShortName(org.short_name)
+  })
+})

--- a/test/unit-tests/cve-id/reserveCveIdTest.js
+++ b/test/unit-tests/cve-id/reserveCveIdTest.js
@@ -277,15 +277,11 @@ describe('Test ID Reservator', () => {
             done(err)
           }
 
-          // assert expected response  // , reason: payload
+          // assert expected response
           expect(res).to.have.status(403)
           expect(res).to.have.property('body').and.to.be.a('object')
           expect(res.body).to.have.property('message').and.to.be.a('string')
-          expect(res.body.message).to.equal('The request for reserving ' + 1 + ' cve id(s) could not be satisfied.')
-          expect(res.body.reason).to.have.nested.property('requested_ids').to.equal(1)
-          expect(res.body.reason).to.have.nested.property('available_sequential_ids').to.equal(0)
-          expect(res.body.reason).to.have.nested.property('available_nonsequential_ids').to.equal(0)
-          expect(res.body.reason).to.have.nested.property('available_priority_ids').to.equal(0)
+          expect(res.body.message).to.equal('The request for reserving ' + 1 + ' cve ids could not be satisfied because there are not enough ids in the CVE ID priority block or sequential block.')
           done()
         })
     })
@@ -349,9 +345,7 @@ describe('Test ID Reservator', () => {
           expect(res).to.have.status(403)
           expect(res).to.have.property('body').and.to.be.a('object')
           expect(res.body).to.have.property('message').and.to.be.a('string')
-          expect(res.body.reason).to.have.nested.property('requested_ids').to.equal(10)
-          expect(res.body.reason).to.have.nested.property('available_sequential_ids').to.equal(0)
-          expect(res.body.reason).to.have.nested.property('available_nonsequential_ids').to.equal(0)
+          expect(res.body.message).to.equal('The request for reserving ' + 10 + ' cve ids could not be satisfied because there are not enough ids in the CVE ID sequential block.')
           done()
         })
     })
@@ -385,10 +379,6 @@ describe('Test ID Reservator', () => {
         })
     })
   })
-
-  // context('Non-Sequential Reservation', () => {
-
-  // })
 
   context(`Create CveId Range for year ${year22}`, () => {
     it('Requester is not the Secretariat', (done) => {

--- a/test/unit-tests/cve-id/reserveCveIdTest.js
+++ b/test/unit-tests/cve-id/reserveCveIdTest.js
@@ -277,11 +277,15 @@ describe('Test ID Reservator', () => {
             done(err)
           }
 
-          // assert expected response
+          // assert expected response  // , reason: payload
           expect(res).to.have.status(403)
           expect(res).to.have.property('body').and.to.be.a('object')
           expect(res.body).to.have.property('message').and.to.be.a('string')
-          expect(res.body.message).to.equal('The cve id block is full for year ' + year21 + '. Please contact an administrator.')
+          expect(res.body.message).to.equal('The request for reserving ' + 1 + ' cve id(s) could not be satisfied.')
+          expect(res.body.reason).to.have.nested.property('requested_ids').to.equal(1)
+          expect(res.body.reason).to.have.nested.property('available_sequential_ids').to.equal(0)
+          expect(res.body.reason).to.have.nested.property('available_nonsequential_ids').to.equal(0)
+          expect(res.body.reason).to.have.nested.property('available_priority_ids').to.equal(0)
           done()
         })
     })
@@ -345,7 +349,9 @@ describe('Test ID Reservator', () => {
           expect(res).to.have.status(403)
           expect(res).to.have.property('body').and.to.be.a('object')
           expect(res.body).to.have.property('message').and.to.be.a('string')
-          expect(res.body.message).to.equal('The cve id block is full for year ' + year21 + '. Please contact an administrator.')
+          expect(res.body.reason).to.have.nested.property('requested_ids').to.equal(10)
+          expect(res.body.reason).to.have.nested.property('available_sequential_ids').to.equal(0)
+          expect(res.body.reason).to.have.nested.property('available_nonsequential_ids').to.equal(0)
           done()
         })
     })

--- a/test/unit-tests/org/orgTest.js
+++ b/test/unit-tests/org/orgTest.js
@@ -1047,10 +1047,11 @@ describe('Test Org Controller', () => {
           }
 
           // assert expected response
-          expect(res).to.have.status(400)
+          expect(res).to.have.status(200)
           expect(res).to.have.property('body').and.to.be.a('object')
-          expect(res.body).to.have.property('message').and.to.be.a('string')
-          expect(res.body.message).to.equal('Total ids reserved exceeded ID quota. Please contact support.')
+          expect(res.body).to.have.property('id_quota').to.equal(-1)
+          expect(res.body).to.have.property('total_reserved').to.equal(0)
+          expect(res.body).to.have.property('available').to.equal(-1)
           done()
         })
     })

--- a/test/unit-tests/org/orgTest.js
+++ b/test/unit-tests/org/orgTest.js
@@ -1050,7 +1050,7 @@ describe('Test Org Controller', () => {
           expect(res).to.have.status(400)
           expect(res).to.have.property('body').and.to.be.a('object')
           expect(res.body).to.have.property('message').and.to.be.a('string')
-          expect(res.body.message).to.equal('Total reserved exceeded id_quota, contact an administrator.')
+          expect(res.body.message).to.equal('Total ids reserved exceeded ID quota. Please contact support.')
           done()
         })
     })


### PR DESCRIPTION
IDR (added): Adding IDR priority and sequential reservation functionality + unit tests.
IDR (added): Secretariat can now search filtered CVE ID metadata on any CNA.
IDR (added): Created an endpoint (for Secretariat only) to create new CVE ID Range documents.
Pre-population (added): Creating CVE ID Range documents for years 1999 to 2021.
Pre-population (modified): Static api secrets for users in dev; Dynamic api secrets for users otherwise.

Miscellaneous changes were made to ensure the above changes work as expected.