### PR TITLE
Create req ctx and req uuid

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const cors = require('cors')
 const morgan = require('morgan')
 const mongoose = require('mongoose')
 const helmet = require('helmet')
+const mw = require('./middleware/middleware')
 const logger = require('./middleware/logger')
 const configureRoutes = require('./routes.config')
 const app = express()
@@ -29,6 +30,7 @@ app.use(helmet()) // Provides standard security <https://www.npmjs.com/package/h
 // Body Parser Middleware
 app.use(express.json()) // Allows us to handle raw JSON data
 app.use(express.urlencoded({ extended: false })) // Allows us to handle url encoded data
+app.use('/api/', mw.createCtxAndReqUUID)
 // Make mongoose connection available globally
 global.mongoose = mongoose
 

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -6,6 +6,7 @@ const logger = require('./logger')
 const Validator = require('jsonschema').Validator
 const v = new Validator()
 const uuidAPIKey = require('uuid-apikey')
+const uuid = require('uuid')
 const utils = require('../utils/utils')
 
 const validateUser = (req, res, next) => {
@@ -83,6 +84,13 @@ async function onlyCnas (req, res, next) {
   }
 }
 
+var createCtxAndReqUUID = function (req, res, next) {
+  req.ctx = {}
+  req.ctx.uuid = uuid.v4()
+  logger.info(JSON.stringify({ uuid: req.ctx.uuid, path: req.path }))
+  next()
+}
+
 // TODO: Request body sanitation, better user messages, and use correct status codes
 const validateCveJsonSchema = (req, res, next) => {
   if (req.method.toUpperCase() === 'POST') {
@@ -141,5 +149,6 @@ module.exports = {
   validateUser,
   onlySecretariat,
   onlyCnas,
+  createCtxAndReqUUID,
   validateCveJsonSchema
 }


### PR DESCRIPTION
While a small change, this is to lay down the path for more code to utilize the request UUID and the context object.

API code can use the request UUID in logging information so a request can be tracked later.

API code can use the ctx object to store parsed and sanitized input that is safe for the rest of the codebase to use along with a myriad of other uses. 