### PR TITLE
Logging messages as strings

### DIFF
--- a/src/middleware/logger.js
+++ b/src/middleware/logger.js
@@ -8,7 +8,9 @@ const myFormat = winston.format.combine(
   winston.format.printf(info => {
     const { timestamp, level, message, ...args } = info
     const ts = timestamp.slice(0, 19).replace('T', ' ')
-    return `${ts} [${level}]: ${message} ${
+    const msg = JSON.stringify(message.trim()) // messages can only be strings (not executable objects)
+
+    return `${ts} [${level}]: ${msg} ${
       Object.keys(args).length ? JSON.stringify(args) : ''
     }`
   })
@@ -17,10 +19,6 @@ const myFormat = winston.format.combine(
 const logger = winston.createLogger({
   level: 'info',
   format: myFormat
-  // transports: [
-  //   // Write all logs with level 'info' and below ('warn' and 'error') to combined.log
-  //   //new winston.transports.File({ filename: 'combined.log' })
-  // ]
 })
 
 if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'integration') {


### PR DESCRIPTION
Logging messages as strings will prevent malicious users from executing malware via the logging system.