### PR TITLE
fix argon2 docker build error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,6 +7,15 @@ LABEL \
 
 WORKDIR /app
 
+# Install python/pip (required for argon2 build from source)
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
+RUN python3 -m ensurepip
+RUN pip3 install --no-cache --upgrade pip setuptools
+
+# Install build essentials (also required for argon2)
+RUN apk add --update --no-cache build-base
+
 # include the package lock so the node install "honors" it
 COPY package-lock.json /app
 COPY package.json /app

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -10,6 +10,15 @@ LABEL \
 
 WORKDIR /app
 
+# Install python/pip (required for argon2 build from source)
+ENV PYTHONUNBUFFERED=1
+RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
+RUN python3 -m ensurepip
+RUN pip3 install --no-cache --upgrade pip setuptools
+
+# Install build essentials (also required for argon2)
+RUN apk add --update --no-cache build-base
+
 # copy into development container only what we need to have
 # defined before running the application
 COPY config /app/config


### PR DESCRIPTION
Python is required and is installed first. Build tools like `make`,
`musl`, `gcc`, etc. are required and are installed with `build-base`.
