### PR TITLE
Adding middleware to only allow CNAs to reserve CVE IDs. Ran the lint…

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -44,23 +44,27 @@ module.exports = {
   },
   INVALID_BATCH_TYPE: {
     error: 'INVALID_BATCH_TYPE',
-    message: 'The batch_type provided is invalid [null when amount=1, sequential, nonsequential||non-sequential].',
+    message: 'The batch_type provided is invalid [null when amount=1, sequential, nonsequential||non-sequential].'
   },
   CANNOT_RESERVE_FOR_YEAR: {
     error: 'CANNOT_RESERVE_FOR_YEAR',
-    message: 'IDR is not currently configured reserve IDs for this year. If you believe you are receiving this message in error, please contact an administrator.',
+    message: 'IDR is not currently configured reserve IDs for this year. If you believe you are receiving this message in error, please contact an administrator.'
   },
   YEAR_RANGE_FULL: {
     error: 'YEAR_RANGE_FULL',
-    message: 'IDR cannot currently reserve IDs for this year as the range its allowed to reserve from is full. Please contact an administrator to have the range extended.',
+    message: 'IDR cannot currently reserve IDs for this year as the range its allowed to reserve from is full. Please contact an administrator to have the range extended.'
   },
   RESERVED_PARTIAL_AMOUNT: {
     error: 'RESERVED_PARTIAL_AMOUNT',
-    message: 'Only a partial amount of CVE IDs were reserved because there are not enough IDs available in the configured range for IDR to reserve the full amount.',
+    message: 'Only a partial amount of CVE IDs were reserved because there are not enough IDs available in the configured range for IDR to reserve the full amount.'
   },
   SECRETARIAT_ONLY: {
     error: 'SECRETARIAT_ONLY',
-    message: 'This function is currently only allowed to the Secretariat. This will change for many functions as more administrative roles are implemented.',
+    message: 'This function is currently only allowed to the Secretariat. This will change for many functions as more administrative roles are implemented.'
+  },
+  CNA_ONLY: {
+    error: 'CNA_ONLY',
+    message: 'This function is currently only allowed to CNAs. This will change for many functions as more administrative roles are implemented.'
   },
   AUTH_ROLE_ENUM: {
     SECRETARIAT: 'SECRETARIAT',

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -15,7 +15,7 @@ async function getCveId (req, res) {
     .exec(async (err, result) => {
       if (err) {
         logger.error(err.stack)
-        return res.status(500).json({ error: 'INTERNAL_SERVER_ERROR', message: 'Internal Server Error'})
+        return res.status(500).json({ error: 'INTERNAL_SERVER_ERROR', message: 'Internal Server Error' })
       }
 
       if (!result) {
@@ -523,10 +523,10 @@ async function nonSequentialReservation (year, amount, cveId, shortName, cnaShor
         if (isFull || returned) {
           res.header(CONSTANTS.QUOTA_HEADER, availableIds - amount)
           logger.info({ message: 'Only ' + amount + ' cve ids were reserved because there are not enough ids in the CVE ID non-sequential block.' })
-          let partial_error = CONSTANTS.RESERVED_PARTIAL_AMOUNT
-          partial_error.details = { amount_reserved: amount }
-          partial_error.cve_ids = cveIdDocuments
-          return res.status(206).json(partial_error)
+          const partialError = CONSTANTS.RESERVED_PARTIAL_AMOUNT
+          partialError.details = { amount_reserved: amount }
+          partialError.cve_ids = cveIdDocuments
+          return res.status(206).json(partialError)
         }
 
         await allocateAvailableCveIds(result.ids, cveId, year) // Pool was incremented. Create 'AVAILABLE' cve ids.

--- a/src/controller/cve-id.controller/index.js
+++ b/src/controller/cve-id.controller/index.js
@@ -4,7 +4,7 @@ const mw = require('../../middleware/middleware')
 const controller = require('./cve-id.controller')
 
 router.get('/cve-id', mw.validateUser, controller.CVEID_GET_FILTER)
-router.post('/cve-id', mw.validateUser, controller.CVEID_RESERVE)
+router.post('/cve-id', mw.validateUser, mw.onlyCnas, controller.CVEID_RESERVE)
 router.get('/cve-id/:id', mw.validateUser, controller.CVEID_GET_SINGLE)
 router.post('/cve-id/:id', mw.onlySecretariat, mw.validateUser, controller.CVEID_STATE_REASIGN_SINGLE)
 router.post('/cve-id-range/:year', mw.onlySecretariat, mw.validateUser, controller.CVEID_RANGE_CREATE)

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -16,7 +16,6 @@ router.get('/org/:shortname/user/:username', mw.onlySecretariat, mw.validateUser
 router.post('/org/:shortname/user/:username', mw.onlySecretariat, mw.validateUser, controller.USER_UPDATE_SINGLE)
 router.post('/org/:shortname/user/:username/reset_secret', mw.onlySecretariat, mw.validateUser, controller.USER_RESET_SECRET)
 
-
 router.get('/org/:shortname/id_quota', mw.validateUser, controller.ORG_ID_QUOTA)
 
 module.exports = router

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -1,6 +1,5 @@
 const CONSTANTS = require('../constants')
 const Org = require('../model/org')
-const util = require('../utils/utils')
 const User = require('../model/user')
 const cveSchema = require('./jsonSchema')
 const logger = require('./logger')
@@ -38,17 +37,17 @@ const validateUser = (req, res, next) => {
 
       if (!result) {
         logger.warn('User not found. User authentication FAILED for ' + user)
-        return res.status(401).json({error: 'Unauthorized', message: 'Unauthorized'})
+        return res.status(401).json({ error: 'Unauthorized', message: 'Unauthorized' })
       }
 
       if (!result.active) {
         logger.warn('User deactivated. Authentication failed for ' + user)
-        return res.status(401).json({error: 'Unauthorized', message: 'Unauthorized'})
+        return res.status(401).json({ error: 'Unauthorized', message: 'Unauthorized' })
       }
 
       if (uuidAPIKey.toAPIKey(result.secret) !== key) {
         logger.warn('Incorrect apikey. User authentication FAILED for ' + user)
-        return res.status(401).json({error: 'Unauthorized', message: 'Unauthorized'})
+        return res.status(401).json({ error: 'Unauthorized', message: 'Unauthorized' })
       }
 
       logger.info('SUCCESSFUL user authentication for ' + user)
@@ -63,7 +62,21 @@ async function onlySecretariat (req, res, next) {
     logger.info({ message: org + ' is NOT a ' + CONSTANTS.AUTH_ROLE_ENUM.SECRETARIAT })
     return res.status(403).json(CONSTANTS.SECRETARIAT_ONLY)
   }
-  logger.info({message: 'Confirmed ' + org + ' as a ' + CONSTANTS.AUTH_ROLE_ENUM.SECRETARIAT })
+  logger.info({ message: 'Confirmed ' + org + ' as a ' + CONSTANTS.AUTH_ROLE_ENUM.SECRETARIAT })
+  next()
+}
+
+async function onlyCnas (req, res, next) {
+  const shortName = req.header(CONSTANTS.AUTH_HEADERS.ORG)
+  const org = await Org.findOne().byShortName(shortName)
+
+  // org is not null because it exists (checked in user validation)
+  if (!org.authority.active_roles.includes(CONSTANTS.AUTH_ROLE_ENUM.CNA)) {
+    logger.info({ message: org + ' is NOT a ' + CONSTANTS.AUTH_ROLE_ENUM.CNA })
+    return res.status(403).json(CONSTANTS.CNA_ONLY)
+  }
+
+  logger.info({ message: 'Confirmed ' + org + ' as a ' + CONSTANTS.AUTH_ROLE_ENUM.CNA })
   next()
 }
 
@@ -124,5 +137,6 @@ const validateCveJsonSchema = (req, res, next) => {
 module.exports = {
   validateUser,
   onlySecretariat,
+  onlyCnas,
   validateCveJsonSchema
 }

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -73,14 +73,12 @@ async function onlyCnas (req, res, next) {
   if (org.authority.active_roles.includes(CONSTANTS.AUTH_ROLE_ENUM.SECRETARIAT)) {
     logger.info({ message: org + ' is a ' + CONSTANTS.AUTH_ROLE_ENUM.SECRETARIAT + ' so until Root CNAs are implemented this role is allowed.' })
     next()
-  }
-
-  // org is not null because it exists (checked in user validation)
-  if (!org.authority.active_roles.includes(CONSTANTS.AUTH_ROLE_ENUM.CNA)) {
+  } else if (!org.authority.active_roles.includes(CONSTANTS.AUTH_ROLE_ENUM.CNA)) {
     logger.info({ message: org + ' is NOT a ' + CONSTANTS.AUTH_ROLE_ENUM.CNA })
     return res.status(403).json(CONSTANTS.CNA_ONLY)
   }
 
+  // the org is a CNA
   logger.info({ message: 'Confirmed ' + org + ' as a ' + CONSTANTS.AUTH_ROLE_ENUM.CNA })
   next()
 }

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -70,6 +70,11 @@ async function onlyCnas (req, res, next) {
   const shortName = req.header(CONSTANTS.AUTH_HEADERS.ORG)
   const org = await Org.findOne().byShortName(shortName)
 
+  if (org.authority.active_roles.includes(CONSTANTS.AUTH_ROLE_ENUM.SECRETARIAT)) {
+    logger.info({ message: org + ' is a ' + CONSTANTS.AUTH_ROLE_ENUM.SECRETARIAT + ' so until Root CNAs are implemented this role is allowed.' })
+    next()
+  }
+
   // org is not null because it exists (checked in user validation)
   if (!org.authority.active_roles.includes(CONSTANTS.AUTH_ROLE_ENUM.CNA)) {
     logger.info({ message: org + ' is NOT a ' + CONSTANTS.AUTH_ROLE_ENUM.CNA })

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -29,6 +29,12 @@ app.route('/api/test/mw/secretariat_only')
     return res.status(200).json({ message: 'Success! You have reached the target endpoint.' })
   })
 
+// cna only
+app.route('/api/test/mw/cna_only')
+  .post(middleware.onlyCnas, (req, res) => {
+    return res.status(200).json({ message: 'Success! You have reached the target endpoint.' })
+  })
+
 // validate json schema 5.0
 app.route('/api/test/mw/schema5')
   .post(middleware.validateCveJsonSchema, (req, res) => {

--- a/test/unit-tests/middleware/onlyCnas.fixtures.js
+++ b/test/unit-tests/middleware/onlyCnas.fixtures.js
@@ -1,0 +1,139 @@
+const secretariatHeaders = {
+    'content-type': 'application/json',
+    'CVE-API-ORG': 'secretariat',
+    'CVE-API-USER': 'secretariat_user',
+    'CVE-API-KEY': 'S96E4QT-SMT4YE3-KX03X6K-4615CED'
+  }
+  
+  const secretariatUser = {
+    UUID: 'b34186d5-ce3d-4fd9-aecd-8698c26897f2',
+    cna_short_name: 'secretariat',
+    name: {
+      first: 'Secretariat',
+      last: 'User'
+    },
+    secret: 'ca4ce25f-cd34-4f38-9f40-3e9a21825639',
+    username: 'secretariat_user',
+    active: true
+  }
+  
+  const secretariatOrg = {
+    UUID: '11kd129f-af00-4d8c-8f7b-e19b0587223f',
+    authority: {
+      active_roles: ['SECRETARIAT']
+    },
+    name: 'The Sec',
+    policies: {
+      id_quota: 5
+    },
+    short_name: 'secretariat'
+  }
+
+const secretariatAndCnaHeaders = {
+    'content-type': 'application/json',
+    'CVE-API-ORG': 'secretariatAndCna',
+    'CVE-API-USER': 'secretariatAndCna_user',
+    'CVE-API-KEY': 'S96E4QT-SMT4YE3-KX03X6K-4615CED'
+  }
+  
+  const secretariatAndCnaUser = {
+    UUID: 'h34186d5-ce3d-4fd9-aecd-8698c26897f2',
+    cna_short_name: 'secretariatAndCna',
+    name: {
+      first: 'SecretariatAndCna',
+      last: 'User'
+    },
+    secret: 'ca4ce25f-cd34-4f38-9f40-3e9a21825639',
+    username: 'secretariatAndCna_user',
+    active: true
+  }
+  
+  const secretariatAndCnaOrg = {
+    UUID: '15fd129f-af00-4d8c-8f7b-e19b0587223f',
+    authority: {
+      active_roles: ['CNA', 'SECRETARIAT']
+    },
+    name: 'The Sec and CNA',
+    policies: {
+      id_quota: 5
+    },
+    short_name: 'secretariatAndCna'
+  }
+  
+  const notCnaHeaders = {
+    'content-type': 'application/json',
+    'CVE-API-ORG': 'not_CNA',
+    'CVE-API-USER': 'not_cna_user',
+    'CVE-API-KEY': 'S96E4QT-SMT4YE3-KX03X6K-4615CED'
+  }
+
+  const notCnaUser = {
+    UUID: 'z13186d5-ce3d-4fd9-aecd-8698c26897f2',
+    cna_short_name: 'not_CNA',
+    name: {
+      first: 'Not',
+      last: 'CNA_User'
+    },
+    secret: 'ca4ce25f-cd34-4f38-9f40-3e9a21825639',
+    username: 'not_cna_user',
+    active: true
+  }
+  
+  const notCnaOrg = {
+    UUID: '25bd129f-af00-4d8c-8f7b-e19b0587223f',
+    authority: {
+      active_roles: ['']
+    },
+    name: 'Not a CNA',
+    policies: {
+      id_quota: 5
+    },
+    short_name: 'not_CNA'
+  }
+
+  const cnaHeaders = {
+    'content-type': 'application/json',
+    'CVE-API-ORG': 'CNA',
+    'CVE-API-USER': 'cna_user',
+    'CVE-API-KEY': 'S96E4QT-SMT4YE3-KX03X6K-4615CED'
+  }
+
+  const cnaUser = {
+    UUID: 'f98186d5-ce3d-4fd9-aecd-8698c26897f2',
+    cna_short_name: 'CNA',
+    name: {
+      first: 'CNA',
+      last: 'User'
+    },
+    secret: 'ca4ce25f-cd34-4f38-9f40-3e9a21825639',
+    username: 'cna_user',
+    active: true
+  }
+  
+  const cnaOrg = {
+    UUID: '87yd129f-af00-4d8c-8f7b-e19b0587223f',
+    authority: {
+      active_roles: ['CNA']
+    },
+    name: 'CNA',
+    policies: {
+      id_quota: 5
+    },
+    short_name: 'CNA'
+  }
+  
+  module.exports = {
+    secretariatHeaders,
+    secretariatUser,
+    secretariatOrg,
+    secretariatAndCnaHeaders,
+    secretariatAndCnaUser,
+    secretariatAndCnaOrg,
+    notCnaHeaders,
+    notCnaUser,
+    notCnaOrg,
+    cnaHeaders,
+    cnaUser,
+    cnaOrg,
+  }
+  

--- a/test/unit-tests/middleware/onlyCnasMiddlewareTest.js
+++ b/test/unit-tests/middleware/onlyCnasMiddlewareTest.js
@@ -1,0 +1,160 @@
+const server = require('../../../test-utils/index')
+const chai = require('chai')
+const expect = chai.expect
+chai.use(require('chai-http'))
+const secretariatHeaders = require('./onlyCnas.fixtures').secretariatHeaders
+const secretariatOrg = require('./onlyCnas.fixtures').secretariatOrg
+const secretariatUser = require('./onlyCnas.fixtures').secretariatUser
+const secretariatAndCnaHeaders = require('./onlyCnas.fixtures').secretariatAndCnaHeaders
+const secretariatAndCnaOrg = require('./onlyCnas.fixtures').secretariatAndCnaOrg
+const secretariatAndCnaUser = require('./onlyCnas.fixtures').secretariatAndCnaUser
+const notCnaHeaders = require('./onlyCnas.fixtures').notCnaHeaders
+const notCnaOrg = require('./onlyCnas.fixtures').notCnaOrg
+const notCnaUser = require('./onlyCnas.fixtures').notCnaUser
+const cnaHeaders = require('./onlyCnas.fixtures').cnaHeaders
+const cnaOrg = require('./onlyCnas.fixtures').cnaOrg
+const cnaUser = require('./onlyCnas.fixtures').cnaUser
+const User = require('../../../src/model/user')
+const Org = require('../../../src/model/org')
+const CONSTANTS = require('../../../src/constants')
+
+describe('Test only CNA middleware', () => {
+    before(async () => {
+        await User.findOneAndUpdate()
+        .byUserNameAndCnaShortName(secretariatUser.username, secretariatUser.cna_short_name)
+        .updateOne(secretariatUser)
+        .setOptions({ upsert: true })
+
+        await Org.findOneAndUpdate()
+        .byShortName(secretariatOrg.short_name)
+        .updateOne(secretariatOrg)
+        .setOptions({ upsert: true })
+
+        await User.findOneAndUpdate()
+        .byUserNameAndCnaShortName(secretariatAndCnaUser.username, secretariatAndCnaUser.cna_short_name)
+        .updateOne(secretariatAndCnaUser)
+        .setOptions({ upsert: true })
+
+        await Org.findOneAndUpdate()
+        .byShortName(secretariatAndCnaOrg.short_name)
+        .updateOne(secretariatAndCnaOrg)
+        .setOptions({ upsert: true })
+
+        await User.findOneAndUpdate()
+        .byUserNameAndCnaShortName(notCnaUser.username, notCnaUser.cna_short_name)
+        .updateOne(notCnaUser)
+        .setOptions({ upsert: true })
+
+        await Org.findOneAndUpdate()
+        .byShortName(notCnaOrg.short_name)
+        .updateOne(notCnaOrg)
+        .setOptions({ upsert: true })
+
+        await User.findOneAndUpdate()
+        .byUserNameAndCnaShortName(cnaUser.username, cnaUser.cna_short_name)
+        .updateOne(cnaUser)
+        .setOptions({ upsert: true })
+
+        await Org.findOneAndUpdate()
+        .byShortName(cnaOrg.short_name)
+        .updateOne(cnaOrg)
+        .setOptions({ upsert: true })
+    })
+
+    context('Positive Tests', function () {
+        it('Users org is a CNA and should pass checks', function (done) {
+            // perform the request to the api
+            chai.request(server)
+            .post('/api/test/mw/cna_only')
+            .set(cnaHeaders)
+            .send()
+            .end((err, res) => {
+                if (err) {
+                done(err)
+                }
+
+                // assert expected response
+                expect(res).to.have.status(200)
+                expect(res).to.have.property('body').and.to.be.a('object')
+                expect(res.body).to.have.property('message').and.to.be.a('string')
+                expect(res.body.message).to.equal('Success! You have reached the target endpoint.')
+                done()
+            })
+        })
+        it('Users org is a CNA and Secretariat and should pass checks', function (done) {
+            // perform the request to the api
+            chai.request(server)
+            .post('/api/test/mw/cna_only')
+            .set(secretariatAndCnaHeaders)
+            .send()
+            .end((err, res) => {
+                if (err) {
+                done(err)
+                }
+
+                // assert expected response
+                expect(res).to.have.status(200)
+                expect(res).to.have.property('body').and.to.be.a('object')
+                expect(res.body).to.have.property('message').and.to.be.a('string')
+                expect(res.body.message).to.equal('Success! You have reached the target endpoint.')
+                done()
+            })
+        })
+        // This test will change with the implementation of Root CNAs, as the burden of reserving IDs
+        // on behalf of other organizations transfers to Roots. Secretariat will then step back.
+        it('Users org is a Secretariat but not a CNA and should pass checks', function (done) {
+            // perform the request to the api
+            chai.request(server)
+            .post('/api/test/mw/cna_only')
+            .set(secretariatHeaders)
+            .send()
+            .end((err, res) => {
+                if (err) {
+                done(err)
+                }
+
+                // assert expected response
+                expect(res).to.have.status(200)
+                expect(res).to.have.property('body').and.to.be.a('object')
+                expect(res.body).to.have.property('message').and.to.be.a('string')
+                expect(res.body.message).to.equal('Success! You have reached the target endpoint.')
+                done()
+            })
+        })
+    })
+
+    context('Negative Tests', function () {
+        it('Users org is not a CNA and should get rejected', function (done) {
+            // perform the request to the api
+            chai.request(server)
+            .post('/api/test/mw/cna_only')
+            .set(notCnaHeaders)
+            .send()
+            .end((err, res) => {
+                if (err) {
+                done(err)
+                }
+
+                // assert expected response
+                expect(res).to.have.status(403)
+                expect(res).to.have.property('body').and.to.be.a('object')
+                expect(res.body).to.have.property('message').and.to.be.a('string')
+                expect(res.body.error).to.equal('CNA_ONLY')
+                expect(res.body).to.have.property('message').and.to.be.a('string')
+                expect(res.body.message).to.equal('This function is currently only allowed to CNAs. This will change for many functions as more administrative roles are implemented.')
+                done()
+            })
+        })
+    })
+
+    after(async () => {
+    await User.findOneAndRemove().byUserNameAndCnaShortName(secretariatUser.username, secretariatUser.cna_short_name)
+    await Org.findOneAndRemove().byShortName(secretariatOrg.short_name)
+    await User.findOneAndRemove().byUserNameAndCnaShortName(secretariatAndCnaUser.username, secretariatAndCnaUser.cna_short_name)
+    await Org.findOneAndRemove().byShortName(secretariatAndCnaOrg.short_name)
+    await User.findOneAndRemove().byUserNameAndCnaShortName(notCnaUser.username, notCnaUser.cna_short_name)
+    await Org.findOneAndRemove().byShortName(notCnaOrg.short_name)
+    await User.findOneAndRemove().byUserNameAndCnaShortName(cnaUser.username, cnaUser.cna_short_name)
+    await Org.findOneAndRemove().byShortName(cnaOrg.short_name)
+    })
+})


### PR DESCRIPTION
New middleware functionality checks that only organizations with the "CNA" role can reserve CVE IDs from the CVE IDR service.