### PR TITLE
Pip no longer fails locally by a self-signed certificate error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,11 +11,7 @@ WORKDIR /app
 ENV PYTHONUNBUFFERED=1
 RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
-RUN pip3 install \
-    --trusted-host files.pythonhosted.org \
-    --trusted-host pypi.python.org \
-    --trusted-host pypi.org \
-    --no-cache --upgrade pip setuptools
+RUN pip3 install --no-cache --upgrade pip setuptools
 
 # Install build essentials (also required for argon2)
 RUN apk add --update --no-cache build-base

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -14,11 +14,7 @@ WORKDIR /app
 ENV PYTHONUNBUFFERED=1
 RUN apk add --update --no-cache python3 && ln -sf python3 /usr/bin/python
 RUN python3 -m ensurepip
-RUN pip3 install \
-    --trusted-host files.pythonhosted.org \
-    --trusted-host pypi.python.org \
-    --trusted-host pypi.org \
-    --no-cache --upgrade pip setuptools
+RUN pip3 install --no-cache --upgrade pip setuptools
 
 # Install build essentials (also required for argon2)
 RUN apk add --update --no-cache build-base


### PR DESCRIPTION
It was known at the time that this may be a temporary fix to "maintain developer velocity" -- likewise, this rollback can be rolled-back at any time if the issue is encountered again.