### PR TITLE
Filtering 'AVAILABLE' cve ids from the IDR GET endpoints

### DIFF
--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -18,17 +18,18 @@ async function getCveId (req, res) {
         return res.status(500).json({ error: 'INTERNAL_SERVER_ERROR', message: 'Internal Server Error' })
       }
 
-      if (!result) {
+      if (!result || result.state === 'AVAILABLE') {
         return res.status(404).json({ error: 'NOT_FOUND', message: id + ' not found' })
       }
 
       const isSecretariat = await util.isSecretariat(cnaShortName)
+      // the requester is not the owning org and the secretariat
       if (cnaShortName !== result.owning_cna && !isSecretariat) {
         if (result.state === 'RESERVED') {
           const cveId = Object.assign({}, result)._doc
           delete cveId._id
 
-          logger.info({ message: id + ' is RESERVED. A 404 status was sent to the requester.', cveId: result })
+          logger.info({ message: id + ' is ' + result.state + '. A 404 status was sent to the requester.', cveId: result })
           return res.status(404).json({ error: 'NOT_FOUND', message: id + ' not found' })
         }
 
@@ -42,6 +43,7 @@ async function getCveId (req, res) {
         logger.info({ message: id + ' record was sent to the user.', cveId: cveId })
         return res.status(200).json(cveId)
       } else {
+        // the requester is the owning org or the secretariat
         const cveId = Object.assign({}, result)._doc
         delete cveId._id
 
@@ -116,12 +118,12 @@ async function getFilteredCveId (req, res) {
     }
   }
 
-  let query = {}
+  const query = {
+    state: { $ne: 'AVAILABLE' }
+  }
 
   if (!isSecretariat) {
-    query = {
-      owning_cna: req.header(CONSTANTS.AUTH_HEADERS.ORG)
-    }
+    query.owning_cna = req.header(CONSTANTS.AUTH_HEADERS.ORG)
   }
 
   if (year) {
@@ -129,6 +131,11 @@ async function getFilteredCveId (req, res) {
   }
 
   if (state) {
+    if (state === 'AVAILABLE') {
+      returned = true
+      return res.status(404).json({ error: 'NOT_FOUND', message: 'No CVE IDs were found for the specified query parameters.' })
+    }
+
     query.state = state
   }
 

--- a/test/unit-tests/cve-id/cveIdTest.js
+++ b/test/unit-tests/cve-id/cveIdTest.js
@@ -22,6 +22,7 @@ const cveIdDummy1 = require('./mockObjects.cve-id').cveDummy1
 const cveIdDummy2 = require('./mockObjects.cve-id').cveDummy2
 const cveIdDummy3 = require('./mockObjects.cve-id').cveDummy3
 const cveIdDummy4 = require('./mockObjects.cve-id').cveDummy4
+const cveIdDummy5 = require('./mockObjects.cve-id').cveDummy5
 const cveId = 'CVE-2017-4024'
 const cveIdYear = cveId.substring(4, 8)
 const nonExistentCveId = 'CVE-2017-35437'
@@ -54,6 +55,11 @@ describe('Test ID Reservator Endpoints', () => {
     await CveId.findOneAndUpdate()
       .byCveId(cveIdDummy4.cve_id)
       .updateOne(cveIdDummy4)
+      .setOptions({ upsert: true })
+
+    await CveId.findOneAndUpdate()
+      .byCveId(cveIdDummy5.cve_id)
+      .updateOne(cveIdDummy5)
       .setOptions({ upsert: true })
 
     await CveId.findOneAndRemove().byCveId(nonExistentCveId)
@@ -107,6 +113,44 @@ describe('Test ID Reservator Endpoints', () => {
           expect(res).to.have.property('body').and.to.be.a('object')
           expect(res.body).to.have.property('message').and.to.be.a('string')
           expect(res.body.message).to.equal(nonExistentCveId + ' not found')
+          done()
+        })
+    })
+
+    it('Requester is not the secretariat and the cve is AVAILABLE', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .get('/api/test/cve-id/' + cveIdDummy5.cve_id)
+        .set(orgHeader) // not the owning cna or secretariat
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(404)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal(cveIdDummy5.cve_id + ' not found')
+          done()
+        })
+    })
+
+    it('Requester is the secretariat and the cve is AVAILABLE', (done) => {
+      // perform the request to the api
+      chai.request(server)
+        .get('/api/test/cve-id/' + cveIdDummy5.cve_id)
+        .set(secretariatHeader) // the secretariat
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          // assert expected response
+          expect(res).to.have.status(404)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal(cveIdDummy5.cve_id + ' not found')
           done()
         })
     })
@@ -612,18 +656,8 @@ describe('Test ID Reservator Endpoints', () => {
   })
 
   after(async () => {
-    await CveId.findOneAndRemove().byCveId(cveId)
-    await CveId.findOneAndRemove().byCveId()
-    await CveId.findOneAndRemove().byCveId()
-    await CveId.findOneAndRemove().byCveId()
-    await CveId.findOneAndRemove().byCveId()
-    await CveId.findOneAndRemove().byCveId(nonExistentCveId)
-    await User.findOneAndRemove().byUserNameAndCnaShortName(secretariatUser.username, secretariatUser.cna_short_name)
-    await User.findOneAndRemove().byUserNameAndCnaShortName(owningOrgUser.username, owningOrgUser.cna_short_name)
-    await User.findOneAndRemove().byUserNameAndCnaShortName(orgUser.username, orgUser.cna_short_name)
-    await Org.findOneAndRemove().byShortName(secretariatOrg.short_name)
-    await Org.findOneAndRemove().byShortName(owningOrg.short_name)
-    await Org.findOneAndRemove().byShortName(org.short_name)
-    await Org.findOneAndRemove().byShortName(nonExistentOrg.short_name)
+    await CveId.deleteMany({})
+    await User.deleteMany({})
+    await Org.deleteMany({})
   })
 })

--- a/test/unit-tests/cve-id/mockObjects.cve-id.js
+++ b/test/unit-tests/cve-id/mockObjects.cve-id.js
@@ -182,6 +182,18 @@ const cveDummy4 = {
   }
 }
 
+// secretariat owned
+const cveDummy5 = {
+  cve_id: 'CVE-2020-20030',
+  cve_year: '2020',
+  state: 'AVAILABLE',
+  owning_cna: 'N/A',
+  requested_by: {
+    cna: 'N/A',
+    user: 'N/A'
+  }
+}
+
 const cveReservedForOrgWithZeroIdQuota = {
   cve_id: 'CVE-2019-4026',
   cve_year: '2019',
@@ -211,5 +223,6 @@ module.exports = {
   cveDummy1,
   cveDummy2,
   cveDummy3,
-  cveDummy4
+  cveDummy4,
+  cveDummy5
 }


### PR DESCRIPTION
Removing 'AVAILABLE' cve ids in the `GET /cve-id` and `GET /cve-id/:id` endpoints in IDR.