### PR TITLE
specify mongo version in docker setup

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   docdb:
-    image: mongo
+    image: mongo:3.6.20-xenial
     container_name: mongo
     env_file: .docker-env
     ports:


### PR DESCRIPTION
This syncs the local docker development environment with the deployed
(DocumentDB cluster) MongoDB API implementation (3.6).