### PR TITLE
Mongo node injection protection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3314,6 +3314,11 @@
         "jsonschema": "^1.0.0"
       }
     },
+    "express-mongo-sanitize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/express-mongo-sanitize/-/express-mongo-sanitize-2.0.0.tgz",
+      "integrity": "sha512-tqGqnKsibDfKqypC6QDYjp4VRLqtTlwuHDfK7KECZvq9fDOq8yi0MdzCJe2DWhv54/IoQV+7uXR7h9eD+Fc5LA=="
+    },
     "express-validator": {
       "version": "6.6.1",
       "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dotenv": "^5.0.1",
     "express": "^4.15.4",
     "express-jsonschema": "^1.1.6",
+    "express-mongo-sanitize": "^2.0.0",
     "express-validator": "^6.6.1",
     "helmet": "^3.21.2",
     "jsonschema": "^1.2.6",

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -222,12 +222,10 @@ async function modifyCveId (req, res, next) {
 
     if (req.ctx.query.state) {
       state = req.ctx.query.state
-      console.log(state)
     }
 
     if (req.ctx.query.cna) {
       newCnaShortname = req.ctx.query.cna
-      console.log(newCnaShortname)
     }
 
     if (state && !returned) {

--- a/src/index.js
+++ b/src/index.js
@@ -26,23 +26,13 @@ if (process.env.NODE_ENV === 'development') {
 }
 app.use(cors())
 app.use(helmet()) // Provides standard security <https://www.npmjs.com/package/helmet>
-
-// Body Parser Middleware
-app.use(express.json()) // Allows us to handle raw JSON data
-app.use(express.urlencoded({ extended: false })) // Allows us to handle url encoded data
+app.use(express.json()) // Body Parser Middleware to handle raw JSON data
+app.use(express.urlencoded({ extended: false })) // Allows us to handle url encoded dat
+app.use('/api/', mw.hasProhibitedKeys)
 app.use('/api/', mw.createCtxAndReqUUID)
-// Make mongoose connection available globally
-global.mongoose = mongoose
-
-//* ********Middleware Config*********** */
-//* ********Middleware Config END*********** */
-
-//* ************API Routes Setup*********** */
-configureRoutes(app)
-//* ********API Routes Setup END*********** */
-
-// error handler
-app.use(mw.errorHandler)
+global.mongoose = mongoose // Make mongoose connection available globally
+configureRoutes(app) // Define api routes
+app.use(mw.errorHandler) // error handler middleware
 
 // construct MongoDB connection string
 // assumes that host, port, database are always defined in default config, but

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -1,4 +1,5 @@
 const CONSTANTS = require('../constants')
+const mongoSanitize = require('express-mongo-sanitize')
 const Org = require('../model/org')
 const User = require('../model/user')
 const cveSchema = require('./jsonSchema')
@@ -8,6 +9,22 @@ const v = new Validator()
 const uuidAPIKey = require('uuid-apikey')
 const uuid = require('uuid')
 const utils = require('../utils/utils')
+
+function hasProhibitedKeys (req, res, next) {
+  try {
+    if (mongoSanitize.has(req.headers)) {
+      mongoSanitize.sanitize(req.headers, { replaceWith: '_' })
+      throw new Error('Prohibited characters found in request header keys. ' + JSON.stringify(req.headers))
+    } else if (mongoSanitize.has(req.query)) {
+      mongoSanitize.sanitize(req.query, { replaceWith: '_' })
+      throw new Error('Prohibited characters found in request query params keys. ' + JSON.stringify(req.query))
+    }
+
+    next()
+  } catch (err) {
+    next(err)
+  }
+}
 
 function createCtxAndReqUUID (req, res, next) {
   try {
@@ -172,6 +189,7 @@ function errorHandler (err, req, res, next) {
 }
 
 module.exports = {
+  hasProhibitedKeys,
   validateUser,
   onlySecretariat,
   onlyCnas,


### PR DESCRIPTION
Added middleware that checks for prohibited characters in the request header keys and query parameters. The request is aborted if the check fails with an error sent to the user where the parameters are sanitized before logged.