### PR TITLE
update docker readme for environment configuration

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -7,9 +7,17 @@ and Mongo) in docker containers.  Note that the current configuration is
 set to run the services in development mode. Note that these commands
 must be run from the `docker/` directory.
 
-1. Build the images:
+The docker setup uses an environment defined in `docker/.docker-env.example`
+but `docker-compose` looks for this file at `docker/.docker-env`.  The
+`docker/.docker-env` file is ignored by our `.gitignore`. This is a
+safeguard against developers committing changes to their local docker
+environment.
+
+1. Create your environment file if it doesn't already exist:
+  `cp .docker-env.example .docker-env`
+2. Build the images:
   `docker-compose build`
-2. Run the containers:
+3. Run the containers:
   `docker-compose up`
 
 ## Try It Out


### PR DESCRIPTION
A recent pull request removed the repo's `docker/.docker-env` in favor
of a `docker/.docker-env.example`, without updating `docker/docker-compose.yml`
to look for the new file. This is a safeguard against developers
committing local docker environment changes, since it forces them to
create a `docker/.docker-env` which is included in our `.gitignore`.
However, that pull request did not update `docker/README.md` with an
instruction for users to copy the environment file.