### PR TITLE
Stop id_quota getting reset on Org updates

### DIFF
--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -313,6 +313,7 @@ async function updateCna (req, res) {
   // updating the CNA roles
   if (result && !returned) {
     const roles = result.authority.active_roles
+    newCna.policies.id_quota = result.policies.id_quota
 
     // adding roles
     addRoles.forEach(role => {
@@ -333,30 +334,28 @@ async function updateCna (req, res) {
     newCna.authority.active_roles = roles
   }
 
+  if (newCna.authority.active_roles.includes('SECRETARIAT')) {
+    newCna.policies.id_quota = 0
+  }
+
   if (quota && !returned) {
     const result = quota.match(/^-*\d+$/)
 
     if (!result) {
       returned = true
-      return res.status(400).json({ message: 'Bad query parameter.' })
+      return res.status(400).json({ error: 'INVALID_ID_QUOTA', message: 'id_quota was not a number.' })
     }
-
-    // org being updated is secretariat
     if (newCna.authority.active_roles.includes('SECRETARIAT')) {
-      newCna.policies.id_quota = 0
-    } else {
-      newCna.policies.id_quota = quota
-
-      if ((CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_min > newCna.policies.id_quota ||
-        newCna.policies.id_quota > CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_max) && !returned) {
-        returned = true
-        return res.status(403).json({ message: 'The id_quota does not comply with CVE id quota limitations.' })
-      }
+      return res.status(400).json({error: 'SECRETARIAT_HAS_NO_QUOTA', message: 'The Secretariat has no ID Quota.'})
     }
-  } else if (newCna.authority.active_roles.includes('SECRETARIAT')) {
-    newCna.policies.id_quota = 0
-  } else {
-    newCna.policies.id_quota = CONSTANTS.DEFAULT_ID_QUOTA
+
+    newCna.policies.id_quota = quota
+
+    if ((CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_min > newCna.policies.id_quota ||
+      newCna.policies.id_quota > CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_max) && !returned) {
+      returned = true
+      return res.status(403).json({ message: 'The id_quota does not comply with CVE id quota limitations.' })
+    }
   }
 
   if (name && !returned) {

--- a/test/unit-tests/org/mockObjects.org.js
+++ b/test/unit-tests/org/mockObjects.org.js
@@ -86,6 +86,30 @@ const nonExistentOrg = {
   short_name: 'oval'
 }
 
+const toBeDeactivatedOrg = {
+  UUID: '345715e2-ded9-4a16-8dfd-9a062a63e1d5',
+  authority: {
+    active_roles: ['CNA']
+  },
+  name: 'OffOn',
+  policies: {
+    id_quota: 50
+  },
+  short_name: 'offon'
+}
+
+const toBeActivatedOrg = {
+  UUID: '543715e2-ded9-4a16-8dfd-9a062a63e1d5',
+  authority: {
+    active_roles: []
+  },
+  name: 'OnOff',
+  policies: {
+    id_quota: 75
+  },
+  short_name: 'OnOff'
+}
+
 // For validating policies.id_quota below minimum
 const orgWithNegativeIdQuota = {
   UUID: '0zoiz5ht-meym-9pj7-95de-ub4ge22rfazn',
@@ -192,5 +216,7 @@ module.exports = {
   nonExistentUser,
   orgWithNegativeIdQuota,
   orgExceedingMaxIdQuota,
-  orgWithZeroIdQuota
+  orgWithZeroIdQuota,
+  toBeDeactivatedOrg,
+  toBeActivatedOrg
 }

--- a/test/unit-tests/org/orgTest.js
+++ b/test/unit-tests/org/orgTest.js
@@ -14,6 +14,8 @@ const nonExistentOrg = require('./mockObjects.org').nonExistentOrg
 const orgWithZeroIdQuota = require('./mockObjects.org').orgWithZeroIdQuota
 const orgWithNegativeIdQuota = require('./mockObjects.org').orgWithNegativeIdQuota
 const orgExceedingMaxIdQuota = require('./mockObjects.org').orgExceedingMaxIdQuota
+const toBeDeactivatedOrg = require('./mockObjects.org').toBeDeactivatedOrg
+const toBeActivatedOrg = require('./mockObjects.org').toBeActivatedOrg
 const existentUser = require('./mockObjects.org').existentUser
 const nonExistentUser = require('./mockObjects.org').nonExistentUser
 const User = require('../../../src/model/user')
@@ -54,6 +56,16 @@ describe('Test Org Controller', () => {
     await Org.findOneAndUpdate()
       .byShortName(orgExceedingMaxIdQuota.short_name)
       .updateOne(orgExceedingMaxIdQuota)
+      .setOptions({ upsert: true })
+
+      await Org.findOneAndUpdate()
+      .byShortName(toBeDeactivatedOrg.short_name)
+      .updateOne(toBeDeactivatedOrg)
+      .setOptions({ upsert: true })
+
+      await Org.findOneAndUpdate()
+      .byShortName(toBeActivatedOrg.short_name)
+      .updateOne(toBeActivatedOrg)
       .setOptions({ upsert: true })
   })
 
@@ -615,7 +627,7 @@ describe('Test Org Controller', () => {
           expect(res).to.have.status(400)
           expect(res).to.have.property('body').and.to.be.a('object')
           expect(res.body).to.have.property('message').and.to.be.a('string')
-          expect(res.body.message).to.equal('Bad query parameter.')
+          expect(res.body.message).to.equal('id_quota was not a number.')
           done()
         })
     })
@@ -697,15 +709,16 @@ describe('Test Org Controller', () => {
         })
     })
 
-    // id_quota, name, and shortname are changed
+    // name, and shortname are changed
     // current: 'CNA', 'ADP'
     // add: 'ROOT_CNA', 'SECRETARIAT'
     // remove: 'CNA', 'ADP'
     // result: 'ROOT_CNA', 'SECRETARIAT'
+    /// + '?id_quota="' + existentOrgDummy2.policies.id_quota 
     it('Org is updated with multiple roles added and removed', (done) => {
       // perform the request to the api
       chai.request(server)
-        .post('/api/test/cna/' + existentOrgDummy.short_name + '?id_quota="' + existentOrgDummy2.policies.id_quota + '"&name="' +
+        .post('/api/test/cna/' + existentOrgDummy.short_name + '?name="' +
         existentOrgDummy2.name + '"&shortname="' + existentOrgDummy2.short_name + '"&active_roles.add="' + existentOrgDummy2.authority.active_roles[0] +
         '"&active_roles.add="' + existentOrgDummy2.authority.active_roles[1] + '&active_roles.remove="' + existentOrgDummy.authority.active_roles[0] +
         '"&active_roles.remove="' + existentOrgDummy.authority.active_roles[1] + '"')
@@ -759,6 +772,58 @@ describe('Test Org Controller', () => {
         })
     })
 
+    // id_quota, shortname, and name are unchanged
+    // current: 'ROOT_CNA', 'SECRETARIAT'
+    // add: 'CNA'
+    // remove: 'SECRETARIAT'
+    // result: 'ROOT_CNA', 'CNA'
+    it('Org has CNA role removed but id quota should not change', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cna/' + toBeDeactivatedOrg.short_name + '?active_roles.remove="CNA"')
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(200)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal(toBeDeactivatedOrg.short_name + ' CNA was successfully updated.')
+          expect(res.body.updated).to.have.nested.property('policies.id_quota').to.equal(50)
+          expect(res.body.updated.authority.active_roles).to.have.lengthOf(0)
+          done()
+        })
+    })
+
+    // id_quota, shortname, and name are unchanged
+    // current: 'ROOT_CNA', 'SECRETARIAT'
+    // add: 'CNA'
+    // remove: 'SECRETARIAT'
+    // result: 'ROOT_CNA', 'CNA'
+    it('Org has CNA role added so id quota should not change', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/cna/' + toBeActivatedOrg.short_name + '?active_roles.add="CNA"')
+        .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(200)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal(toBeActivatedOrg.short_name + ' CNA was successfully updated.')
+          expect(res.body.updated).to.have.nested.property('policies.id_quota').to.equal(75)
+          expect(res.body.updated.authority.active_roles).to.have.lengthOf(1)
+          done()
+        })
+    })
+
     it('Org is secretariat and id_quota is defined', (done) => {
       // perform the request to the api
       chai.request(server)
@@ -770,11 +835,11 @@ describe('Test Org Controller', () => {
           }
 
           // assert expected response
-          expect(res).to.have.status(200)
+          expect(res).to.have.status(400)
           expect(res).to.have.property('body').and.to.be.a('object')
           expect(res.body).to.have.property('message').and.to.be.a('string')
-          expect(res.body.message).to.equal(existentOrg.short_name + ' CNA was successfully updated.')
-          expect(res.body.updated).to.have.nested.property('policies.id_quota').to.equal(0)
+          expect(res.body.message).to.equal('The Secretariat has no ID Quota.')
+          //expect(res.body.updated).to.have.nested.property('policies.id_quota').to.equal(0)
           done()
         })
     })


### PR DESCRIPTION
Some of the logic around making sure id_quota gets set to zero when the
org is the Secretariat caused all regular orgs to have their id_quota
reset upon any update without a quota provided in that update. Now,
the original quota won't get wiped if a quota is not included.