### PR TITLE
batch inserting CVE IDs allows for larger migrations

### DIFF
--- a/src/index-populate.js
+++ b/src/index-populate.js
@@ -207,6 +207,7 @@ async function populateUserCollection () {
 async function populateCveIdCollection () {
   // replace Org and User values with their UUID equivalents
   // unlike in the view, we don't care about the original data
+  let batchCveIds = []
   for (let i = 0; i < cveIdData.length; i++) {
     const cveid = cveIdData[i]
 
@@ -217,8 +218,17 @@ async function populateCveIdCollection () {
     cveid.owning_cna = tmpOwningCnaUUID
     const tmpUserUUID = await utils.getUserUUID(cveid.requested_by.user, tmpOwningCnaUUID)
     cveid.requested_by.user = tmpUserUUID
+
+    // batch insert IDs
+    batchCveIds.push(cveid)
+    const isLastItem = i === cveIdData.length - 1
+    if (i % 100 === 0 || isLastItem) {
+        await CveId.insertMany(batchCveIds)
+        batchCveIds = []
+    }
   }
 
-  await CveId.insertMany(cveIdData)
+  // success!
+  // await CveId.insertMany(cveIdData)
   logger.info('Cve-Id collection populated')
 }


### PR DESCRIPTION
A recent data migration exposed an issue populating a database with large sets of IDs. A temporary solution is to batch-insert into the `Cve-Id` collection, instead of inserting all IDs at once.