### PR TITLE
Reverting 'fix' to IDR duplicates

### DIFF
--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -507,10 +507,10 @@ async function nonSequentialReservation (year, amount, cveId, shortName, cnaShor
 
     if (result.isReserved) {
       cveIdDocuments.push(result.cveId) // add reserved cve id to the array of reserved cve ids
-      available = available.splice(index, 1) // remove reserved cve id from the 'AVAILABLE' pool
+      available.splice(index, 1) // remove reserved cve id from the 'AVAILABLE' pool
       counter = counter + 1
     } else {
-      available = available.splice(index, 1) // remove reserved cve id from the 'AVAILABLE' pool
+      available.splice(index, 1) // remove reserved cve id from the 'AVAILABLE' pool
       available = await CveId.countDocuments({ cve_year: year, state: 'AVAILABLE' }).limit(availableLimit) // get available ids
       availableLimit = Math.max(3 * (amount - counter), CONSTANTS.DEFAULT_AVAILABLE_POOL)
 


### PR DESCRIPTION
Reverting a"fix" in non sequential IDR for duplicate cve id reservations.