### PR TITLE
Reset api secret owning user

### DIFF
--- a/src/controller/org.controller/error.js
+++ b/src/controller/org.controller/error.js
@@ -22,6 +22,13 @@ class OrgControllerError extends idrErr.IDRError {
     return err
   }
 
+  notSameUserOrSecretariat () { // org
+    const err = {}
+    err.error = 'NOT_SAME_USER_OR_SECRETARIAT'
+    err.message = 'This information can only be viewed or modified by the Secretariat or if the requester is the user.'
+    return err
+  }
+
   orgExists (shortname) { // org
     const err = {}
     err.error = 'ORG_EXISTS'

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -85,7 +85,6 @@ router.post('/org/:shortname/user/:username',
   parsePostParams,
   controller.USER_UPDATE_SINGLE)
 router.post('/org/:shortname/user/:username/reset_secret',
-  mw.onlySecretariat,
   mw.validateUser,
   param(['shortname']).isString().trim().escape().notEmpty(),
   param(['username']).isString().trim().escape().notEmpty(),

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -111,7 +111,7 @@ async function getUsers (req, res, next) {
 
     if (orgShortName !== shortName && !isSecretariat && !returned) {
       returned = true
-      logger.info({ uuid: req.ctx.uuid, message: orgShortName + ' organization can only be viewed by the users of the same organization.' })
+      logger.info({ uuid: req.ctx.uuid, message: orgShortName + ' organization can only be viewed by the users of the same organization or the Secretariat.' })
       return res.status(403).json(error.notSameOrgOrSecretariat())
     }
 
@@ -641,6 +641,8 @@ async function updateUser (req, res, next) {
 // Resets the user secret
 async function resetSecret (req, res, next) {
   try {
+    const requesterShortName = req.ctx.org
+    const requesterUsername = req.ctx.user
     const username = req.ctx.params.username
     const orgShortName = req.ctx.params.shortname
     const newUser = new User()
@@ -650,16 +652,22 @@ async function resetSecret (req, res, next) {
     const userRepo = req.ctx.repositories.getUserRepository()
     const orgRepo = req.ctx.repositories.getOrgRepository()
     const orgUUID = await orgRepo.getOrgUUID(orgShortName) // userUUID may be null if user does not exist
+    const isSecretariat = await orgRepo.isSecretariat(requesterShortName)
 
     if (!orgUUID) {
       logger.info({ uuid: req.ctx.uuid, messsage: orgShortName + ' organization does not exist.' })
       return res.status(404).json(error.orgDneParam(orgShortName))
     }
 
-    const result = await userRepo.updateByUserNameAndOrgUUID(newUser.username, orgUUID, newUser)
-    if (result.n === 0) {
+    const user = await userRepo.updateByUserNameAndOrgUUID(newUser.username, orgUUID, newUser)
+    if (user.n === 0) {
       logger.info({ uuid: req.ctx.uuid, message: 'The user could not be updated because ' + username + ' does not exist for ' + orgShortName + ' organization.' })
       return res.status(404).json(error.userDne(username))
+    }
+
+    if ((orgShortName !== requesterShortName || username !== requesterUsername) && !isSecretariat) {
+      logger.info({ uuid: req.ctx.uuid, message: 'The api secret can only be reset by the Secretariat or if the requester is the user.' })
+      return res.status(403).json(error.notSameUserOrSecretariat())
     }
 
     logger.info({ uuid: req.ctx.uuid, message: `The API secret was successfully reset and sent to ${username}` })

--- a/test-utils/index.js
+++ b/test-utils/index.js
@@ -1,7 +1,6 @@
 const express = require('express')
 const app = express()
 const orgController = require('../src/controller/org.controller/org.controller')
-// const cveController = require('../src/controller/cve.controller/cve.controller')
 const orgParams = require('../src/controller/org.controller/org.middleware')
 const cveIdController = require('../src/controller/cve-id.controller/cve-id.controller')
 const cveIdParams = require('../src/controller/cve-id.controller/cve-id.middleware')
@@ -414,10 +413,40 @@ app.route('/user-secret-not-reset-user-doesnt-exist/:shortname/:username')
     next()
   }, orgParams.parsePostParams, orgController.USER_RESET_SECRET)
 
-app.route('/user-secret-reset/:shortname/:username')
+app.route('/user-secret-reset-sameOrg/:shortname/:username')
+  .post((req, res, next) => {
+    const factory = {
+      getOrgRepository: () => { return new repos.OrgUserSecretResetNotSecretariat() },
+      getUserRepository: () => { return new repos.UserSecretReset() }
+    }
+    req.ctx.repositories = factory
+    next()
+  }, orgParams.parsePostParams, orgController.USER_RESET_SECRET)
+
+app.route('/user-secret-reset-sameUsername/:shortname/:username')
+  .post((req, res, next) => {
+    const factory = {
+      getOrgRepository: () => { return new repos.OrgUserSecretResetNotSecretariat() },
+      getUserRepository: () => { return new repos.UserSecretReset() }
+    }
+    req.ctx.repositories = factory
+    next()
+  }, orgParams.parsePostParams, orgController.USER_RESET_SECRET)
+
+app.route('/user-secret-reset-secretariat/:shortname/:username')
   .post((req, res, next) => {
     const factory = {
       getOrgRepository: () => { return new repos.OrgUserSecretReset() },
+      getUserRepository: () => { return new repos.UserSecretReset() }
+    }
+    req.ctx.repositories = factory
+    next()
+  }, orgParams.parsePostParams, orgController.USER_RESET_SECRET)
+
+app.route('/user-secret-reset-notSameOrgOrSecretariat/:shortname/:username')
+  .post((req, res, next) => {
+    const factory = {
+      getOrgRepository: () => { return new repos.OrgUserSecretResetNotSecretariat() },
       getUserRepository: () => { return new repos.UserSecretReset() }
     }
     req.ctx.repositories = factory

--- a/test-utils/repositories.js
+++ b/test-utils/repositories.js
@@ -368,20 +368,46 @@ class OrgGetUserCveIdUpdated {
 }
 
 class OrgUserSecretNotResetOrgDoesntExist {
+  async isSecretariat () {
+    return true
+  }
+
   async getOrgUUID () {
     return null
   }
 }
 
 class OrgUserSecretNotResetUserDoesntExist {
+  async isSecretariat () {
+    return true
+  }
+
   async getOrgUUID () {
     return orgMockObj.existentOrg.UUID
   }
 }
 
 class OrgUserSecretReset {
+  async isSecretariat () {
+    return true
+  }
+
   async getOrgUUID () {
     return orgMockObj.existentOrg.UUID
+  }
+}
+
+class OrgUserSecretResetNotSecretariat {
+  async isSecretariat () {
+    return false
+  }
+
+  async getOrgUUID (shortname) {
+    if (shortname === orgMockObj.existentOrgDummy.short_name) {
+      return orgMockObj.existentOrgDummy.UUID
+    }
+
+    return orgMockObj.owningOrg.UUID
   }
 }
 
@@ -2455,8 +2481,14 @@ class UserSecretReset {
     return { n: 1, nModified: 1, ok: 1 }
   }
 
-  async getUserUUID () {
-    return orgMockObj.existentUser.UUID
+  async getUserUUID (userName, orgUUID) {
+    if (userName === orgMockObj.userC.username && orgUUID === orgMockObj.userC.org_UUID) {
+      return orgMockObj.userC.UUID
+    } else if (userName === orgMockObj.userB.username && orgUUID === orgMockObj.userB.org_UUID) {
+      return orgMockObj.userB.UUID
+    }
+
+    return orgMockObj.userA.UUID
   }
 }
 
@@ -2625,6 +2657,7 @@ module.exports = {
   OrgUserSecretNotResetOrgDoesntExist,
   OrgUserSecretNotResetUserDoesntExist,
   OrgUserSecretReset,
+  OrgUserSecretResetNotSecretariat,
   OrgGetUserOrgDoesntExist,
   OrgGetUser,
   OrgGetUserUpdated,

--- a/test/unit-tests/org/mockObjects.org.js
+++ b/test/unit-tests/org/mockObjects.org.js
@@ -24,6 +24,14 @@ const orgHeader = {
   'PAGINATOR-PAGE': CONSTANTS.PAGINATOR_PAGE
 }
 
+const userAHeader = {
+  'content-type': 'application/json',
+  'CVE-API-ORG': 'google',
+  'CVE-API-USER': 'abaker',
+  'CVE-API-KEY': 'TCF25YM-39C4H6D-KA32EGF-V5XSHN3',
+  'PAGINATOR-PAGE': CONSTANTS.PAGINATOR_PAGE
+}
+
 const existentOrg = {
   UUID: '15fd129f-af00-4d8c-8f7b-e19b0587223f',
   authority: {
@@ -198,6 +206,48 @@ const nonExistentUser = {
   active: false
 }
 
+const userA = {
+  username: 'abaker',
+  active: true,
+  name: {
+    first: 'Ashley',
+    last: 'Baker',
+    middle: 'N',
+    surname: 'Dr.',
+    suffix: 'I'
+  },
+  org_UUID: existentOrgDummy.UUID,
+  UUID: '33394284-4acf-424f-b199-9e57656ee451',
+  secret: '$argon2i$v=19$m=4096,t=3,p=1$meXeqZas6Ba2eQrIb3xbiA$x8KRFqYVuvlvsyMiUA2/hSaFbd2mxaKhEM5rXUfx9sw'
+}
+
+const userB = { // same username as userA but different org_UUID
+  username: 'abaker',
+  active: true,
+  name: {
+    first: 'Ashley',
+    last: 'Baker',
+    middle: 'N',
+    surname: 'Dr.',
+    suffix: 'I'
+  },
+  org_UUID: owningOrg.UUID,
+  UUID: '33394284-4acf-424f-b199-9e57656ff451',
+  secret: '$argon2i$v=19$m=4096,t=3,p=1$meXeqZas6Ba2eQrIb3xbiA$x8KRFqYVuvlvsyMiUA2/hSaFbd2mxaKhEM5rXUfx9sw'
+}
+
+const userC = { // same org_UUID as userA but different username
+  username: 'wbalck',
+  active: true,
+  name: {
+    first: 'William',
+    last: 'Black'
+  },
+  org_UUID: existentOrgDummy.UUID,
+  UUID: '33394284-4acf-423b-b199-9e57656ee451',
+  secret: '$argon2i$v=19$m=4096,t=3,p=1$meXeqZas6Ba2eQrIb3xbiA$x8KRFqYVuvlvsyMiUA2/hSaFbd2mxaKhEM5rXUfx9sw'
+}
+
 const allOrgs = [existentOrg, owningOrg, existentOrgDummy, existentOrgDummy2, toBeDeactivatedOrg, toBeActivatedOrg, orgWithNegativeIdQuota, orgExceedingMaxIdQuota, orgWithZeroIdQuota]
 
 const allOwningOrgUsers = [
@@ -251,10 +301,14 @@ const allOwningOrgUsers = [
 ]
 
 module.exports = {
+  userA,
+  userB,
+  userC,
   allOrgs,
   allOwningOrgUsers,
   secretariatHeader,
   owningOrgHeader,
+  userAHeader,
   orgHeader,
   owningOrg,
   existentOrg,

--- a/test/unit-tests/org/userTest.js
+++ b/test/unit-tests/org/userTest.js
@@ -3,6 +3,10 @@ const chai = require('chai')
 const expect = chai.expect
 chai.use(require('chai-http'))
 
+const userA = require('./mockObjects.org').userA
+const userB = require('./mockObjects.org').userB
+const userC = require('./mockObjects.org').userC
+const userAHeader = require('./mockObjects.org').userAHeader
 const secretariatHeader = require('./mockObjects.org').secretariatHeader
 const owningOrgHeader = require('./mockObjects.org').owningOrgHeader
 const orgHeader = require('./mockObjects.org').orgHeader
@@ -11,6 +15,7 @@ const nonExistentUser = require('./mockObjects.org').nonExistentUser
 const existentOrg = require('./mockObjects.org').existentOrg
 const owningOrg = require('./mockObjects.org').owningOrg
 const existentUserDummy = require('./mockObjects.org').existentUserDummy
+const existentOrgDummy = require('./mockObjects.org').existentOrgDummy
 const nonExistentOrg = require('./mockObjects.org').nonExistentOrg
 
 const errors = require('../../../src/controller/org.controller/error')
@@ -320,11 +325,62 @@ describe('Test user functions in Org Controller', () => {
         })
     })
 
-    it('User secret is reset', (done) => {
+    it('Requester is from same org but has different username: User secret is not reset because requester is not the same user or is the secretariat', (done) => {
       chai.request(server)
+        .post(`/user-secret-reset-sameOrg/${existentOrgDummy.short_name}/${userC.username}`) // requester has same org as user but different username
+        .set(userAHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
 
-        .post(`/user-secret-reset/${existentOrg.short_name}/${existentUser.username}`)
+          expect(res).to.have.status(403)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          const errObj = error.notSameUserOrSecretariat()
+          expect(res.body.error).to.equal(errObj.error)
+          expect(res.body.message).to.equal(errObj.message)
+          done()
+        })
+    })
+
+    it('Requester has same username but is from different org: User secret is not reset because requester is not the same user or is the secretariat', (done) => {
+      chai.request(server)
+        .post(`/user-secret-reset-sameUsername/${owningOrg.short_name}/${userB.username}`) // requester has same username as user but different org
+        .set(userAHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          expect(res).to.have.status(403)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          const errObj = error.notSameUserOrSecretariat()
+          expect(res.body.error).to.equal(errObj.error)
+          expect(res.body.message).to.equal(errObj.message)
+          done()
+        })
+    })
+
+    it('Secret is reset because requester is a secretariat', (done) => {
+      chai.request(server)
+        .post(`/user-secret-reset-secretariat/${existentOrg.short_name}/${existentUser.username}`)
         .set(secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          expect(res).to.have.status(200)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('API-secret').and.to.be.a('string')
+          done()
+        })
+    })
+
+    it('Secret is reset because requester is the user', (done) => {
+      chai.request(server)
+        .post(`/user-secret-reset-notSameOrgOrSecretariat/${existentOrgDummy.short_name}/${userA.username}`)
+        .set(userAHeader)
         .end((err, res) => {
           if (err) {
             done(err)


### PR DESCRIPTION
Resolves issue #313 

Endpoint POST /org/:shortname/user/:username/reset_secret is no longer reserved for the Secretariat.
A user's api secret can now be reset by the Secretariat or if the requester is the same user as the user who's secret is to be reset.