### PR TITLE
Adding missing access control to UR's update org endpoint

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -873,7 +873,7 @@ paths:
         500:
           description: Internal Server Error
     put: 
-      summary: Update an organization record, only allowed by [TODO].
+      summary: Update an organization record, only allowed by the Secretariat.
       operationId: orgUpdateSingle
       parameters:
         - in: query

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -30,8 +30,8 @@ router.get('/org/:shortname',
   parseGetParams,
   controller.ORG_SINGLE)
 router.put('/org/:shortname',
+  mw.onlySecretariat,
   mw.validateUser,
-  // missing permissions
   param(['shortname']).isString().trim().escape(),
   query(['shortname']).optional().isString().trim().escape().notEmpty(),
   query(['id_quota']).optional().not().isArray().isInt({ min: CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_min, max: CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_max }).withMessage('The id_quota does not comply with CVE id quota limitations.'),

--- a/test-http/src/test/org.py
+++ b/test-http/src/test/org.py
@@ -231,12 +231,10 @@ def test_put_update_mitre_org_nonexistent_user():
     tmp = copy.deepcopy(utils.BASE_HEADERS)
     tmp['CVE-API-ORG'] = uid
     tmp['CVE-API-USER'] = uid
-    print(tmp)
     res = requests.get(
         f'{env.AWG_BASE_URL}{ORG_URL}/mitre',
         headers=tmp
     )
-    print(res)
     assert res.status_code == 401
     assert res.reason == 'Unauthorized'
     response_contains_json(res, 'error', 'UNAUTHORIZED')

--- a/test-http/src/test/org.py
+++ b/test-http/src/test/org.py
@@ -225,22 +225,22 @@ def test_put_update_org_that_does_not_exist():
     response_contains_json(res, 'error', 'ORG_DNE_PARAM')
     assert_contains(res, 'by the shortname parameter does not exist')
 
-
 def test_put_update_mitre_org_nonexistent_user():
-    """ cve services api only allows mitre to update id quotas """
+    """ cve services api will fail request with from an invalid user """
     uid = str(uuid.uuid4())
     tmp = copy.deepcopy(utils.BASE_HEADERS)
     tmp['CVE-API-ORG'] = uid
     tmp['CVE-API-USER'] = uid
-    res = requests.put(
-        f'{env.AWG_BASE_URL}{ORG_URL}/mitre?id_quota=100',
+    print(tmp)
+    res = requests.get(
+        f'{env.AWG_BASE_URL}{ORG_URL}/mitre',
         headers=tmp
     )
+    print(res)
     assert res.status_code == 401
     assert res.reason == 'Unauthorized'
     response_contains_json(res, 'error', 'UNAUTHORIZED')
     response_contains_json(res, 'message', 'Unauthorized')
-
 
 def test_put_update_user_username():
     """ services api allows user usernames to be updated by secretariat """

--- a/test-http/src/test/org.py
+++ b/test-http/src/test/org.py
@@ -226,7 +226,7 @@ def test_put_update_org_that_does_not_exist():
     assert_contains(res, 'by the shortname parameter does not exist')
 
 def test_put_update_mitre_org_nonexistent_user():
-    """ cve services api will fail request with from an invalid user """
+    """ cve services api will fail requests from users that don't exist """
     uid = str(uuid.uuid4())
     tmp = copy.deepcopy(utils.BASE_HEADERS)
     tmp['CVE-API-ORG'] = uid

--- a/test-http/src/test/org_as_org_admin.py
+++ b/test-http/src/test/org_as_org_admin.py
@@ -111,6 +111,15 @@ def test_org_admin_cannot_create_another_org(org_admin_headers):
     assert res.status_code == 403
     response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
 
+def test_org_admin_cannot_update_org(org_admin_headers):
+    """ services api does not allow org admins to update their own orgs """
+    res = requests.post(
+        f'{env.AWG_BASE_URL}{ORG_URL}',
+        headers=org_admin_headers,
+        params={'name': str(uuid.uuid4())}
+    )
+    assert res.status_code == 403
+    response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
 
 def test_org_admin_cannot_create_user_for_another_org(org_admin_headers):
     """ services api prevents org admins from creating users for other orgs """
@@ -124,7 +133,6 @@ def test_org_admin_cannot_create_user_for_another_org(org_admin_headers):
     )
     assert res.status_code == 403
     response_contains_json(res, 'error', 'NOT_ORG_ADMIN_OR_SECRETARIAT')
-
 
 def test_org_admin_reset_own_secret(org_admin_headers):
     """ services api allows admin users to reset their own secret """


### PR DESCRIPTION
Updating `PUT /org/:shortname` endpoint to only be accessed by the Secretariat (i.e., only Secretariats can update an organization).
