### PR TITLE
Prevent duplicated users per org in UpdateUser

### DIFF
--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -499,12 +499,14 @@ async function updateUser (req, res, next) {
       console.log(duplicate_users)
       if (duplicate_users.length) {
         returned = true
+        logger.info('The user could not be updated because ' + shortName + ' CNA contains a user with the same name.')
         return res.status(404).json({ message: 'The user could not be updated because ' + shortName + ' CNA contains a user with the same name.' })
       }
     } else if (newCnaShortname && !returned) {
       let duplicate_users = await User.find({ org_UUID: newUser.org_UUID, username: username})
       if (duplicate_users.length) {
         returned = true
+        logger.info('The user could not be updated because ' + newCnaShortname + ' CNA contains a user with the same name.')
         return res.status(404).json({ message: 'The user could not be updated because ' + newCnaShortname + ' CNA contains a user with the same name.' })
       }
     }

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -486,6 +486,29 @@ async function updateUser (req, res, next) {
       }
     }
 
+    // check if org has user of same username already
+    if ((newUsername && newCnaShortname) && !returned) {
+      let duplicate_users = await User.find({ org_UUID: newUser.org_UUID, username: newUser.username })
+      if (duplicate_users.length) {
+        returned = true
+        logger.info('The user could not be updated because ' + newCnaShortname + ' CNA contains a user with the same name.')
+        return res.status(404).json({ message: 'The user could not be updated because ' + newCnaShortname + ' CNA contains a user with the same name.' })
+      }
+    } else if (newUsername && !returned) {
+      let duplicate_users = await User.find({ org_UUID: orgUUID, username: newUser.username})
+      console.log(duplicate_users)
+      if (duplicate_users.length) {
+        returned = true
+        return res.status(404).json({ message: 'The user could not be updated because ' + shortName + ' CNA contains a user with the same name.' })
+      }
+    } else if (newCnaShortname && !returned) {
+      let duplicate_users = await User.find({ org_UUID: newUser.org_UUID, username: username})
+      if (duplicate_users.length) {
+        returned = true
+        return res.status(404).json({ message: 'The user could not be updated because ' + newCnaShortname + ' CNA contains a user with the same name.' })
+      }
+    }
+
     if (!returned) {
       const result = await User.findOneAndUpdate().byUserNameAndOrgUUID(username, orgUUID).updateOne(newUser)
 

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -492,22 +492,21 @@ async function updateUser (req, res, next) {
       if (duplicate_users.length) {
         returned = true
         logger.info('The user could not be updated because ' + newCnaShortname + ' CNA contains a user with the same name.')
-        return res.status(404).json({ message: 'The user could not be updated because ' + newCnaShortname + ' CNA contains a user with the same name.' })
+        return res.status(403).json({ error: 'DUPLICATE_USERNAME', message: `The user could not be updated because ${newCnaShortname} CNA contains a user with the same name: ${newUsername}` })
       }
     } else if (newUsername && !returned) {
       let duplicate_users = await User.find({ org_UUID: orgUUID, username: newUser.username})
-      console.log(duplicate_users)
       if (duplicate_users.length) {
         returned = true
         logger.info('The user could not be updated because ' + shortName + ' CNA contains a user with the same name.')
-        return res.status(404).json({ message: 'The user could not be updated because ' + shortName + ' CNA contains a user with the same name.' })
+        return res.status(403).json({ error: 'DUPLICATE_USERNAME', message: `The user could not be updated because ${ShortName} CNA contains a user with the same name: ${newUsername}` })
       }
     } else if (newCnaShortname && !returned) {
       let duplicate_users = await User.find({ org_UUID: newUser.org_UUID, username: username})
       if (duplicate_users.length) {
         returned = true
         logger.info('The user could not be updated because ' + newCnaShortname + ' CNA contains a user with the same name.')
-        return res.status(404).json({ message: 'The user could not be updated because ' + newCnaShortname + ' CNA contains a user with the same name.' })
+        return res.status(403).json({ error: 'DUPLICATE_USERNAME', message: `The user could not be updated because ${newCnaShortname} CNA contains a user with the same name: ${username}` })
       }
     }
 


### PR DESCRIPTION
Functionality:

UpdateUser should return an error when a user is updated to contain the same username as another user within the same org.
