### PR TITLE
Priority ids are for 2021 onward and stop at 20k

### DIFF
--- a/datadump/pre-population/cve-ids-range.json
+++ b/datadump/pre-population/cve-ids-range.json
@@ -318,8 +318,8 @@
     "cve_year": 2020,
     "ranges": {
         "priority": {
-            "top_id": 0,
-            "start": 0,
+            "top_id": 35000,
+            "start": 35000,
             "end": 35000
         },
         "general": {
@@ -335,11 +335,11 @@
         "priority": {
             "top_id": 0,
             "start": 0,
-            "end": 35000
+            "end": 20000
         },
         "general": {
-            "top_id": 35000,
-            "start": 35000,
+            "top_id": 20000,
+            "start": 20000,
             "end": 50000000
         }
     }


### PR DESCRIPTION
There was a miscommunication in delivering what ranges would be made
available for past years and what the ranges would be going forward.
This corrected list for 2020 and 2021 makes the document accurate to
the ranges that will be made available when IDR goes to production.

