### PR TITLE
Deactivated users get Unauthorized response

### DIFF
--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -34,12 +34,17 @@ const validateUser = (req, res, next) => {
 
       if (!result) {
         logger.warn('User not found. User authentication FAILED for ' + submitter)
-        return res.status(401).json({ message: 'Unauthorized' })
+        return res.status(401).json({error: 'Unauthorized', message: 'Unauthorized'})
+      }
+
+      if (!result.active) {
+        logger.info('User deactivated. Authentication failed for ' + submitter)
+        return res.status(401).json({error: 'Unauthorized', message: 'Unauthorized'})
       }
 
       if (uuidAPIKey.toAPIKey(result.secret) !== secret) {
         logger.warn('Incorrect apikey. User authentication FAILED for ' + submitter)
-        return res.status(401).json({ message: 'Unauthorized' })
+        return res.status(401).json({error: 'Unauthorized', message: 'Unauthorized'})
       }
 
       logger.info('SUCCESSFUL user authentication for ' + submitter)

--- a/test/unit-tests/middleware/middlewareTest.js
+++ b/test/unit-tests/middleware/middlewareTest.js
@@ -4,6 +4,7 @@ const expect = chai.expect
 chai.use(require('chai-http'))
 const headers = require('./mockObjects.middleware').headers
 const existingUser = require('./mockObjects.middleware').existentUser
+const deactivatedUser = require('./mockObjects.middleware').deactivatedUser
 const existentOrg = require('./mockObjects.middleware').existentOrg
 const User = require('../../../src/model/user')
 const Org = require('../../../src/model/org')
@@ -19,6 +20,11 @@ describe('Test for middleware', () => {
     await User.findOneAndUpdate()
       .byUserNameAndCnaShortName(existingUser.username, existingUser.cna_short_name)
       .updateOne(existingUser)
+      .setOptions({ upsert: true })
+
+    await User.findOneAndUpdate()
+      .byUserNameAndCnaShortName(deactivatedUser.username, deactivatedUser.cna_short_name)
+      .updateOne(deactivatedUser)
       .setOptions({ upsert: true })
 
     await Org.findOneAndUpdate()
@@ -212,6 +218,33 @@ describe('Test for middleware', () => {
         .post('/api/test/mw/user')
         .set(testHeaders)
         .send(cvePass5)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(401)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('Unauthorized')
+          done()
+        })
+    })
+
+    it('User is deactivated', function (done) {
+      const deactivatedHeaders = {
+        'content-type': 'application/json',
+        'CVE-API-CNA': 'mitre',
+        'CVE-API-SUBMITTER': 'flast',
+        'CVE-API-SECRET': 'S96E4QT-SMT4YE3-KX03X6K-4615CED'
+      }
+
+      // perform the request to the api
+      chai.request(server)
+        .post('/api/test/mw/user')
+        .set(deactivatedHeaders)
+        .send()
         .end((err, res) => {
           if (err) {
             done(err)

--- a/test/unit-tests/middleware/mockObjects.middleware.js
+++ b/test/unit-tests/middleware/mockObjects.middleware.js
@@ -17,6 +17,18 @@ const existentUser = {
   active: true
 }
 
+const deactivatedUser = {
+  UUID: 'a32386d5-ce3d-4fd9-aecd-8698c26897f2',
+  cna_short_name: 'mitre',
+  name: {
+    first: 'First',
+    last: 'Last'
+  },
+  secret: 'ca4ce25f-cd34-4f38-9f40-3e9a21825639',
+  username: 'flast',
+  active: false
+}
+
 const existentOrg = {
   UUID: '15fd129f-af00-4d8c-8f7b-e19b0587223f',
   authority: {
@@ -32,5 +44,6 @@ const existentOrg = {
 module.exports = {
   headers,
   existentOrg,
-  existentUser
+  existentUser,
+  deactivatedUser
 }


### PR DESCRIPTION
If a user's `active` field is false, they have been deactivated and should not be allowed to authenticate with the services.
