### PR TITLE
revert mongoose version after testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "helmet": "^3.21.2",
     "jsonschema": "<1.3.0",
     "kleur": "^4.1.1",
-    "mongoose": "^5.11.9",
+    "mongoose": "<=5.10.9",
     "morgan": "^1.9.1",
     "node-dev": "^4.0.0",
     "prompt-sync": "^4.2.0",


### PR DESCRIPTION
We'll still want to upgrade Mongoose to resolve our `mquery` Dependabot issue, but, not until a new method for running one-off scripts is established.