### PR TITLE
update static data with new export, no reserved records

### DIFF
--- a/datadump/pre-population/cve-ids.json
+++ b/datadump/pre-population/cve-ids.json
@@ -1,3452 +1,3452 @@
 [
     {
         "requested_by": {
-            "cna": "after_3",
-            "user": "adamcox@after_3.com"
+            "cna": "whatever_18",
+            "user": "stevenvalentine@whatever_18.com"
         },
         "time": {
-            "created": "2011-04-14T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2012-06-01T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-1999-0001",
         "cve_year": 1999,
         "state": "RESERVED",
-        "owning_cna": "after_3",
-        "reserved": "2011-04-14T00:00:00.000000Z"
+        "owning_cna": "whatever_18",
+        "reserved": "2012-06-01T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "media_7",
-            "user": "emilyperez@media_7.com"
+            "cna": "from_11",
+            "user": "kimmiller@from_11.com"
         },
         "time": {
-            "created": "2017-10-19T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2021-01-30T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-1999-0002",
         "cve_year": 1999,
-        "state": "REJECT",
-        "owning_cna": "media_7",
-        "reserved": "2017-10-19T00:00:00.000000Z"
+        "state": "RESERVED",
+        "owning_cna": "from_11",
+        "reserved": "2021-01-30T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "tend_14",
-            "user": "vincentaguilar@tend_14.com"
+            "cna": "technology_4",
+            "user": "jamesvaldez@technology_4.com"
         },
         "time": {
-            "created": "2013-06-21T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2015-08-10T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-1999-0003",
         "cve_year": 1999,
-        "state": "REJECT",
-        "owning_cna": "tend_14",
-        "reserved": "2013-06-21T00:00:00.000000Z"
+        "state": "RESERVED",
+        "owning_cna": "technology_4",
+        "reserved": "2015-08-10T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "central_20",
-            "user": "shanejimenez@central_20.com"
+            "cna": "today_2",
+            "user": "franciscoanderson@today_2.com"
         },
         "time": {
-            "created": "2020-08-11T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:21.000000Z"
+            "created": "2012-06-07T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-1999-0004",
         "cve_year": 1999,
         "state": "REJECT",
-        "owning_cna": "central_20",
-        "reserved": "2020-08-11T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "tend_14",
-            "user": "vincentaguilar@tend_14.com"
-        },
-        "time": {
-            "created": "2016-12-27T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-1999-0005",
-        "cve_year": 1999,
-        "state": "REJECT",
-        "owning_cna": "tend_14",
-        "reserved": "2016-12-27T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
-        },
-        "time": {
-            "created": "2012-02-10T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-1999-0006",
-        "cve_year": 1999,
-        "state": "PUBLIC",
-        "owning_cna": "front_11",
-        "reserved": "2012-02-10T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
-        },
-        "time": {
-            "created": "2013-09-10T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-1999-0007",
-        "cve_year": 1999,
-        "state": "PUBLIC",
-        "owning_cna": "safe_15",
-        "reserved": "2013-09-10T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
-        },
-        "time": {
-            "created": "2017-05-27T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-1999-0008",
-        "cve_year": 1999,
-        "state": "RESERVED",
-        "owning_cna": "front_11",
-        "reserved": "2017-05-27T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "central_20",
-            "user": "shanejimenez@central_20.com"
-        },
-        "time": {
-            "created": "2012-01-19T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:22.000000Z"
-        },
-        "cve_id": "CVE-1999-0009",
-        "cve_year": 1999,
-        "state": "REJECT",
-        "owning_cna": "central_20",
-        "reserved": "2012-01-19T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "easy_5",
-            "user": "vernonvazquez@easy_5.com"
-        },
-        "time": {
-            "created": "2021-02-16T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-1999-0010",
-        "cve_year": 1999,
-        "state": "REJECT",
-        "owning_cna": "easy_5",
-        "reserved": "2021-02-16T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
-        },
-        "time": {
-            "created": "2013-12-22T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2000-0001",
-        "cve_year": 2000,
-        "state": "PUBLIC",
-        "owning_cna": "guy_12",
-        "reserved": "2013-12-22T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
-        },
-        "time": {
-            "created": "2017-02-03T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2000-0002",
-        "cve_year": 2000,
-        "state": "REJECT",
-        "owning_cna": "some_19",
-        "reserved": "2017-02-03T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "them_17",
-            "user": "pennyhodge@them_17.com"
-        },
-        "time": {
-            "created": "2017-05-20T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2000-0003",
-        "cve_year": 2000,
-        "state": "REJECT",
-        "owning_cna": "them_17",
-        "reserved": "2017-05-20T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "easy_5",
-            "user": "vernonvazquez@easy_5.com"
-        },
-        "time": {
-            "created": "2019-03-02T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2000-0004",
-        "cve_year": 2000,
-        "state": "REJECT",
-        "owning_cna": "easy_5",
-        "reserved": "2019-03-02T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
-        },
-        "time": {
-            "created": "2019-03-01T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2000-0005",
-        "cve_year": 2000,
-        "state": "RESERVED",
-        "owning_cna": "guy_12",
-        "reserved": "2019-03-01T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "imagine_16",
-            "user": "sherrylopez@imagine_16.com"
-        },
-        "time": {
-            "created": "2019-07-05T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2000-0006",
-        "cve_year": 2000,
-        "state": "PUBLIC",
-        "owning_cna": "imagine_16",
-        "reserved": "2019-07-05T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "media_7",
-            "user": "emilyperez@media_7.com"
-        },
-        "time": {
-            "created": "2017-02-07T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:23.000000Z"
-        },
-        "cve_id": "CVE-2000-0007",
-        "cve_year": 2000,
-        "state": "RESERVED",
-        "owning_cna": "media_7",
-        "reserved": "2017-02-07T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "reveal_18",
-            "user": "williambeck@reveal_18.com"
-        },
-        "time": {
-            "created": "2017-08-31T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2000-0008",
-        "cve_year": 2000,
-        "state": "PUBLIC",
-        "owning_cna": "reveal_18",
-        "reserved": "2017-08-31T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "them_17",
-            "user": "pennyhodge@them_17.com"
-        },
-        "time": {
-            "created": "2014-05-28T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2000-0009",
-        "cve_year": 2000,
-        "state": "PUBLIC",
-        "owning_cna": "them_17",
-        "reserved": "2014-05-28T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "them_17",
-            "user": "pennyhodge@them_17.com"
-        },
-        "time": {
-            "created": "2019-11-13T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2000-0010",
-        "cve_year": 2000,
-        "state": "RESERVED",
-        "owning_cna": "them_17",
-        "reserved": "2019-11-13T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "at_1",
-            "user": "amandawilson@at_1.com"
-        },
-        "time": {
-            "created": "2016-08-13T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:24.000000Z"
-        },
-        "cve_id": "CVE-2001-0001",
-        "cve_year": 2001,
-        "state": "REJECT",
-        "owning_cna": "at_1",
-        "reserved": "2016-08-13T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
-        },
-        "time": {
-            "created": "2015-02-26T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2001-0002",
-        "cve_year": 2001,
-        "state": "RESERVED",
-        "owning_cna": "guy_12",
-        "reserved": "2015-02-26T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "media_7",
-            "user": "emilyperez@media_7.com"
-        },
-        "time": {
-            "created": "2016-09-17T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2001-0003",
-        "cve_year": 2001,
-        "state": "REJECT",
-        "owning_cna": "media_7",
-        "reserved": "2016-09-17T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
-        },
-        "time": {
-            "created": "2013-07-24T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2001-0004",
-        "cve_year": 2001,
-        "state": "REJECT",
-        "owning_cna": "front_11",
-        "reserved": "2013-07-24T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "central_20",
-            "user": "shanejimenez@central_20.com"
-        },
-        "time": {
-            "created": "2016-05-24T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2001-0005",
-        "cve_year": 2001,
-        "state": "PUBLIC",
-        "owning_cna": "central_20",
-        "reserved": "2016-05-24T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "at_1",
-            "user": "amandawilson@at_1.com"
-        },
-        "time": {
-            "created": "2014-03-31T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:25.000000Z"
-        },
-        "cve_id": "CVE-2001-0006",
-        "cve_year": 2001,
-        "state": "RESERVED",
-        "owning_cna": "at_1",
-        "reserved": "2014-03-31T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "attorney_13",
-            "user": "jessicaburnett@attorney_13.com"
-        },
-        "time": {
-            "created": "2019-06-10T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2001-0007",
-        "cve_year": 2001,
-        "state": "PUBLIC",
-        "owning_cna": "attorney_13",
-        "reserved": "2019-06-10T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "pressure_10",
-            "user": "christophersteele@pressure_10.com"
-        },
-        "time": {
-            "created": "2013-12-25T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:25.000000Z"
-        },
-        "cve_id": "CVE-2001-0008",
-        "cve_year": 2001,
-        "state": "REJECT",
-        "owning_cna": "pressure_10",
-        "reserved": "2013-12-25T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "either_4",
-            "user": "jeremiahlloyd@either_4.com"
-        },
-        "time": {
-            "created": "2013-11-05T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2001-0009",
-        "cve_year": 2001,
-        "state": "RESERVED",
-        "owning_cna": "either_4",
-        "reserved": "2013-11-05T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "tend_14",
-            "user": "vincentaguilar@tend_14.com"
-        },
-        "time": {
-            "created": "2012-10-08T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2001-0010",
-        "cve_year": 2001,
-        "state": "REJECT",
-        "owning_cna": "tend_14",
-        "reserved": "2012-10-08T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "at_1",
-            "user": "amandawilson@at_1.com"
-        },
-        "time": {
-            "created": "2019-01-30T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:26.000000Z"
-        },
-        "cve_id": "CVE-2002-0001",
-        "cve_year": 2002,
-        "state": "RESERVED",
-        "owning_cna": "at_1",
-        "reserved": "2019-01-30T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "either_4",
-            "user": "jeremiahlloyd@either_4.com"
-        },
-        "time": {
-            "created": "2013-06-01T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2002-0002",
-        "cve_year": 2002,
-        "state": "REJECT",
-        "owning_cna": "either_4",
-        "reserved": "2013-06-01T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
-        },
-        "time": {
-            "created": "2018-11-14T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2002-0003",
-        "cve_year": 2002,
-        "state": "RESERVED",
-        "owning_cna": "guy_12",
-        "reserved": "2018-11-14T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "after_3",
-            "user": "adamcox@after_3.com"
-        },
-        "time": {
-            "created": "2016-07-22T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2002-0004",
-        "cve_year": 2002,
-        "state": "PUBLIC",
-        "owning_cna": "after_3",
-        "reserved": "2016-07-22T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
-        },
-        "time": {
-            "created": "2016-12-26T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2002-0005",
-        "cve_year": 2002,
-        "state": "RESERVED",
-        "owning_cna": "some_19",
-        "reserved": "2016-12-26T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
-        },
-        "time": {
-            "created": "2020-08-30T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2002-0006",
-        "cve_year": 2002,
-        "state": "RESERVED",
-        "owning_cna": "safe_15",
-        "reserved": "2020-08-30T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "central_20",
-            "user": "shanejimenez@central_20.com"
-        },
-        "time": {
-            "created": "2020-12-21T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2002-0007",
-        "cve_year": 2002,
-        "state": "PUBLIC",
-        "owning_cna": "central_20",
-        "reserved": "2020-12-21T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
-        },
-        "time": {
-            "created": "2016-07-20T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2002-0008",
-        "cve_year": 2002,
-        "state": "RESERVED",
-        "owning_cna": "front_11",
-        "reserved": "2016-07-20T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "at_1",
-            "user": "amandawilson@at_1.com"
-        },
-        "time": {
-            "created": "2012-08-21T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2002-0009",
-        "cve_year": 2002,
-        "state": "REJECT",
-        "owning_cna": "at_1",
-        "reserved": "2012-08-21T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "pressure_10",
-            "user": "christophersteele@pressure_10.com"
-        },
-        "time": {
-            "created": "2017-12-09T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:27.000000Z"
-        },
-        "cve_id": "CVE-2002-0010",
-        "cve_year": 2002,
-        "state": "RESERVED",
-        "owning_cna": "pressure_10",
-        "reserved": "2017-12-09T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
-        },
-        "time": {
-            "created": "2019-11-24T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2003-0001",
-        "cve_year": 2003,
-        "state": "PUBLIC",
-        "owning_cna": "some_19",
-        "reserved": "2019-11-24T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
-        },
-        "time": {
-            "created": "2020-11-27T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2003-0002",
-        "cve_year": 2003,
-        "state": "PUBLIC",
-        "owning_cna": "some_19",
-        "reserved": "2020-11-27T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "left_2",
-            "user": "josephleon@left_2.com"
-        },
-        "time": {
-            "created": "2015-05-08T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2003-0003",
-        "cve_year": 2003,
-        "state": "RESERVED",
-        "owning_cna": "left_2",
-        "reserved": "2015-05-08T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "at_1",
-            "user": "amandawilson@at_1.com"
-        },
-        "time": {
-            "created": "2021-03-03T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2003-0004",
-        "cve_year": 2003,
-        "state": "RESERVED",
-        "owning_cna": "at_1",
-        "reserved": "2021-03-03T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "imagine_16",
-            "user": "sherrylopez@imagine_16.com"
-        },
-        "time": {
-            "created": "2020-06-05T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2003-0005",
-        "cve_year": 2003,
-        "state": "PUBLIC",
-        "owning_cna": "imagine_16",
-        "reserved": "2020-06-05T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "either_4",
-            "user": "jeremiahlloyd@either_4.com"
-        },
-        "time": {
-            "created": "2012-06-04T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2003-0006",
-        "cve_year": 2003,
-        "state": "RESERVED",
-        "owning_cna": "either_4",
-        "reserved": "2012-06-04T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "imagine_16",
-            "user": "sherrylopez@imagine_16.com"
-        },
-        "time": {
-            "created": "2016-03-10T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:28.000000Z"
-        },
-        "cve_id": "CVE-2003-0007",
-        "cve_year": 2003,
-        "state": "REJECT",
-        "owning_cna": "imagine_16",
-        "reserved": "2016-03-10T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "best_8",
-            "user": "melanietaylor@best_8.com"
-        },
-        "time": {
-            "created": "2016-09-12T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2003-0008",
-        "cve_year": 2003,
-        "state": "REJECT",
-        "owning_cna": "best_8",
-        "reserved": "2016-09-12T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "mitre",
-            "user": "angelajohnson@mitre.com"
-        },
-        "time": {
-            "created": "2020-02-12T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2003-0009",
-        "cve_year": 2003,
-        "state": "REJECT",
-        "owning_cna": "mitre",
-        "reserved": "2020-02-12T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "central_20",
-            "user": "shanejimenez@central_20.com"
-        },
-        "time": {
-            "created": "2019-10-15T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:29.000000Z"
-        },
-        "cve_id": "CVE-2003-0010",
-        "cve_year": 2003,
-        "state": "RESERVED",
-        "owning_cna": "central_20",
-        "reserved": "2019-10-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "pressure_10",
-            "user": "christophersteele@pressure_10.com"
-        },
-        "time": {
-            "created": "2018-12-01T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2004-0001",
-        "cve_year": 2004,
-        "state": "RESERVED",
-        "owning_cna": "pressure_10",
-        "reserved": "2018-12-01T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
-        },
-        "time": {
-            "created": "2015-11-23T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2004-0002",
-        "cve_year": 2004,
-        "state": "RESERVED",
-        "owning_cna": "guy_12",
-        "reserved": "2015-11-23T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "reveal_18",
-            "user": "williambeck@reveal_18.com"
-        },
-        "time": {
-            "created": "2014-11-17T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2004-0003",
-        "cve_year": 2004,
-        "state": "REJECT",
-        "owning_cna": "reveal_18",
-        "reserved": "2014-11-17T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "left_2",
-            "user": "josephleon@left_2.com"
-        },
-        "time": {
-            "created": "2016-07-19T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2004-0004",
-        "cve_year": 2004,
-        "state": "RESERVED",
-        "owning_cna": "left_2",
-        "reserved": "2016-07-19T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "probably_6",
-            "user": "nicholaswhite@probably_6.com"
-        },
-        "time": {
-            "created": "2019-11-26T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2004-0005",
-        "cve_year": 2004,
-        "state": "RESERVED",
-        "owning_cna": "probably_6",
-        "reserved": "2019-11-26T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "imagine_16",
-            "user": "sherrylopez@imagine_16.com"
-        },
-        "time": {
-            "created": "2016-05-19T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2004-0006",
-        "cve_year": 2004,
-        "state": "PUBLIC",
-        "owning_cna": "imagine_16",
-        "reserved": "2016-05-19T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "after_3",
-            "user": "adamcox@after_3.com"
-        },
-        "time": {
-            "created": "2011-08-07T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2004-0007",
-        "cve_year": 2004,
-        "state": "PUBLIC",
-        "owning_cna": "after_3",
-        "reserved": "2011-08-07T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "probably_6",
-            "user": "nicholaswhite@probably_6.com"
-        },
-        "time": {
-            "created": "2018-12-08T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2004-0008",
-        "cve_year": 2004,
-        "state": "RESERVED",
-        "owning_cna": "probably_6",
-        "reserved": "2018-12-08T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
-        },
-        "time": {
-            "created": "2012-01-21T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2004-0009",
-        "cve_year": 2004,
-        "state": "RESERVED",
-        "owning_cna": "some_19",
-        "reserved": "2012-01-21T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "at_1",
-            "user": "amandawilson@at_1.com"
-        },
-        "time": {
-            "created": "2016-08-07T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:30.000000Z"
-        },
-        "cve_id": "CVE-2004-0010",
-        "cve_year": 2004,
-        "state": "REJECT",
-        "owning_cna": "at_1",
-        "reserved": "2016-08-07T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "pressure_10",
-            "user": "christophersteele@pressure_10.com"
-        },
-        "time": {
-            "created": "2012-09-01T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:30.000000Z"
-        },
-        "cve_id": "CVE-2005-0001",
-        "cve_year": 2005,
-        "state": "REJECT",
-        "owning_cna": "pressure_10",
-        "reserved": "2012-09-01T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
-        },
-        "time": {
-            "created": "2012-11-27T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:31.000000Z"
-        },
-        "cve_id": "CVE-2005-0002",
-        "cve_year": 2005,
-        "state": "RESERVED",
-        "owning_cna": "front_11",
-        "reserved": "2012-11-27T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "either_4",
-            "user": "jeremiahlloyd@either_4.com"
-        },
-        "time": {
-            "created": "2012-07-21T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:31.000000Z"
-        },
-        "cve_id": "CVE-2005-0003",
-        "cve_year": 2005,
-        "state": "RESERVED",
-        "owning_cna": "either_4",
-        "reserved": "2012-07-21T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "probably_6",
-            "user": "nicholaswhite@probably_6.com"
-        },
-        "time": {
-            "created": "2013-10-15T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2005-0004",
-        "cve_year": 2005,
-        "state": "REJECT",
-        "owning_cna": "probably_6",
-        "reserved": "2013-10-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
-        },
-        "time": {
-            "created": "2015-12-15T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2005-0005",
-        "cve_year": 2005,
-        "state": "RESERVED",
-        "owning_cna": "some_19",
-        "reserved": "2015-12-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
-        },
-        "time": {
-            "created": "2016-06-13T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2005-0006",
-        "cve_year": 2005,
-        "state": "REJECT",
-        "owning_cna": "front_11",
-        "reserved": "2016-06-13T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
-        },
-        "time": {
-            "created": "2015-12-16T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2005-0007",
-        "cve_year": 2005,
-        "state": "REJECT",
-        "owning_cna": "some_19",
-        "reserved": "2015-12-16T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "media_7",
-            "user": "emilyperez@media_7.com"
-        },
-        "time": {
-            "created": "2019-06-29T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2005-0008",
-        "cve_year": 2005,
-        "state": "RESERVED",
-        "owning_cna": "media_7",
-        "reserved": "2019-06-29T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
-        },
-        "time": {
-            "created": "2017-08-20T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2005-0009",
-        "cve_year": 2005,
-        "state": "PUBLIC",
-        "owning_cna": "front_11",
-        "reserved": "2017-08-20T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "television_9",
-            "user": "marybond@television_9.com"
-        },
-        "time": {
-            "created": "2016-02-06T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2005-0010",
-        "cve_year": 2005,
-        "state": "RESERVED",
-        "owning_cna": "television_9",
-        "reserved": "2016-02-06T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "imagine_16",
-            "user": "sherrylopez@imagine_16.com"
-        },
-        "time": {
-            "created": "2018-12-02T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2006-0001",
-        "cve_year": 2006,
-        "state": "PUBLIC",
-        "owning_cna": "imagine_16",
-        "reserved": "2018-12-02T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "media_7",
-            "user": "emilyperez@media_7.com"
-        },
-        "time": {
-            "created": "2011-09-20T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:33.000000Z"
-        },
-        "cve_id": "CVE-2006-0002",
-        "cve_year": 2006,
-        "state": "PUBLIC",
-        "owning_cna": "media_7",
-        "reserved": "2011-09-20T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "imagine_16",
-            "user": "sherrylopez@imagine_16.com"
-        },
-        "time": {
-            "created": "2012-04-18T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2006-0003",
-        "cve_year": 2006,
-        "state": "RESERVED",
-        "owning_cna": "imagine_16",
-        "reserved": "2012-04-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
-        },
-        "time": {
-            "created": "2015-07-24T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:33.000000Z"
-        },
-        "cve_id": "CVE-2006-0004",
-        "cve_year": 2006,
-        "state": "RESERVED",
-        "owning_cna": "safe_15",
-        "reserved": "2015-07-24T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "pressure_10",
-            "user": "christophersteele@pressure_10.com"
-        },
-        "time": {
-            "created": "2017-08-21T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2006-0005",
-        "cve_year": 2006,
-        "state": "PUBLIC",
-        "owning_cna": "pressure_10",
-        "reserved": "2017-08-21T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "at_1",
-            "user": "amandawilson@at_1.com"
-        },
-        "time": {
-            "created": "2016-05-18T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2006-0006",
-        "cve_year": 2006,
-        "state": "RESERVED",
-        "owning_cna": "at_1",
-        "reserved": "2016-05-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
-        },
-        "time": {
-            "created": "2016-08-05T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2006-0007",
-        "cve_year": 2006,
-        "state": "RESERVED",
-        "owning_cna": "front_11",
-        "reserved": "2016-08-05T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "pressure_10",
-            "user": "christophersteele@pressure_10.com"
-        },
-        "time": {
-            "created": "2012-03-05T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2006-0008",
-        "cve_year": 2006,
-        "state": "RESERVED",
-        "owning_cna": "pressure_10",
-        "reserved": "2012-03-05T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "television_9",
-            "user": "marybond@television_9.com"
-        },
-        "time": {
-            "created": "2013-09-25T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2006-0009",
-        "cve_year": 2006,
-        "state": "REJECT",
-        "owning_cna": "television_9",
-        "reserved": "2013-09-25T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "either_4",
-            "user": "jeremiahlloyd@either_4.com"
-        },
-        "time": {
-            "created": "2013-08-08T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2006-0010",
-        "cve_year": 2006,
-        "state": "PUBLIC",
-        "owning_cna": "either_4",
-        "reserved": "2013-08-08T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "tend_14",
-            "user": "vincentaguilar@tend_14.com"
-        },
-        "time": {
-            "created": "2012-02-11T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2007-0001",
-        "cve_year": 2007,
-        "state": "RESERVED",
-        "owning_cna": "tend_14",
-        "reserved": "2012-02-11T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "television_9",
-            "user": "marybond@television_9.com"
-        },
-        "time": {
-            "created": "2020-12-29T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2007-0002",
-        "cve_year": 2007,
-        "state": "RESERVED",
-        "owning_cna": "television_9",
-        "reserved": "2020-12-29T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
-        },
-        "time": {
-            "created": "2015-06-15T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:35.000000Z"
-        },
-        "cve_id": "CVE-2007-0003",
-        "cve_year": 2007,
-        "state": "RESERVED",
-        "owning_cna": "safe_15",
-        "reserved": "2015-06-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
-        },
-        "time": {
-            "created": "2016-05-01T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2007-0004",
-        "cve_year": 2007,
-        "state": "RESERVED",
-        "owning_cna": "safe_15",
-        "reserved": "2016-05-01T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "media_7",
-            "user": "emilyperez@media_7.com"
-        },
-        "time": {
-            "created": "2015-12-16T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2007-0005",
-        "cve_year": 2007,
-        "state": "PUBLIC",
-        "owning_cna": "media_7",
-        "reserved": "2015-12-16T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
-        },
-        "time": {
-            "created": "2011-12-09T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2007-0006",
-        "cve_year": 2007,
-        "state": "PUBLIC",
-        "owning_cna": "front_11",
-        "reserved": "2011-12-09T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
-        },
-        "time": {
-            "created": "2019-06-24T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2007-0007",
-        "cve_year": 2007,
-        "state": "PUBLIC",
-        "owning_cna": "safe_15",
-        "reserved": "2019-06-24T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "probably_6",
-            "user": "nicholaswhite@probably_6.com"
-        },
-        "time": {
-            "created": "2015-08-27T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2007-0008",
-        "cve_year": 2007,
-        "state": "RESERVED",
-        "owning_cna": "probably_6",
-        "reserved": "2015-08-27T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "after_3",
-            "user": "adamcox@after_3.com"
-        },
-        "time": {
-            "created": "2018-09-26T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2007-0009",
-        "cve_year": 2007,
-        "state": "PUBLIC",
-        "owning_cna": "after_3",
-        "reserved": "2018-09-26T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "after_3",
-            "user": "adamcox@after_3.com"
-        },
-        "time": {
-            "created": "2013-09-02T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2007-0010",
-        "cve_year": 2007,
-        "state": "REJECT",
-        "owning_cna": "after_3",
-        "reserved": "2013-09-02T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "best_8",
-            "user": "melanietaylor@best_8.com"
-        },
-        "time": {
-            "created": "2019-01-07T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2008-0001",
-        "cve_year": 2008,
-        "state": "REJECT",
-        "owning_cna": "best_8",
-        "reserved": "2019-01-07T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "easy_5",
-            "user": "vernonvazquez@easy_5.com"
-        },
-        "time": {
-            "created": "2015-01-21T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2008-0002",
-        "cve_year": 2008,
-        "state": "RESERVED",
-        "owning_cna": "easy_5",
-        "reserved": "2015-01-21T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "attorney_13",
-            "user": "jessicaburnett@attorney_13.com"
-        },
-        "time": {
-            "created": "2018-11-22T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2008-0003",
-        "cve_year": 2008,
-        "state": "REJECT",
-        "owning_cna": "attorney_13",
-        "reserved": "2018-11-22T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
-        },
-        "time": {
-            "created": "2011-12-01T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2008-0004",
-        "cve_year": 2008,
-        "state": "PUBLIC",
-        "owning_cna": "front_11",
-        "reserved": "2011-12-01T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
-        },
-        "time": {
-            "created": "2015-10-25T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:37.000000Z"
-        },
-        "cve_id": "CVE-2008-0005",
-        "cve_year": 2008,
-        "state": "REJECT",
-        "owning_cna": "guy_12",
-        "reserved": "2015-10-25T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "left_2",
-            "user": "josephleon@left_2.com"
-        },
-        "time": {
-            "created": "2017-11-05T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2008-0006",
-        "cve_year": 2008,
-        "state": "REJECT",
-        "owning_cna": "left_2",
-        "reserved": "2017-11-05T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
-        },
-        "time": {
-            "created": "2017-06-18T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2008-0007",
-        "cve_year": 2008,
-        "state": "REJECT",
-        "owning_cna": "front_11",
-        "reserved": "2017-06-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "television_9",
-            "user": "marybond@television_9.com"
-        },
-        "time": {
-            "created": "2017-10-22T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2008-0008",
-        "cve_year": 2008,
-        "state": "RESERVED",
-        "owning_cna": "television_9",
-        "reserved": "2017-10-22T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "easy_5",
-            "user": "vernonvazquez@easy_5.com"
-        },
-        "time": {
-            "created": "2017-12-29T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2008-0009",
-        "cve_year": 2008,
-        "state": "PUBLIC",
-        "owning_cna": "easy_5",
-        "reserved": "2017-12-29T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
-        },
-        "time": {
-            "created": "2011-06-23T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2008-0010",
-        "cve_year": 2008,
-        "state": "RESERVED",
-        "owning_cna": "safe_15",
-        "reserved": "2011-06-23T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "reveal_18",
-            "user": "williambeck@reveal_18.com"
-        },
-        "time": {
-            "created": "2019-06-21T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:37.000000Z"
-        },
-        "cve_id": "CVE-2009-0001",
-        "cve_year": 2009,
-        "state": "RESERVED",
-        "owning_cna": "reveal_18",
-        "reserved": "2019-06-21T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "left_2",
-            "user": "josephleon@left_2.com"
-        },
-        "time": {
-            "created": "2019-12-26T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:38.000000Z"
-        },
-        "cve_id": "CVE-2009-0002",
-        "cve_year": 2009,
-        "state": "PUBLIC",
-        "owning_cna": "left_2",
-        "reserved": "2019-12-26T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "attorney_13",
-            "user": "jessicaburnett@attorney_13.com"
-        },
-        "time": {
-            "created": "2013-12-30T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2009-0003",
-        "cve_year": 2009,
-        "state": "REJECT",
-        "owning_cna": "attorney_13",
-        "reserved": "2013-12-30T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "probably_6",
-            "user": "nicholaswhite@probably_6.com"
-        },
-        "time": {
-            "created": "2015-06-27T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:38.000000Z"
-        },
-        "cve_id": "CVE-2009-0004",
-        "cve_year": 2009,
-        "state": "REJECT",
-        "owning_cna": "probably_6",
-        "reserved": "2015-06-27T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "television_9",
-            "user": "marybond@television_9.com"
-        },
-        "time": {
-            "created": "2018-06-12T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2009-0005",
-        "cve_year": 2009,
-        "state": "REJECT",
-        "owning_cna": "television_9",
-        "reserved": "2018-06-12T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
-        },
-        "time": {
-            "created": "2013-10-19T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2009-0006",
-        "cve_year": 2009,
-        "state": "RESERVED",
-        "owning_cna": "front_11",
-        "reserved": "2013-10-19T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "television_9",
-            "user": "marybond@television_9.com"
-        },
-        "time": {
-            "created": "2013-06-29T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2009-0007",
-        "cve_year": 2009,
-        "state": "RESERVED",
-        "owning_cna": "television_9",
-        "reserved": "2013-06-29T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "after_3",
-            "user": "adamcox@after_3.com"
-        },
-        "time": {
-            "created": "2016-02-23T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2009-0008",
-        "cve_year": 2009,
-        "state": "RESERVED",
-        "owning_cna": "after_3",
-        "reserved": "2016-02-23T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
-        },
-        "time": {
-            "created": "2019-12-01T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:39.000000Z"
-        },
-        "cve_id": "CVE-2009-0009",
-        "cve_year": 2009,
-        "state": "REJECT",
-        "owning_cna": "safe_15",
-        "reserved": "2019-12-01T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "television_9",
-            "user": "marybond@television_9.com"
-        },
-        "time": {
-            "created": "2020-03-14T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:39.000000Z"
-        },
-        "cve_id": "CVE-2009-0010",
-        "cve_year": 2009,
-        "state": "PUBLIC",
-        "owning_cna": "television_9",
-        "reserved": "2020-03-14T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "at_1",
-            "user": "amandawilson@at_1.com"
-        },
-        "time": {
-            "created": "2018-07-16T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2010-0001",
-        "cve_year": 2010,
-        "state": "REJECT",
-        "owning_cna": "at_1",
-        "reserved": "2018-07-16T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
-        },
-        "time": {
-            "created": "2012-06-07T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2010-0002",
-        "cve_year": 2010,
-        "state": "RESERVED",
-        "owning_cna": "some_19",
+        "owning_cna": "today_2",
         "reserved": "2012-06-07T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "media_7",
-            "user": "emilyperez@media_7.com"
+            "cna": "man_5",
+            "user": "jeffreyfigueroa@man_5.com"
         },
         "time": {
-            "created": "2016-05-24T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:39.000000Z"
+            "created": "2011-04-22T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:20.000000Z"
         },
-        "cve_id": "CVE-2010-0003",
-        "cve_year": 2010,
+        "cve_id": "CVE-1999-0005",
+        "cve_year": 1999,
         "state": "RESERVED",
-        "owning_cna": "media_7",
-        "reserved": "2016-05-24T00:00:00.000000Z"
+        "owning_cna": "man_5",
+        "reserved": "2011-04-22T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "them_17",
-            "user": "pennyhodge@them_17.com"
+            "cna": "technology_4",
+            "user": "jamesvaldez@technology_4.com"
         },
         "time": {
-            "created": "2013-01-17T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2020-03-31T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2010-0004",
-        "cve_year": 2010,
-        "state": "RESERVED",
-        "owning_cna": "them_17",
-        "reserved": "2013-01-17T00:00:00.000000Z"
+        "cve_id": "CVE-1999-0006",
+        "cve_year": 1999,
+        "state": "REJECT",
+        "owning_cna": "technology_4",
+        "reserved": "2020-03-31T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "imagine_16",
-            "user": "sherrylopez@imagine_16.com"
+            "cna": "difference_16",
+            "user": "rebeccahenry@difference_16.com"
         },
         "time": {
-            "created": "2020-06-20T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2011-09-06T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2010-0005",
-        "cve_year": 2010,
+        "cve_id": "CVE-1999-0007",
+        "cve_year": 1999,
+        "state": "RESERVED",
+        "owning_cna": "difference_16",
+        "reserved": "2011-09-06T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "certain_10",
+            "user": "williammorris@certain_10.com"
+        },
+        "time": {
+            "created": "2018-08-20T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-1999-0008",
+        "cve_year": 1999,
+        "state": "RESERVED",
+        "owning_cna": "certain_10",
+        "reserved": "2018-08-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "accept_19",
+            "user": "stephenjohnson@accept_19.com"
+        },
+        "time": {
+            "created": "2013-08-09T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-1999-0009",
+        "cve_year": 1999,
+        "state": "REJECT",
+        "owning_cna": "accept_19",
+        "reserved": "2013-08-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "from_11",
+            "user": "kimmiller@from_11.com"
+        },
+        "time": {
+            "created": "2015-09-20T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-1999-0010",
+        "cve_year": 1999,
         "state": "PUBLIC",
-        "owning_cna": "imagine_16",
-        "reserved": "2020-06-20T00:00:00.000000Z"
+        "owning_cna": "from_11",
+        "reserved": "2015-09-20T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "after_3",
-            "user": "adamcox@after_3.com"
+            "cna": "song_3",
+            "user": "sandrabrown@song_3.com"
         },
         "time": {
-            "created": "2018-06-25T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2013-04-10T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:21.000000Z"
         },
-        "cve_id": "CVE-2010-0006",
-        "cve_year": 2010,
+        "cve_id": "CVE-2000-0001",
+        "cve_year": 2000,
+        "state": "REJECT",
+        "owning_cna": "song_3",
+        "reserved": "2013-04-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "accept_19",
+            "user": "stephenjohnson@accept_19.com"
+        },
+        "time": {
+            "created": "2019-11-30T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2000-0002",
+        "cve_year": 2000,
+        "state": "REJECT",
+        "owning_cna": "accept_19",
+        "reserved": "2019-11-30T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
+        },
+        "time": {
+            "created": "2017-07-15T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:21.000000Z"
+        },
+        "cve_id": "CVE-2000-0003",
+        "cve_year": 2000,
         "state": "RESERVED",
-        "owning_cna": "after_3",
-        "reserved": "2018-06-25T00:00:00.000000Z"
+        "owning_cna": "magazine_15",
+        "reserved": "2017-07-15T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "tend_14",
-            "user": "vincentaguilar@tend_14.com"
+            "cna": "difference_16",
+            "user": "rebeccahenry@difference_16.com"
         },
         "time": {
-            "created": "2012-03-15T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:40.000000Z"
+            "created": "2015-02-16T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2010-0007",
-        "cve_year": 2010,
+        "cve_id": "CVE-2000-0004",
+        "cve_year": 2000,
+        "state": "RESERVED",
+        "owning_cna": "difference_16",
+        "reserved": "2015-02-16T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "certain_10",
+            "user": "williammorris@certain_10.com"
+        },
+        "time": {
+            "created": "2011-07-10T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2000-0005",
+        "cve_year": 2000,
         "state": "PUBLIC",
-        "owning_cna": "tend_14",
-        "reserved": "2012-03-15T00:00:00.000000Z"
+        "owning_cna": "certain_10",
+        "reserved": "2011-07-10T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
         },
         "time": {
-            "created": "2014-05-05T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2019-10-19T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:22.000000Z"
         },
-        "cve_id": "CVE-2010-0008",
-        "cve_year": 2010,
-        "state": "RESERVED",
-        "owning_cna": "guy_12",
-        "reserved": "2014-05-05T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "after_3",
-            "user": "adamcox@after_3.com"
-        },
-        "time": {
-            "created": "2020-10-30T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2010-0009",
-        "cve_year": 2010,
+        "cve_id": "CVE-2000-0006",
+        "cve_year": 2000,
         "state": "REJECT",
-        "owning_cna": "after_3",
-        "reserved": "2020-10-30T00:00:00.000000Z"
+        "owning_cna": "only_6",
+        "reserved": "2019-10-19T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
+            "cna": "ok_17",
+            "user": "dominiquefrench@ok_17.com"
         },
         "time": {
-            "created": "2017-02-15T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2016-02-22T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2010-0010",
-        "cve_year": 2010,
-        "state": "RESERVED",
-        "owning_cna": "some_19",
-        "reserved": "2017-02-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
-        },
-        "time": {
-            "created": "2016-07-30T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2011-0001",
-        "cve_year": 2011,
-        "state": "RESERVED",
-        "owning_cna": "some_19",
-        "reserved": "2016-07-30T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "attorney_13",
-            "user": "jessicaburnett@attorney_13.com"
-        },
-        "time": {
-            "created": "2017-02-23T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2011-0002",
-        "cve_year": 2011,
-        "state": "RESERVED",
-        "owning_cna": "attorney_13",
-        "reserved": "2017-02-23T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "them_17",
-            "user": "pennyhodge@them_17.com"
-        },
-        "time": {
-            "created": "2012-08-10T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:41.000000Z"
-        },
-        "cve_id": "CVE-2011-0003",
-        "cve_year": 2011,
-        "state": "RESERVED",
-        "owning_cna": "them_17",
-        "reserved": "2012-08-10T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "tend_14",
-            "user": "vincentaguilar@tend_14.com"
-        },
-        "time": {
-            "created": "2019-04-28T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2011-0004",
-        "cve_year": 2011,
-        "state": "RESERVED",
-        "owning_cna": "tend_14",
-        "reserved": "2019-04-28T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "television_9",
-            "user": "marybond@television_9.com"
-        },
-        "time": {
-            "created": "2018-04-12T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2011-0005",
-        "cve_year": 2011,
-        "state": "REJECT",
-        "owning_cna": "television_9",
-        "reserved": "2018-04-12T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "attorney_13",
-            "user": "jessicaburnett@attorney_13.com"
-        },
-        "time": {
-            "created": "2020-07-28T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2011-0006",
-        "cve_year": 2011,
-        "state": "RESERVED",
-        "owning_cna": "attorney_13",
-        "reserved": "2020-07-28T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "easy_5",
-            "user": "vernonvazquez@easy_5.com"
-        },
-        "time": {
-            "created": "2021-02-20T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:42.000000Z"
-        },
-        "cve_id": "CVE-2011-0007",
-        "cve_year": 2011,
+        "cve_id": "CVE-2000-0007",
+        "cve_year": 2000,
         "state": "PUBLIC",
-        "owning_cna": "easy_5",
-        "reserved": "2021-02-20T00:00:00.000000Z"
+        "owning_cna": "ok_17",
+        "reserved": "2016-02-22T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
+            "cna": "ok_17",
+            "user": "dominiquefrench@ok_17.com"
         },
         "time": {
-            "created": "2013-04-19T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:42.000000Z"
+            "created": "2017-01-09T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2011-0008",
-        "cve_year": 2011,
+        "cve_id": "CVE-2000-0008",
+        "cve_year": 2000,
         "state": "RESERVED",
-        "owning_cna": "some_19",
-        "reserved": "2013-04-19T00:00:00.000000Z"
+        "owning_cna": "ok_17",
+        "reserved": "2017-01-09T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "either_4",
-            "user": "jeremiahlloyd@either_4.com"
+            "cna": "whatever_18",
+            "user": "stevenvalentine@whatever_18.com"
         },
         "time": {
-            "created": "2018-11-25T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2012-01-13T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:22.000000Z"
         },
-        "cve_id": "CVE-2011-0009",
-        "cve_year": 2011,
-        "state": "REJECT",
-        "owning_cna": "either_4",
-        "reserved": "2018-11-25T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "them_17",
-            "user": "pennyhodge@them_17.com"
-        },
-        "time": {
-            "created": "2019-07-31T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:42.000000Z"
-        },
-        "cve_id": "CVE-2011-0010",
-        "cve_year": 2011,
-        "state": "RESERVED",
-        "owning_cna": "them_17",
-        "reserved": "2019-07-31T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "imagine_16",
-            "user": "sherrylopez@imagine_16.com"
-        },
-        "time": {
-            "created": "2019-03-14T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:43.000000Z"
-        },
-        "cve_id": "CVE-2012-0001",
-        "cve_year": 2012,
-        "state": "REJECT",
-        "owning_cna": "imagine_16",
-        "reserved": "2019-03-14T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "left_2",
-            "user": "josephleon@left_2.com"
-        },
-        "time": {
-            "created": "2021-02-21T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2012-0002",
-        "cve_year": 2012,
-        "state": "RESERVED",
-        "owning_cna": "left_2",
-        "reserved": "2021-02-21T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "reveal_18",
-            "user": "williambeck@reveal_18.com"
-        },
-        "time": {
-            "created": "2016-01-02T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2012-0003",
-        "cve_year": 2012,
-        "state": "RESERVED",
-        "owning_cna": "reveal_18",
-        "reserved": "2016-01-02T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
-        },
-        "time": {
-            "created": "2015-06-03T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:43.000000Z"
-        },
-        "cve_id": "CVE-2012-0004",
-        "cve_year": 2012,
-        "state": "RESERVED",
-        "owning_cna": "safe_15",
-        "reserved": "2015-06-03T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "left_2",
-            "user": "josephleon@left_2.com"
-        },
-        "time": {
-            "created": "2015-11-29T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2012-0005",
-        "cve_year": 2012,
+        "cve_id": "CVE-2000-0009",
+        "cve_year": 2000,
         "state": "PUBLIC",
-        "owning_cna": "left_2",
-        "reserved": "2015-11-29T00:00:00.000000Z"
+        "owning_cna": "whatever_18",
+        "reserved": "2012-01-13T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
         },
         "time": {
-            "created": "2020-07-05T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2014-06-02T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:22.000000Z"
         },
-        "cve_id": "CVE-2012-0006",
-        "cve_year": 2012,
+        "cve_id": "CVE-2000-0010",
+        "cve_year": 2000,
+        "state": "PUBLIC",
+        "owning_cna": "only_6",
+        "reserved": "2014-06-02T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "technology_4",
+            "user": "jamesvaldez@technology_4.com"
+        },
+        "time": {
+            "created": "2011-08-26T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2001-0001",
+        "cve_year": 2001,
+        "state": "PUBLIC",
+        "owning_cna": "technology_4",
+        "reserved": "2011-08-26T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "technology_4",
+            "user": "jamesvaldez@technology_4.com"
+        },
+        "time": {
+            "created": "2015-09-06T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2001-0002",
+        "cve_year": 2001,
         "state": "RESERVED",
-        "owning_cna": "front_11",
-        "reserved": "2020-07-05T00:00:00.000000Z"
+        "owning_cna": "technology_4",
+        "reserved": "2015-09-06T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "television_9",
-            "user": "marybond@television_9.com"
+            "cna": "accept_19",
+            "user": "stephenjohnson@accept_19.com"
         },
         "time": {
-            "created": "2019-01-09T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2011-12-13T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:23.000000Z"
         },
-        "cve_id": "CVE-2012-0007",
-        "cve_year": 2012,
-        "state": "RESERVED",
-        "owning_cna": "television_9",
-        "reserved": "2019-01-09T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "after_3",
-            "user": "adamcox@after_3.com"
-        },
-        "time": {
-            "created": "2012-02-20T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2012-0008",
-        "cve_year": 2012,
-        "state": "RESERVED",
-        "owning_cna": "after_3",
-        "reserved": "2012-02-20T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "probably_6",
-            "user": "nicholaswhite@probably_6.com"
-        },
-        "time": {
-            "created": "2017-03-04T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2012-0009",
-        "cve_year": 2012,
-        "state": "RESERVED",
-        "owning_cna": "probably_6",
-        "reserved": "2017-03-04T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "reveal_18",
-            "user": "williambeck@reveal_18.com"
-        },
-        "time": {
-            "created": "2018-05-31T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:44.000000Z"
-        },
-        "cve_id": "CVE-2012-0010",
-        "cve_year": 2012,
+        "cve_id": "CVE-2001-0003",
+        "cve_year": 2001,
         "state": "REJECT",
-        "owning_cna": "reveal_18",
-        "reserved": "2018-05-31T00:00:00.000000Z"
+        "owning_cna": "accept_19",
+        "reserved": "2011-12-13T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "at_1",
-            "user": "amandawilson@at_1.com"
+            "cna": "man_5",
+            "user": "jeffreyfigueroa@man_5.com"
         },
         "time": {
-            "created": "2017-02-25T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2016-08-10T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2013-0001",
-        "cve_year": 2013,
+        "cve_id": "CVE-2001-0004",
+        "cve_year": 2001,
         "state": "RESERVED",
-        "owning_cna": "at_1",
-        "reserved": "2017-02-25T00:00:00.000000Z"
+        "owning_cna": "man_5",
+        "reserved": "2016-08-10T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "after_3",
-            "user": "adamcox@after_3.com"
+            "cna": "song_3",
+            "user": "sandrabrown@song_3.com"
+        },
+        "time": {
+            "created": "2016-07-29T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2001-0005",
+        "cve_year": 2001,
+        "state": "RESERVED",
+        "owning_cna": "song_3",
+        "reserved": "2016-07-29T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "opportunity_13",
+            "user": "colleentorres@opportunity_13.com"
+        },
+        "time": {
+            "created": "2019-11-03T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2001-0006",
+        "cve_year": 2001,
+        "state": "RESERVED",
+        "owning_cna": "opportunity_13",
+        "reserved": "2019-11-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "quickly_7",
+            "user": "ashleyanderson@quickly_7.com"
+        },
+        "time": {
+            "created": "2016-10-07T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2001-0007",
+        "cve_year": 2001,
+        "state": "RESERVED",
+        "owning_cna": "quickly_7",
+        "reserved": "2016-10-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "christianromero@mitre.com"
+        },
+        "time": {
+            "created": "2016-05-20T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:24.000000Z"
+        },
+        "cve_id": "CVE-2001-0008",
+        "cve_year": 2001,
+        "state": "RESERVED",
+        "owning_cna": "mitre",
+        "reserved": "2016-05-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "cost_12",
+            "user": "codymurphy@cost_12.com"
+        },
+        "time": {
+            "created": "2011-10-22T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2001-0009",
+        "cve_year": 2001,
+        "state": "RESERVED",
+        "owning_cna": "cost_12",
+        "reserved": "2011-10-22T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "opportunity_13",
+            "user": "colleentorres@opportunity_13.com"
+        },
+        "time": {
+            "created": "2014-09-02T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2001-0010",
+        "cve_year": 2001,
+        "state": "REJECT",
+        "owning_cna": "opportunity_13",
+        "reserved": "2014-09-02T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "difference_16",
+            "user": "rebeccahenry@difference_16.com"
+        },
+        "time": {
+            "created": "2018-09-23T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2002-0001",
+        "cve_year": 2002,
+        "state": "RESERVED",
+        "owning_cna": "difference_16",
+        "reserved": "2018-09-23T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
+        },
+        "time": {
+            "created": "2016-02-10T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:25.000000Z"
+        },
+        "cve_id": "CVE-2002-0002",
+        "cve_year": 2002,
+        "state": "RESERVED",
+        "owning_cna": "magazine_15",
+        "reserved": "2016-02-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "concern_8",
+            "user": "jasongray@concern_8.com"
+        },
+        "time": {
+            "created": "2021-03-21T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2002-0003",
+        "cve_year": 2002,
+        "state": "PUBLIC",
+        "owning_cna": "concern_8",
+        "reserved": "2021-03-21T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "accept_19",
+            "user": "stephenjohnson@accept_19.com"
         },
         "time": {
             "created": "2019-12-05T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2013-0002",
-        "cve_year": 2013,
-        "state": "RESERVED",
-        "owning_cna": "after_3",
+        "cve_id": "CVE-2002-0004",
+        "cve_year": 2002,
+        "state": "REJECT",
+        "owning_cna": "accept_19",
         "reserved": "2019-12-05T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "television_9",
-            "user": "marybond@television_9.com"
+            "cna": "difference_16",
+            "user": "rebeccahenry@difference_16.com"
         },
         "time": {
-            "created": "2020-01-27T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2018-12-05T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2013-0003",
-        "cve_year": 2013,
+        "cve_id": "CVE-2002-0005",
+        "cve_year": 2002,
         "state": "RESERVED",
-        "owning_cna": "television_9",
-        "reserved": "2020-01-27T00:00:00.000000Z"
+        "owning_cna": "difference_16",
+        "reserved": "2018-12-05T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "at_1",
-            "user": "amandawilson@at_1.com"
+            "cna": "raise_9",
+            "user": "ashleybradley@raise_9.com"
         },
         "time": {
-            "created": "2014-09-30T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2014-07-18T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2013-0004",
-        "cve_year": 2013,
+        "cve_id": "CVE-2002-0006",
+        "cve_year": 2002,
+        "state": "RESERVED",
+        "owning_cna": "raise_9",
+        "reserved": "2014-07-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "difference_16",
+            "user": "rebeccahenry@difference_16.com"
+        },
+        "time": {
+            "created": "2020-01-09T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2002-0007",
+        "cve_year": 2002,
         "state": "PUBLIC",
-        "owning_cna": "at_1",
-        "reserved": "2014-09-30T00:00:00.000000Z"
+        "owning_cna": "difference_16",
+        "reserved": "2020-01-09T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "best_8",
-            "user": "melanietaylor@best_8.com"
+            "cna": "today_2",
+            "user": "franciscoanderson@today_2.com"
         },
         "time": {
-            "created": "2014-09-23T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2013-07-01T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2013-0005",
-        "cve_year": 2013,
+        "cve_id": "CVE-2002-0008",
+        "cve_year": 2002,
         "state": "RESERVED",
-        "owning_cna": "best_8",
-        "reserved": "2014-09-23T00:00:00.000000Z"
+        "owning_cna": "today_2",
+        "reserved": "2013-07-01T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "quickly_7",
+            "user": "ashleyanderson@quickly_7.com"
+        },
+        "time": {
+            "created": "2014-05-03T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2002-0009",
+        "cve_year": 2002,
+        "state": "REJECT",
+        "owning_cna": "quickly_7",
+        "reserved": "2014-05-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "man_5",
+            "user": "jeffreyfigueroa@man_5.com"
+        },
+        "time": {
+            "created": "2016-02-08T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2002-0010",
+        "cve_year": 2002,
+        "state": "REJECT",
+        "owning_cna": "man_5",
+        "reserved": "2016-02-08T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
+        },
+        "time": {
+            "created": "2013-06-15T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2003-0001",
+        "cve_year": 2003,
+        "state": "RESERVED",
+        "owning_cna": "magazine_15",
+        "reserved": "2013-06-15T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "technology_4",
+            "user": "jamesvaldez@technology_4.com"
+        },
+        "time": {
+            "created": "2011-06-23T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:26.000000Z"
+        },
+        "cve_id": "CVE-2003-0002",
+        "cve_year": 2003,
+        "state": "RESERVED",
+        "owning_cna": "technology_4",
+        "reserved": "2011-06-23T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "difference_16",
+            "user": "rebeccahenry@difference_16.com"
+        },
+        "time": {
+            "created": "2014-03-04T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2003-0003",
+        "cve_year": 2003,
+        "state": "PUBLIC",
+        "owning_cna": "difference_16",
+        "reserved": "2014-03-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "quickly_7",
+            "user": "ashleyanderson@quickly_7.com"
+        },
+        "time": {
+            "created": "2021-03-29T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2003-0004",
+        "cve_year": 2003,
+        "state": "RESERVED",
+        "owning_cna": "quickly_7",
+        "reserved": "2021-03-29T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
+        },
+        "time": {
+            "created": "2018-03-31T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:27.000000Z"
+        },
+        "cve_id": "CVE-2003-0005",
+        "cve_year": 2003,
+        "state": "RESERVED",
+        "owning_cna": "only_6",
+        "reserved": "2018-03-31T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "song_3",
+            "user": "sandrabrown@song_3.com"
+        },
+        "time": {
+            "created": "2021-03-12T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2003-0006",
+        "cve_year": 2003,
+        "state": "REJECT",
+        "owning_cna": "song_3",
+        "reserved": "2021-03-12T00:00:00.000000Z"
     },
     {
         "requested_by": {
             "cna": "mitre",
-            "user": "angelajohnson@mitre.com"
+            "user": "christianromero@mitre.com"
         },
         "time": {
-            "created": "2012-03-07T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2017-08-09T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2013-0006",
-        "cve_year": 2013,
-        "state": "REJECT",
-        "owning_cna": "mitre",
-        "reserved": "2012-03-07T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "mitre",
-            "user": "angelajohnson@mitre.com"
-        },
-        "time": {
-            "created": "2018-01-09T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2013-0007",
-        "cve_year": 2013,
-        "state": "RESERVED",
-        "owning_cna": "mitre",
-        "reserved": "2018-01-09T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
-        },
-        "time": {
-            "created": "2016-11-13T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2013-0008",
-        "cve_year": 2013,
-        "state": "RESERVED",
-        "owning_cna": "guy_12",
-        "reserved": "2016-11-13T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
-        },
-        "time": {
-            "created": "2016-02-07T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2013-0009",
-        "cve_year": 2013,
-        "state": "RESERVED",
-        "owning_cna": "safe_15",
-        "reserved": "2016-02-07T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "mitre",
-            "user": "angelajohnson@mitre.com"
-        },
-        "time": {
-            "created": "2015-08-26T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2013-0010",
-        "cve_year": 2013,
+        "cve_id": "CVE-2003-0007",
+        "cve_year": 2003,
         "state": "PUBLIC",
         "owning_cna": "mitre",
-        "reserved": "2015-08-26T00:00:00.000000Z"
+        "reserved": "2017-08-09T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "attorney_13",
-            "user": "jessicaburnett@attorney_13.com"
+            "cna": "opportunity_13",
+            "user": "colleentorres@opportunity_13.com"
         },
         "time": {
-            "created": "2020-03-28T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:46.000000Z"
+            "created": "2013-10-27T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:27.000000Z"
         },
-        "cve_id": "CVE-2014-0001",
-        "cve_year": 2014,
-        "state": "RESERVED",
-        "owning_cna": "attorney_13",
-        "reserved": "2020-03-28T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
-        },
-        "time": {
-            "created": "2013-07-16T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2014-0002",
-        "cve_year": 2014,
-        "state": "RESERVED",
-        "owning_cna": "guy_12",
-        "reserved": "2013-07-16T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
-        },
-        "time": {
-            "created": "2013-04-28T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:47.000000Z"
-        },
-        "cve_id": "CVE-2014-0003",
-        "cve_year": 2014,
-        "state": "RESERVED",
-        "owning_cna": "front_11",
-        "reserved": "2013-04-28T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "tend_14",
-            "user": "vincentaguilar@tend_14.com"
-        },
-        "time": {
-            "created": "2014-04-24T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2014-0004",
-        "cve_year": 2014,
+        "cve_id": "CVE-2003-0008",
+        "cve_year": 2003,
         "state": "PUBLIC",
-        "owning_cna": "tend_14",
-        "reserved": "2014-04-24T00:00:00.000000Z"
+        "owning_cna": "opportunity_13",
+        "reserved": "2013-10-27T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "central_20",
-            "user": "shanejimenez@central_20.com"
+            "cna": "certain_10",
+            "user": "williammorris@certain_10.com"
         },
         "time": {
-            "created": "2011-03-22T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:47.000000Z"
+            "created": "2012-09-04T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2014-0005",
-        "cve_year": 2014,
+        "cve_id": "CVE-2003-0009",
+        "cve_year": 2003,
         "state": "REJECT",
-        "owning_cna": "central_20",
-        "reserved": "2011-03-22T00:00:00.000000Z"
+        "owning_cna": "certain_10",
+        "reserved": "2012-09-04T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "left_2",
-            "user": "josephleon@left_2.com"
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
         },
         "time": {
-            "created": "2019-07-31T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2018-11-17T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:28.000000Z"
         },
-        "cve_id": "CVE-2014-0006",
-        "cve_year": 2014,
+        "cve_id": "CVE-2003-0010",
+        "cve_year": 2003,
         "state": "REJECT",
-        "owning_cna": "left_2",
-        "reserved": "2019-07-31T00:00:00.000000Z"
+        "owning_cna": "only_6",
+        "reserved": "2018-11-17T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
+            "cna": "raise_9",
+            "user": "ashleybradley@raise_9.com"
         },
         "time": {
-            "created": "2012-03-29T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2016-10-10T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:28.000000Z"
         },
-        "cve_id": "CVE-2014-0007",
-        "cve_year": 2014,
+        "cve_id": "CVE-2004-0001",
+        "cve_year": 2004,
+        "state": "RESERVED",
+        "owning_cna": "raise_9",
+        "reserved": "2016-10-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "cost_12",
+            "user": "codymurphy@cost_12.com"
+        },
+        "time": {
+            "created": "2012-04-02T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2004-0002",
+        "cve_year": 2004,
+        "state": "RESERVED",
+        "owning_cna": "cost_12",
+        "reserved": "2012-04-02T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "from_11",
+            "user": "kimmiller@from_11.com"
+        },
+        "time": {
+            "created": "2015-01-23T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2004-0003",
+        "cve_year": 2004,
+        "state": "RESERVED",
+        "owning_cna": "from_11",
+        "reserved": "2015-01-23T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
+        },
+        "time": {
+            "created": "2018-03-04T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2004-0004",
+        "cve_year": 2004,
+        "state": "RESERVED",
+        "owning_cna": "magazine_15",
+        "reserved": "2018-03-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "quickly_7",
+            "user": "ashleyanderson@quickly_7.com"
+        },
+        "time": {
+            "created": "2016-12-23T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2004-0005",
+        "cve_year": 2004,
+        "state": "REJECT",
+        "owning_cna": "quickly_7",
+        "reserved": "2016-12-23T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
+        },
+        "time": {
+            "created": "2018-06-02T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2004-0006",
+        "cve_year": 2004,
+        "state": "REJECT",
+        "owning_cna": "only_6",
+        "reserved": "2018-06-02T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
+        },
+        "time": {
+            "created": "2017-10-07T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2004-0007",
+        "cve_year": 2004,
+        "state": "REJECT",
+        "owning_cna": "only_6",
+        "reserved": "2017-10-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "from_11",
+            "user": "kimmiller@from_11.com"
+        },
+        "time": {
+            "created": "2015-08-12T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2004-0008",
+        "cve_year": 2004,
+        "state": "RESERVED",
+        "owning_cna": "from_11",
+        "reserved": "2015-08-12T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "difference_16",
+            "user": "rebeccahenry@difference_16.com"
+        },
+        "time": {
+            "created": "2014-12-06T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2004-0009",
+        "cve_year": 2004,
+        "state": "RESERVED",
+        "owning_cna": "difference_16",
+        "reserved": "2014-12-06T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "cost_12",
+            "user": "codymurphy@cost_12.com"
+        },
+        "time": {
+            "created": "2019-07-28T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2004-0010",
+        "cve_year": 2004,
         "state": "PUBLIC",
-        "owning_cna": "guy_12",
-        "reserved": "2012-03-29T00:00:00.000000Z"
+        "owning_cna": "cost_12",
+        "reserved": "2019-07-28T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
+            "cna": "whether_20",
+            "user": "nicolecallahan@whether_20.com"
+        },
+        "time": {
+            "created": "2017-05-07T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:29.000000Z"
+        },
+        "cve_id": "CVE-2005-0001",
+        "cve_year": 2005,
+        "state": "RESERVED",
+        "owning_cna": "whether_20",
+        "reserved": "2017-05-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "song_3",
+            "user": "sandrabrown@song_3.com"
+        },
+        "time": {
+            "created": "2012-05-22T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2005-0002",
+        "cve_year": 2005,
+        "state": "RESERVED",
+        "owning_cna": "song_3",
+        "reserved": "2012-05-22T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "raise_9",
+            "user": "ashleybradley@raise_9.com"
         },
         "time": {
             "created": "2015-01-22T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:48.000000Z"
+            "modified": "2021-04-21T02:08:30.000000Z"
         },
-        "cve_id": "CVE-2014-0008",
-        "cve_year": 2014,
-        "state": "RESERVED",
-        "owning_cna": "some_19",
+        "cve_id": "CVE-2005-0003",
+        "cve_year": 2005,
+        "state": "PUBLIC",
+        "owning_cna": "raise_9",
         "reserved": "2015-01-22T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "probably_6",
-            "user": "nicholaswhite@probably_6.com"
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
         },
         "time": {
-            "created": "2018-01-13T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2013-04-22T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:30.000000Z"
         },
-        "cve_id": "CVE-2014-0009",
-        "cve_year": 2014,
+        "cve_id": "CVE-2005-0004",
+        "cve_year": 2005,
         "state": "RESERVED",
-        "owning_cna": "probably_6",
-        "reserved": "2018-01-13T00:00:00.000000Z"
+        "owning_cna": "magazine_15",
+        "reserved": "2013-04-22T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "tend_14",
-            "user": "vincentaguilar@tend_14.com"
-        },
-        "time": {
-            "created": "2021-03-06T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2014-0010",
-        "cve_year": 2014,
-        "state": "REJECT",
-        "owning_cna": "tend_14",
-        "reserved": "2021-03-06T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "attorney_13",
-            "user": "jessicaburnett@attorney_13.com"
-        },
-        "time": {
-            "created": "2016-12-20T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:48.000000Z"
-        },
-        "cve_id": "CVE-2015-0001",
-        "cve_year": 2015,
-        "state": "REJECT",
-        "owning_cna": "attorney_13",
-        "reserved": "2016-12-20T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "pressure_10",
-            "user": "christophersteele@pressure_10.com"
-        },
-        "time": {
-            "created": "2013-04-21T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2015-0002",
-        "cve_year": 2015,
-        "state": "RESERVED",
-        "owning_cna": "pressure_10",
-        "reserved": "2013-04-21T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
-        },
-        "time": {
-            "created": "2015-10-01T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2015-0003",
-        "cve_year": 2015,
-        "state": "RESERVED",
-        "owning_cna": "guy_12",
-        "reserved": "2015-10-01T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "television_9",
-            "user": "marybond@television_9.com"
-        },
-        "time": {
-            "created": "2011-10-01T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2015-0004",
-        "cve_year": 2015,
-        "state": "RESERVED",
-        "owning_cna": "television_9",
-        "reserved": "2011-10-01T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "central_20",
-            "user": "shanejimenez@central_20.com"
-        },
-        "time": {
-            "created": "2015-03-13T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2015-0005",
-        "cve_year": 2015,
-        "state": "PUBLIC",
-        "owning_cna": "central_20",
-        "reserved": "2015-03-13T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "television_9",
-            "user": "marybond@television_9.com"
-        },
-        "time": {
-            "created": "2014-05-08T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2015-0006",
-        "cve_year": 2015,
-        "state": "PUBLIC",
-        "owning_cna": "television_9",
-        "reserved": "2014-05-08T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "media_7",
-            "user": "emilyperez@media_7.com"
-        },
-        "time": {
-            "created": "2012-06-04T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2015-0007",
-        "cve_year": 2015,
-        "state": "PUBLIC",
-        "owning_cna": "media_7",
-        "reserved": "2012-06-04T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "attorney_13",
-            "user": "jessicaburnett@attorney_13.com"
-        },
-        "time": {
-            "created": "2015-12-07T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2015-0008",
-        "cve_year": 2015,
-        "state": "RESERVED",
-        "owning_cna": "attorney_13",
-        "reserved": "2015-12-07T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "either_4",
-            "user": "jeremiahlloyd@either_4.com"
-        },
-        "time": {
-            "created": "2013-06-25T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2015-0009",
-        "cve_year": 2015,
-        "state": "RESERVED",
-        "owning_cna": "either_4",
-        "reserved": "2013-06-25T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "media_7",
-            "user": "emilyperez@media_7.com"
-        },
-        "time": {
-            "created": "2019-09-13T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:50.000000Z"
-        },
-        "cve_id": "CVE-2015-0010",
-        "cve_year": 2015,
-        "state": "RESERVED",
-        "owning_cna": "media_7",
-        "reserved": "2019-09-13T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
-        },
-        "time": {
-            "created": "2020-07-23T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2016-0001",
-        "cve_year": 2016,
-        "state": "REJECT",
-        "owning_cna": "front_11",
-        "reserved": "2020-07-23T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
-        },
-        "time": {
-            "created": "2018-06-18T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2016-0002",
-        "cve_year": 2016,
-        "state": "REJECT",
-        "owning_cna": "safe_15",
-        "reserved": "2018-06-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "tend_14",
-            "user": "vincentaguilar@tend_14.com"
-        },
-        "time": {
-            "created": "2017-08-31T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2016-0003",
-        "cve_year": 2016,
-        "state": "RESERVED",
-        "owning_cna": "tend_14",
-        "reserved": "2017-08-31T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "attorney_13",
-            "user": "jessicaburnett@attorney_13.com"
-        },
-        "time": {
-            "created": "2014-10-15T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2016-0004",
-        "cve_year": 2016,
-        "state": "RESERVED",
-        "owning_cna": "attorney_13",
-        "reserved": "2014-10-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "tend_14",
-            "user": "vincentaguilar@tend_14.com"
-        },
-        "time": {
-            "created": "2014-06-19T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2016-0005",
-        "cve_year": 2016,
-        "state": "PUBLIC",
-        "owning_cna": "tend_14",
-        "reserved": "2014-06-19T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "imagine_16",
-            "user": "sherrylopez@imagine_16.com"
-        },
-        "time": {
-            "created": "2011-12-03T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2016-0006",
-        "cve_year": 2016,
-        "state": "RESERVED",
-        "owning_cna": "imagine_16",
-        "reserved": "2011-12-03T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
-        },
-        "time": {
-            "created": "2011-08-03T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2016-0007",
-        "cve_year": 2016,
-        "state": "RESERVED",
-        "owning_cna": "some_19",
-        "reserved": "2011-08-03T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
-        },
-        "time": {
-            "created": "2015-04-15T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2016-0008",
-        "cve_year": 2016,
-        "state": "RESERVED",
-        "owning_cna": "some_19",
-        "reserved": "2015-04-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "tend_14",
-            "user": "vincentaguilar@tend_14.com"
-        },
-        "time": {
-            "created": "2015-09-02T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2016-0009",
-        "cve_year": 2016,
-        "state": "PUBLIC",
-        "owning_cna": "tend_14",
-        "reserved": "2015-09-02T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "pressure_10",
-            "user": "christophersteele@pressure_10.com"
-        },
-        "time": {
-            "created": "2018-10-22T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2016-0010",
-        "cve_year": 2016,
-        "state": "RESERVED",
-        "owning_cna": "pressure_10",
-        "reserved": "2018-10-22T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "tend_14",
-            "user": "vincentaguilar@tend_14.com"
-        },
-        "time": {
-            "created": "2016-07-14T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2017-0001",
-        "cve_year": 2017,
-        "state": "REJECT",
-        "owning_cna": "tend_14",
-        "reserved": "2016-07-14T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "after_3",
-            "user": "adamcox@after_3.com"
-        },
-        "time": {
-            "created": "2013-12-04T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2017-0002",
-        "cve_year": 2017,
-        "state": "PUBLIC",
-        "owning_cna": "after_3",
-        "reserved": "2013-12-04T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "best_8",
-            "user": "melanietaylor@best_8.com"
-        },
-        "time": {
-            "created": "2016-05-03T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2017-0003",
-        "cve_year": 2017,
-        "state": "RESERVED",
-        "owning_cna": "best_8",
-        "reserved": "2016-05-03T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "tend_14",
-            "user": "vincentaguilar@tend_14.com"
-        },
-        "time": {
-            "created": "2017-12-15T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2017-0004",
-        "cve_year": 2017,
-        "state": "REJECT",
-        "owning_cna": "tend_14",
-        "reserved": "2017-12-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "either_4",
-            "user": "jeremiahlloyd@either_4.com"
-        },
-        "time": {
-            "created": "2020-10-07T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:53.000000Z"
-        },
-        "cve_id": "CVE-2017-0005",
-        "cve_year": 2017,
-        "state": "RESERVED",
-        "owning_cna": "either_4",
-        "reserved": "2020-10-07T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "probably_6",
-            "user": "nicholaswhite@probably_6.com"
-        },
-        "time": {
-            "created": "2011-08-30T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2017-0006",
-        "cve_year": 2017,
-        "state": "PUBLIC",
-        "owning_cna": "probably_6",
-        "reserved": "2011-08-30T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
-        },
-        "time": {
-            "created": "2020-10-10T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2017-0007",
-        "cve_year": 2017,
-        "state": "REJECT",
-        "owning_cna": "guy_12",
-        "reserved": "2020-10-10T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "attorney_13",
-            "user": "jessicaburnett@attorney_13.com"
-        },
-        "time": {
-            "created": "2014-03-11T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2017-0008",
-        "cve_year": 2017,
-        "state": "RESERVED",
-        "owning_cna": "attorney_13",
-        "reserved": "2014-03-11T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
-        },
-        "time": {
-            "created": "2015-08-11T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2017-0009",
-        "cve_year": 2017,
-        "state": "REJECT",
-        "owning_cna": "guy_12",
-        "reserved": "2015-08-11T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "either_4",
-            "user": "jeremiahlloyd@either_4.com"
-        },
-        "time": {
-            "created": "2017-02-08T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2017-0010",
-        "cve_year": 2017,
-        "state": "PUBLIC",
-        "owning_cna": "either_4",
-        "reserved": "2017-02-08T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "probably_6",
-            "user": "nicholaswhite@probably_6.com"
-        },
-        "time": {
-            "created": "2019-05-15T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:54.000000Z"
-        },
-        "cve_id": "CVE-2018-0001",
-        "cve_year": 2018,
-        "state": "REJECT",
-        "owning_cna": "probably_6",
-        "reserved": "2019-05-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "easy_5",
-            "user": "vernonvazquez@easy_5.com"
-        },
-        "time": {
-            "created": "2013-04-30T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2018-0002",
-        "cve_year": 2018,
-        "state": "PUBLIC",
-        "owning_cna": "easy_5",
-        "reserved": "2013-04-30T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
-        },
-        "time": {
-            "created": "2020-05-02T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2018-0003",
-        "cve_year": 2018,
-        "state": "RESERVED",
-        "owning_cna": "some_19",
-        "reserved": "2020-05-02T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "easy_5",
-            "user": "vernonvazquez@easy_5.com"
+            "cna": "certain_10",
+            "user": "williammorris@certain_10.com"
         },
         "time": {
             "created": "2016-10-04T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:55.000000Z"
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2018-0004",
-        "cve_year": 2018,
+        "cve_id": "CVE-2005-0005",
+        "cve_year": 2005,
         "state": "PUBLIC",
-        "owning_cna": "easy_5",
+        "owning_cna": "certain_10",
         "reserved": "2016-10-04T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
+            "cna": "song_3",
+            "user": "sandrabrown@song_3.com"
         },
         "time": {
-            "created": "2012-10-07T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:55.000000Z"
+            "created": "2018-08-14T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:30.000000Z"
         },
-        "cve_id": "CVE-2018-0005",
-        "cve_year": 2018,
-        "state": "RESERVED",
-        "owning_cna": "safe_15",
-        "reserved": "2012-10-07T00:00:00.000000Z"
+        "cve_id": "CVE-2005-0006",
+        "cve_year": 2005,
+        "state": "PUBLIC",
+        "owning_cna": "song_3",
+        "reserved": "2018-08-14T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "after_3",
-            "user": "adamcox@after_3.com"
+            "cna": "ok_17",
+            "user": "dominiquefrench@ok_17.com"
         },
         "time": {
-            "created": "2017-05-02T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:55.000000Z"
+            "created": "2012-10-12T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2018-0006",
-        "cve_year": 2018,
+        "cve_id": "CVE-2005-0007",
+        "cve_year": 2005,
         "state": "RESERVED",
-        "owning_cna": "after_3",
-        "reserved": "2017-05-02T00:00:00.000000Z"
+        "owning_cna": "ok_17",
+        "reserved": "2012-10-12T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "best_8",
-            "user": "melanietaylor@best_8.com"
+            "cna": "ok_17",
+            "user": "dominiquefrench@ok_17.com"
         },
         "time": {
-            "created": "2012-12-14T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2017-01-11T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2018-0007",
-        "cve_year": 2018,
-        "state": "RESERVED",
-        "owning_cna": "best_8",
-        "reserved": "2012-12-14T00:00:00.000000Z"
+        "cve_id": "CVE-2005-0008",
+        "cve_year": 2005,
+        "state": "PUBLIC",
+        "owning_cna": "ok_17",
+        "reserved": "2017-01-11T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
+            "cna": "here_1",
+            "user": "jamesfreeman@here_1.com"
         },
         "time": {
-            "created": "2013-06-14T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2019-12-31T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:31.000000Z"
         },
-        "cve_id": "CVE-2018-0008",
-        "cve_year": 2018,
-        "state": "RESERVED",
-        "owning_cna": "safe_15",
-        "reserved": "2013-06-14T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
-        },
-        "time": {
-            "created": "2015-03-11T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:56.000000Z"
-        },
-        "cve_id": "CVE-2018-0009",
-        "cve_year": 2018,
-        "state": "RESERVED",
-        "owning_cna": "guy_12",
-        "reserved": "2015-03-11T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "imagine_16",
-            "user": "sherrylopez@imagine_16.com"
-        },
-        "time": {
-            "created": "2020-01-11T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:56.000000Z"
-        },
-        "cve_id": "CVE-2018-0010",
-        "cve_year": 2018,
+        "cve_id": "CVE-2005-0009",
+        "cve_year": 2005,
         "state": "REJECT",
-        "owning_cna": "imagine_16",
-        "reserved": "2020-01-11T00:00:00.000000Z"
+        "owning_cna": "here_1",
+        "reserved": "2019-12-31T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "reveal_18",
-            "user": "williambeck@reveal_18.com"
+            "cna": "raise_9",
+            "user": "ashleybradley@raise_9.com"
+        },
+        "time": {
+            "created": "2013-09-18T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:31.000000Z"
+        },
+        "cve_id": "CVE-2005-0010",
+        "cve_year": 2005,
+        "state": "RESERVED",
+        "owning_cna": "raise_9",
+        "reserved": "2013-09-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "song_3",
+            "user": "sandrabrown@song_3.com"
+        },
+        "time": {
+            "created": "2012-11-18T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2006-0001",
+        "cve_year": 2006,
+        "state": "PUBLIC",
+        "owning_cna": "song_3",
+        "reserved": "2012-11-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "certain_10",
+            "user": "williammorris@certain_10.com"
+        },
+        "time": {
+            "created": "2016-07-21T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2006-0002",
+        "cve_year": 2006,
+        "state": "RESERVED",
+        "owning_cna": "certain_10",
+        "reserved": "2016-07-21T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "concern_8",
+            "user": "jasongray@concern_8.com"
+        },
+        "time": {
+            "created": "2019-01-19T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:32.000000Z"
+        },
+        "cve_id": "CVE-2006-0003",
+        "cve_year": 2006,
+        "state": "RESERVED",
+        "owning_cna": "concern_8",
+        "reserved": "2019-01-19T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "value_14",
+            "user": "janetdean@value_14.com"
+        },
+        "time": {
+            "created": "2019-01-23T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2006-0004",
+        "cve_year": 2006,
+        "state": "REJECT",
+        "owning_cna": "value_14",
+        "reserved": "2019-01-23T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "difference_16",
+            "user": "rebeccahenry@difference_16.com"
+        },
+        "time": {
+            "created": "2017-09-07T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2006-0005",
+        "cve_year": 2006,
+        "state": "PUBLIC",
+        "owning_cna": "difference_16",
+        "reserved": "2017-09-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "today_2",
+            "user": "franciscoanderson@today_2.com"
+        },
+        "time": {
+            "created": "2015-01-22T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2006-0006",
+        "cve_year": 2006,
+        "state": "REJECT",
+        "owning_cna": "today_2",
+        "reserved": "2015-01-22T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "man_5",
+            "user": "jeffreyfigueroa@man_5.com"
+        },
+        "time": {
+            "created": "2020-02-26T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2006-0007",
+        "cve_year": 2006,
+        "state": "PUBLIC",
+        "owning_cna": "man_5",
+        "reserved": "2020-02-26T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "technology_4",
+            "user": "jamesvaldez@technology_4.com"
+        },
+        "time": {
+            "created": "2018-02-25T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2006-0008",
+        "cve_year": 2006,
+        "state": "RESERVED",
+        "owning_cna": "technology_4",
+        "reserved": "2018-02-25T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "christianromero@mitre.com"
+        },
+        "time": {
+            "created": "2011-06-05T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2006-0009",
+        "cve_year": 2006,
+        "state": "RESERVED",
+        "owning_cna": "mitre",
+        "reserved": "2011-06-05T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "here_1",
+            "user": "jamesfreeman@here_1.com"
+        },
+        "time": {
+            "created": "2021-01-03T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2006-0010",
+        "cve_year": 2006,
+        "state": "RESERVED",
+        "owning_cna": "here_1",
+        "reserved": "2021-01-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "christianromero@mitre.com"
+        },
+        "time": {
+            "created": "2020-05-20T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2007-0001",
+        "cve_year": 2007,
+        "state": "RESERVED",
+        "owning_cna": "mitre",
+        "reserved": "2020-05-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "opportunity_13",
+            "user": "colleentorres@opportunity_13.com"
+        },
+        "time": {
+            "created": "2016-12-18T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:33.000000Z"
+        },
+        "cve_id": "CVE-2007-0002",
+        "cve_year": 2007,
+        "state": "REJECT",
+        "owning_cna": "opportunity_13",
+        "reserved": "2016-12-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
+        },
+        "time": {
+            "created": "2019-12-21T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2007-0003",
+        "cve_year": 2007,
+        "state": "RESERVED",
+        "owning_cna": "magazine_15",
+        "reserved": "2019-12-21T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "accept_19",
+            "user": "stephenjohnson@accept_19.com"
+        },
+        "time": {
+            "created": "2012-02-13T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2007-0004",
+        "cve_year": 2007,
+        "state": "PUBLIC",
+        "owning_cna": "accept_19",
+        "reserved": "2012-02-13T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "value_14",
+            "user": "janetdean@value_14.com"
+        },
+        "time": {
+            "created": "2019-03-03T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2007-0005",
+        "cve_year": 2007,
+        "state": "RESERVED",
+        "owning_cna": "value_14",
+        "reserved": "2019-03-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "cost_12",
+            "user": "codymurphy@cost_12.com"
+        },
+        "time": {
+            "created": "2019-01-15T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2007-0006",
+        "cve_year": 2007,
+        "state": "RESERVED",
+        "owning_cna": "cost_12",
+        "reserved": "2019-01-15T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "concern_8",
+            "user": "jasongray@concern_8.com"
+        },
+        "time": {
+            "created": "2016-06-30T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2007-0007",
+        "cve_year": 2007,
+        "state": "RESERVED",
+        "owning_cna": "concern_8",
+        "reserved": "2016-06-30T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "today_2",
+            "user": "franciscoanderson@today_2.com"
+        },
+        "time": {
+            "created": "2016-07-30T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2007-0008",
+        "cve_year": 2007,
+        "state": "REJECT",
+        "owning_cna": "today_2",
+        "reserved": "2016-07-30T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whether_20",
+            "user": "nicolecallahan@whether_20.com"
+        },
+        "time": {
+            "created": "2013-12-16T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2007-0009",
+        "cve_year": 2007,
+        "state": "RESERVED",
+        "owning_cna": "whether_20",
+        "reserved": "2013-12-16T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whether_20",
+            "user": "nicolecallahan@whether_20.com"
+        },
+        "time": {
+            "created": "2019-03-15T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2007-0010",
+        "cve_year": 2007,
+        "state": "PUBLIC",
+        "owning_cna": "whether_20",
+        "reserved": "2019-03-15T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "quickly_7",
+            "user": "ashleyanderson@quickly_7.com"
+        },
+        "time": {
+            "created": "2016-02-14T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2008-0001",
+        "cve_year": 2008,
+        "state": "RESERVED",
+        "owning_cna": "quickly_7",
+        "reserved": "2016-02-14T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "opportunity_13",
+            "user": "colleentorres@opportunity_13.com"
+        },
+        "time": {
+            "created": "2020-07-10T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2008-0002",
+        "cve_year": 2008,
+        "state": "RESERVED",
+        "owning_cna": "opportunity_13",
+        "reserved": "2020-07-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "man_5",
+            "user": "jeffreyfigueroa@man_5.com"
+        },
+        "time": {
+            "created": "2015-10-28T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2008-0003",
+        "cve_year": 2008,
+        "state": "PUBLIC",
+        "owning_cna": "man_5",
+        "reserved": "2015-10-28T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "cost_12",
+            "user": "codymurphy@cost_12.com"
+        },
+        "time": {
+            "created": "2017-10-26T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2008-0004",
+        "cve_year": 2008,
+        "state": "RESERVED",
+        "owning_cna": "cost_12",
+        "reserved": "2017-10-26T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "difference_16",
+            "user": "rebeccahenry@difference_16.com"
+        },
+        "time": {
+            "created": "2019-07-13T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:35.000000Z"
+        },
+        "cve_id": "CVE-2008-0005",
+        "cve_year": 2008,
+        "state": "REJECT",
+        "owning_cna": "difference_16",
+        "reserved": "2019-07-13T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whether_20",
+            "user": "nicolecallahan@whether_20.com"
+        },
+        "time": {
+            "created": "2020-01-26T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2008-0006",
+        "cve_year": 2008,
+        "state": "PUBLIC",
+        "owning_cna": "whether_20",
+        "reserved": "2020-01-26T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "value_14",
+            "user": "janetdean@value_14.com"
+        },
+        "time": {
+            "created": "2012-02-29T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2008-0007",
+        "cve_year": 2008,
+        "state": "RESERVED",
+        "owning_cna": "value_14",
+        "reserved": "2012-02-29T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "christianromero@mitre.com"
+        },
+        "time": {
+            "created": "2014-05-06T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2008-0008",
+        "cve_year": 2008,
+        "state": "RESERVED",
+        "owning_cna": "mitre",
+        "reserved": "2014-05-06T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "today_2",
+            "user": "franciscoanderson@today_2.com"
+        },
+        "time": {
+            "created": "2012-08-15T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2008-0009",
+        "cve_year": 2008,
+        "state": "RESERVED",
+        "owning_cna": "today_2",
+        "reserved": "2012-08-15T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "cost_12",
+            "user": "codymurphy@cost_12.com"
+        },
+        "time": {
+            "created": "2011-11-17T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2008-0010",
+        "cve_year": 2008,
+        "state": "REJECT",
+        "owning_cna": "cost_12",
+        "reserved": "2011-11-17T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "today_2",
+            "user": "franciscoanderson@today_2.com"
+        },
+        "time": {
+            "created": "2014-04-04T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2009-0001",
+        "cve_year": 2009,
+        "state": "REJECT",
+        "owning_cna": "today_2",
+        "reserved": "2014-04-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "today_2",
+            "user": "franciscoanderson@today_2.com"
+        },
+        "time": {
+            "created": "2015-08-19T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2009-0002",
+        "cve_year": 2009,
+        "state": "RESERVED",
+        "owning_cna": "today_2",
+        "reserved": "2015-08-19T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "song_3",
+            "user": "sandrabrown@song_3.com"
+        },
+        "time": {
+            "created": "2012-09-13T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:37.000000Z"
+        },
+        "cve_id": "CVE-2009-0003",
+        "cve_year": 2009,
+        "state": "PUBLIC",
+        "owning_cna": "song_3",
+        "reserved": "2012-09-13T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "opportunity_13",
+            "user": "colleentorres@opportunity_13.com"
+        },
+        "time": {
+            "created": "2014-03-17T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2009-0004",
+        "cve_year": 2009,
+        "state": "PUBLIC",
+        "owning_cna": "opportunity_13",
+        "reserved": "2014-03-17T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "accept_19",
+            "user": "stephenjohnson@accept_19.com"
+        },
+        "time": {
+            "created": "2019-04-24T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:37.000000Z"
+        },
+        "cve_id": "CVE-2009-0005",
+        "cve_year": 2009,
+        "state": "PUBLIC",
+        "owning_cna": "accept_19",
+        "reserved": "2019-04-24T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whatever_18",
+            "user": "stevenvalentine@whatever_18.com"
+        },
+        "time": {
+            "created": "2012-06-27T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2009-0006",
+        "cve_year": 2009,
+        "state": "REJECT",
+        "owning_cna": "whatever_18",
+        "reserved": "2012-06-27T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "accept_19",
+            "user": "stephenjohnson@accept_19.com"
+        },
+        "time": {
+            "created": "2016-02-03T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2009-0007",
+        "cve_year": 2009,
+        "state": "RESERVED",
+        "owning_cna": "accept_19",
+        "reserved": "2016-02-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "technology_4",
+            "user": "jamesvaldez@technology_4.com"
+        },
+        "time": {
+            "created": "2014-11-21T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:37.000000Z"
+        },
+        "cve_id": "CVE-2009-0008",
+        "cve_year": 2009,
+        "state": "RESERVED",
+        "owning_cna": "technology_4",
+        "reserved": "2014-11-21T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whatever_18",
+            "user": "stevenvalentine@whatever_18.com"
+        },
+        "time": {
+            "created": "2018-04-01T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2009-0009",
+        "cve_year": 2009,
+        "state": "RESERVED",
+        "owning_cna": "whatever_18",
+        "reserved": "2018-04-01T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "song_3",
+            "user": "sandrabrown@song_3.com"
+        },
+        "time": {
+            "created": "2014-08-20T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2009-0010",
+        "cve_year": 2009,
+        "state": "RESERVED",
+        "owning_cna": "song_3",
+        "reserved": "2014-08-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "value_14",
+            "user": "janetdean@value_14.com"
+        },
+        "time": {
+            "created": "2020-06-04T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:38.000000Z"
+        },
+        "cve_id": "CVE-2010-0001",
+        "cve_year": 2010,
+        "state": "RESERVED",
+        "owning_cna": "value_14",
+        "reserved": "2020-06-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "technology_4",
+            "user": "jamesvaldez@technology_4.com"
+        },
+        "time": {
+            "created": "2012-10-06T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:38.000000Z"
+        },
+        "cve_id": "CVE-2010-0002",
+        "cve_year": 2010,
+        "state": "PUBLIC",
+        "owning_cna": "technology_4",
+        "reserved": "2012-10-06T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
+        },
+        "time": {
+            "created": "2014-12-11T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2010-0003",
+        "cve_year": 2010,
+        "state": "RESERVED",
+        "owning_cna": "magazine_15",
+        "reserved": "2014-12-11T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "cost_12",
+            "user": "codymurphy@cost_12.com"
+        },
+        "time": {
+            "created": "2016-04-28T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:38.000000Z"
+        },
+        "cve_id": "CVE-2010-0004",
+        "cve_year": 2010,
+        "state": "RESERVED",
+        "owning_cna": "cost_12",
+        "reserved": "2016-04-28T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whatever_18",
+            "user": "stevenvalentine@whatever_18.com"
+        },
+        "time": {
+            "created": "2014-03-08T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2010-0005",
+        "cve_year": 2010,
+        "state": "PUBLIC",
+        "owning_cna": "whatever_18",
+        "reserved": "2014-03-08T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whether_20",
+            "user": "nicolecallahan@whether_20.com"
+        },
+        "time": {
+            "created": "2011-10-24T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:39.000000Z"
+        },
+        "cve_id": "CVE-2010-0006",
+        "cve_year": 2010,
+        "state": "REJECT",
+        "owning_cna": "whether_20",
+        "reserved": "2011-10-24T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "man_5",
+            "user": "jeffreyfigueroa@man_5.com"
+        },
+        "time": {
+            "created": "2019-06-26T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2010-0007",
+        "cve_year": 2010,
+        "state": "REJECT",
+        "owning_cna": "man_5",
+        "reserved": "2019-06-26T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "today_2",
+            "user": "franciscoanderson@today_2.com"
+        },
+        "time": {
+            "created": "2014-10-07T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2010-0008",
+        "cve_year": 2010,
+        "state": "RESERVED",
+        "owning_cna": "today_2",
+        "reserved": "2014-10-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "difference_16",
+            "user": "rebeccahenry@difference_16.com"
+        },
+        "time": {
+            "created": "2017-02-19T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2010-0009",
+        "cve_year": 2010,
+        "state": "REJECT",
+        "owning_cna": "difference_16",
+        "reserved": "2017-02-19T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "today_2",
+            "user": "franciscoanderson@today_2.com"
+        },
+        "time": {
+            "created": "2015-09-04T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2010-0010",
+        "cve_year": 2010,
+        "state": "PUBLIC",
+        "owning_cna": "today_2",
+        "reserved": "2015-09-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whatever_18",
+            "user": "stevenvalentine@whatever_18.com"
+        },
+        "time": {
+            "created": "2013-12-20T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2011-0001",
+        "cve_year": 2011,
+        "state": "PUBLIC",
+        "owning_cna": "whatever_18",
+        "reserved": "2013-12-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "certain_10",
+            "user": "williammorris@certain_10.com"
+        },
+        "time": {
+            "created": "2012-06-27T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2011-0002",
+        "cve_year": 2011,
+        "state": "RESERVED",
+        "owning_cna": "certain_10",
+        "reserved": "2012-06-27T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "technology_4",
+            "user": "jamesvaldez@technology_4.com"
+        },
+        "time": {
+            "created": "2014-10-10T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:40.000000Z"
+        },
+        "cve_id": "CVE-2011-0003",
+        "cve_year": 2011,
+        "state": "PUBLIC",
+        "owning_cna": "technology_4",
+        "reserved": "2014-10-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
+        },
+        "time": {
+            "created": "2019-08-13T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2011-0004",
+        "cve_year": 2011,
+        "state": "PUBLIC",
+        "owning_cna": "only_6",
+        "reserved": "2019-08-13T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "certain_10",
+            "user": "williammorris@certain_10.com"
+        },
+        "time": {
+            "created": "2020-08-14T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2011-0005",
+        "cve_year": 2011,
+        "state": "REJECT",
+        "owning_cna": "certain_10",
+        "reserved": "2020-08-14T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "quickly_7",
+            "user": "ashleyanderson@quickly_7.com"
+        },
+        "time": {
+            "created": "2012-02-08T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:41.000000Z"
+        },
+        "cve_id": "CVE-2011-0006",
+        "cve_year": 2011,
+        "state": "RESERVED",
+        "owning_cna": "quickly_7",
+        "reserved": "2012-02-08T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whether_20",
+            "user": "nicolecallahan@whether_20.com"
+        },
+        "time": {
+            "created": "2019-05-28T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2011-0007",
+        "cve_year": 2011,
+        "state": "RESERVED",
+        "owning_cna": "whether_20",
+        "reserved": "2019-05-28T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
+        },
+        "time": {
+            "created": "2016-01-18T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2011-0008",
+        "cve_year": 2011,
+        "state": "REJECT",
+        "owning_cna": "magazine_15",
+        "reserved": "2016-01-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "opportunity_13",
+            "user": "colleentorres@opportunity_13.com"
+        },
+        "time": {
+            "created": "2017-03-22T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:41.000000Z"
+        },
+        "cve_id": "CVE-2011-0009",
+        "cve_year": 2011,
+        "state": "REJECT",
+        "owning_cna": "opportunity_13",
+        "reserved": "2017-03-22T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "from_11",
+            "user": "kimmiller@from_11.com"
+        },
+        "time": {
+            "created": "2016-08-02T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2011-0010",
+        "cve_year": 2011,
+        "state": "RESERVED",
+        "owning_cna": "from_11",
+        "reserved": "2016-08-02T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "christianromero@mitre.com"
+        },
+        "time": {
+            "created": "2015-05-03T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2012-0001",
+        "cve_year": 2012,
+        "state": "PUBLIC",
+        "owning_cna": "mitre",
+        "reserved": "2015-05-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "accept_19",
+            "user": "stephenjohnson@accept_19.com"
+        },
+        "time": {
+            "created": "2020-06-03T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2012-0002",
+        "cve_year": 2012,
+        "state": "RESERVED",
+        "owning_cna": "accept_19",
+        "reserved": "2020-06-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "difference_16",
+            "user": "rebeccahenry@difference_16.com"
+        },
+        "time": {
+            "created": "2016-09-27T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2012-0003",
+        "cve_year": 2012,
+        "state": "RESERVED",
+        "owning_cna": "difference_16",
+        "reserved": "2016-09-27T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "quickly_7",
+            "user": "ashleyanderson@quickly_7.com"
+        },
+        "time": {
+            "created": "2019-07-18T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2012-0004",
+        "cve_year": 2012,
+        "state": "RESERVED",
+        "owning_cna": "quickly_7",
+        "reserved": "2019-07-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "today_2",
+            "user": "franciscoanderson@today_2.com"
+        },
+        "time": {
+            "created": "2015-01-06T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2012-0005",
+        "cve_year": 2012,
+        "state": "RESERVED",
+        "owning_cna": "today_2",
+        "reserved": "2015-01-06T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "technology_4",
+            "user": "jamesvaldez@technology_4.com"
+        },
+        "time": {
+            "created": "2018-02-23T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2012-0006",
+        "cve_year": 2012,
+        "state": "RESERVED",
+        "owning_cna": "technology_4",
+        "reserved": "2018-02-23T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "opportunity_13",
+            "user": "colleentorres@opportunity_13.com"
+        },
+        "time": {
+            "created": "2012-08-11T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:43.000000Z"
+        },
+        "cve_id": "CVE-2012-0007",
+        "cve_year": 2012,
+        "state": "RESERVED",
+        "owning_cna": "opportunity_13",
+        "reserved": "2012-08-11T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "concern_8",
+            "user": "jasongray@concern_8.com"
+        },
+        "time": {
+            "created": "2017-05-15T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:43.000000Z"
+        },
+        "cve_id": "CVE-2012-0008",
+        "cve_year": 2012,
+        "state": "REJECT",
+        "owning_cna": "concern_8",
+        "reserved": "2017-05-15T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "ok_17",
+            "user": "dominiquefrench@ok_17.com"
+        },
+        "time": {
+            "created": "2015-09-09T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2012-0009",
+        "cve_year": 2012,
+        "state": "RESERVED",
+        "owning_cna": "ok_17",
+        "reserved": "2015-09-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "song_3",
+            "user": "sandrabrown@song_3.com"
+        },
+        "time": {
+            "created": "2017-09-23T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2012-0010",
+        "cve_year": 2012,
+        "state": "RESERVED",
+        "owning_cna": "song_3",
+        "reserved": "2017-09-23T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "technology_4",
+            "user": "jamesvaldez@technology_4.com"
+        },
+        "time": {
+            "created": "2012-04-26T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:43.000000Z"
+        },
+        "cve_id": "CVE-2013-0001",
+        "cve_year": 2013,
+        "state": "RESERVED",
+        "owning_cna": "technology_4",
+        "reserved": "2012-04-26T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "here_1",
+            "user": "jamesfreeman@here_1.com"
+        },
+        "time": {
+            "created": "2017-10-02T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2013-0002",
+        "cve_year": 2013,
+        "state": "RESERVED",
+        "owning_cna": "here_1",
+        "reserved": "2017-10-02T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "value_14",
+            "user": "janetdean@value_14.com"
+        },
+        "time": {
+            "created": "2014-10-11T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2013-0003",
+        "cve_year": 2013,
+        "state": "RESERVED",
+        "owning_cna": "value_14",
+        "reserved": "2014-10-11T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "cost_12",
+            "user": "codymurphy@cost_12.com"
+        },
+        "time": {
+            "created": "2014-11-03T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:44.000000Z"
+        },
+        "cve_id": "CVE-2013-0004",
+        "cve_year": 2013,
+        "state": "RESERVED",
+        "owning_cna": "cost_12",
+        "reserved": "2014-11-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
+        },
+        "time": {
+            "created": "2016-10-07T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2013-0005",
+        "cve_year": 2013,
+        "state": "REJECT",
+        "owning_cna": "magazine_15",
+        "reserved": "2016-10-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "ok_17",
+            "user": "dominiquefrench@ok_17.com"
+        },
+        "time": {
+            "created": "2011-05-18T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2013-0006",
+        "cve_year": 2013,
+        "state": "RESERVED",
+        "owning_cna": "ok_17",
+        "reserved": "2011-05-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "raise_9",
+            "user": "ashleybradley@raise_9.com"
+        },
+        "time": {
+            "created": "2018-05-15T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2013-0007",
+        "cve_year": 2013,
+        "state": "REJECT",
+        "owning_cna": "raise_9",
+        "reserved": "2018-05-15T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whatever_18",
+            "user": "stevenvalentine@whatever_18.com"
+        },
+        "time": {
+            "created": "2018-09-28T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:44.000000Z"
+        },
+        "cve_id": "CVE-2013-0008",
+        "cve_year": 2013,
+        "state": "REJECT",
+        "owning_cna": "whatever_18",
+        "reserved": "2018-09-28T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "man_5",
+            "user": "jeffreyfigueroa@man_5.com"
+        },
+        "time": {
+            "created": "2012-07-16T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2013-0009",
+        "cve_year": 2013,
+        "state": "REJECT",
+        "owning_cna": "man_5",
+        "reserved": "2012-07-16T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
+        },
+        "time": {
+            "created": "2016-12-12T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2013-0010",
+        "cve_year": 2013,
+        "state": "REJECT",
+        "owning_cna": "only_6",
+        "reserved": "2016-12-12T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whatever_18",
+            "user": "stevenvalentine@whatever_18.com"
+        },
+        "time": {
+            "created": "2020-10-24T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2014-0001",
+        "cve_year": 2014,
+        "state": "PUBLIC",
+        "owning_cna": "whatever_18",
+        "reserved": "2020-10-24T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
+        },
+        "time": {
+            "created": "2016-01-19T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2014-0002",
+        "cve_year": 2014,
+        "state": "RESERVED",
+        "owning_cna": "magazine_15",
+        "reserved": "2016-01-19T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "value_14",
+            "user": "janetdean@value_14.com"
+        },
+        "time": {
+            "created": "2016-08-25T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2014-0003",
+        "cve_year": 2014,
+        "state": "REJECT",
+        "owning_cna": "value_14",
+        "reserved": "2016-08-25T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "today_2",
+            "user": "franciscoanderson@today_2.com"
+        },
+        "time": {
+            "created": "2016-05-24T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:45.000000Z"
+        },
+        "cve_id": "CVE-2014-0004",
+        "cve_year": 2014,
+        "state": "PUBLIC",
+        "owning_cna": "today_2",
+        "reserved": "2016-05-24T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
+        },
+        "time": {
+            "created": "2019-03-05T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:46.000000Z"
+        },
+        "cve_id": "CVE-2014-0005",
+        "cve_year": 2014,
+        "state": "PUBLIC",
+        "owning_cna": "magazine_15",
+        "reserved": "2019-03-05T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "certain_10",
+            "user": "williammorris@certain_10.com"
+        },
+        "time": {
+            "created": "2016-02-05T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:46.000000Z"
+        },
+        "cve_id": "CVE-2014-0006",
+        "cve_year": 2014,
+        "state": "PUBLIC",
+        "owning_cna": "certain_10",
+        "reserved": "2016-02-05T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "song_3",
+            "user": "sandrabrown@song_3.com"
+        },
+        "time": {
+            "created": "2020-08-09T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2014-0007",
+        "cve_year": 2014,
+        "state": "RESERVED",
+        "owning_cna": "song_3",
+        "reserved": "2020-08-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "ok_17",
+            "user": "dominiquefrench@ok_17.com"
+        },
+        "time": {
+            "created": "2019-01-31T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:46.000000Z"
+        },
+        "cve_id": "CVE-2014-0008",
+        "cve_year": 2014,
+        "state": "REJECT",
+        "owning_cna": "ok_17",
+        "reserved": "2019-01-31T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whatever_18",
+            "user": "stevenvalentine@whatever_18.com"
+        },
+        "time": {
+            "created": "2019-05-20T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:46.000000Z"
+        },
+        "cve_id": "CVE-2014-0009",
+        "cve_year": 2014,
+        "state": "PUBLIC",
+        "owning_cna": "whatever_18",
+        "reserved": "2019-05-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "ok_17",
+            "user": "dominiquefrench@ok_17.com"
+        },
+        "time": {
+            "created": "2016-02-29T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:46.000000Z"
+        },
+        "cve_id": "CVE-2014-0010",
+        "cve_year": 2014,
+        "state": "RESERVED",
+        "owning_cna": "ok_17",
+        "reserved": "2016-02-29T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whether_20",
+            "user": "nicolecallahan@whether_20.com"
+        },
+        "time": {
+            "created": "2012-11-23T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2015-0001",
+        "cve_year": 2015,
+        "state": "RESERVED",
+        "owning_cna": "whether_20",
+        "reserved": "2012-11-23T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
+        },
+        "time": {
+            "created": "2012-08-10T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:47.000000Z"
+        },
+        "cve_id": "CVE-2015-0002",
+        "cve_year": 2015,
+        "state": "REJECT",
+        "owning_cna": "only_6",
+        "reserved": "2012-08-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "quickly_7",
+            "user": "ashleyanderson@quickly_7.com"
+        },
+        "time": {
+            "created": "2020-06-04T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2015-0003",
+        "cve_year": 2015,
+        "state": "RESERVED",
+        "owning_cna": "quickly_7",
+        "reserved": "2020-06-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "opportunity_13",
+            "user": "colleentorres@opportunity_13.com"
+        },
+        "time": {
+            "created": "2015-06-23T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:47.000000Z"
+        },
+        "cve_id": "CVE-2015-0004",
+        "cve_year": 2015,
+        "state": "REJECT",
+        "owning_cna": "opportunity_13",
+        "reserved": "2015-06-23T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "concern_8",
+            "user": "jasongray@concern_8.com"
+        },
+        "time": {
+            "created": "2012-08-09T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2015-0005",
+        "cve_year": 2015,
+        "state": "RESERVED",
+        "owning_cna": "concern_8",
+        "reserved": "2012-08-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "value_14",
+            "user": "janetdean@value_14.com"
+        },
+        "time": {
+            "created": "2020-10-10T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2015-0006",
+        "cve_year": 2015,
+        "state": "RESERVED",
+        "owning_cna": "value_14",
+        "reserved": "2020-10-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "opportunity_13",
+            "user": "colleentorres@opportunity_13.com"
+        },
+        "time": {
+            "created": "2013-07-27T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2015-0007",
+        "cve_year": 2015,
+        "state": "RESERVED",
+        "owning_cna": "opportunity_13",
+        "reserved": "2013-07-27T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "quickly_7",
+            "user": "ashleyanderson@quickly_7.com"
+        },
+        "time": {
+            "created": "2013-03-20T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2015-0008",
+        "cve_year": 2015,
+        "state": "REJECT",
+        "owning_cna": "quickly_7",
+        "reserved": "2013-03-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "from_11",
+            "user": "kimmiller@from_11.com"
+        },
+        "time": {
+            "created": "2011-05-29T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2015-0009",
+        "cve_year": 2015,
+        "state": "RESERVED",
+        "owning_cna": "from_11",
+        "reserved": "2011-05-29T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whatever_18",
+            "user": "stevenvalentine@whatever_18.com"
+        },
+        "time": {
+            "created": "2020-11-13T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2015-0010",
+        "cve_year": 2015,
+        "state": "RESERVED",
+        "owning_cna": "whatever_18",
+        "reserved": "2020-11-13T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whatever_18",
+            "user": "stevenvalentine@whatever_18.com"
+        },
+        "time": {
+            "created": "2013-09-19T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2016-0001",
+        "cve_year": 2016,
+        "state": "PUBLIC",
+        "owning_cna": "whatever_18",
+        "reserved": "2013-09-19T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "certain_10",
+            "user": "williammorris@certain_10.com"
+        },
+        "time": {
+            "created": "2012-05-31T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2016-0002",
+        "cve_year": 2016,
+        "state": "RESERVED",
+        "owning_cna": "certain_10",
+        "reserved": "2012-05-31T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
         },
         "time": {
             "created": "2019-04-06T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2019-0001",
-        "cve_year": 2019,
+        "cve_id": "CVE-2016-0003",
+        "cve_year": 2016,
         "state": "PUBLIC",
-        "owning_cna": "reveal_18",
+        "owning_cna": "magazine_15",
         "reserved": "2019-04-06T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "central_20",
-            "user": "shanejimenez@central_20.com"
+            "cna": "whether_20",
+            "user": "nicolecallahan@whether_20.com"
         },
         "time": {
-            "created": "2013-04-16T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2016-12-21T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:49.000000Z"
         },
-        "cve_id": "CVE-2019-0002",
-        "cve_year": 2019,
-        "state": "REJECT",
-        "owning_cna": "central_20",
-        "reserved": "2013-04-16T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "pressure_10",
-            "user": "christophersteele@pressure_10.com"
-        },
-        "time": {
-            "created": "2014-02-20T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:56.000000Z"
-        },
-        "cve_id": "CVE-2019-0003",
-        "cve_year": 2019,
+        "cve_id": "CVE-2016-0004",
+        "cve_year": 2016,
         "state": "RESERVED",
-        "owning_cna": "pressure_10",
-        "reserved": "2014-02-20T00:00:00.000000Z"
+        "owning_cna": "whether_20",
+        "reserved": "2016-12-21T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "after_3",
-            "user": "adamcox@after_3.com"
+            "cna": "man_5",
+            "user": "jeffreyfigueroa@man_5.com"
         },
         "time": {
-            "created": "2013-02-10T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:56.000000Z"
+            "created": "2015-12-09T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2019-0004",
-        "cve_year": 2019,
+        "cve_id": "CVE-2016-0005",
+        "cve_year": 2016,
         "state": "REJECT",
-        "owning_cna": "after_3",
-        "reserved": "2013-02-10T00:00:00.000000Z"
+        "owning_cna": "man_5",
+        "reserved": "2015-12-09T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "reveal_18",
-            "user": "williambeck@reveal_18.com"
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
         },
         "time": {
-            "created": "2011-09-26T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2015-06-24T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:49.000000Z"
         },
-        "cve_id": "CVE-2019-0005",
-        "cve_year": 2019,
+        "cve_id": "CVE-2016-0006",
+        "cve_year": 2016,
         "state": "REJECT",
-        "owning_cna": "reveal_18",
-        "reserved": "2011-09-26T00:00:00.000000Z"
+        "owning_cna": "only_6",
+        "reserved": "2015-06-24T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "media_7",
-            "user": "emilyperez@media_7.com"
+            "cna": "from_11",
+            "user": "kimmiller@from_11.com"
         },
         "time": {
-            "created": "2017-09-27T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2020-02-07T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:49.000000Z"
         },
-        "cve_id": "CVE-2019-0006",
-        "cve_year": 2019,
+        "cve_id": "CVE-2016-0007",
+        "cve_year": 2016,
+        "state": "PUBLIC",
+        "owning_cna": "from_11",
+        "reserved": "2020-02-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "concern_8",
+            "user": "jasongray@concern_8.com"
+        },
+        "time": {
+            "created": "2011-05-25T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2016-0008",
+        "cve_year": 2016,
+        "state": "PUBLIC",
+        "owning_cna": "concern_8",
+        "reserved": "2011-05-25T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "song_3",
+            "user": "sandrabrown@song_3.com"
+        },
+        "time": {
+            "created": "2020-01-18T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:50.000000Z"
+        },
+        "cve_id": "CVE-2016-0009",
+        "cve_year": 2016,
         "state": "REJECT",
-        "owning_cna": "media_7",
-        "reserved": "2017-09-27T00:00:00.000000Z"
+        "owning_cna": "song_3",
+        "reserved": "2020-01-18T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "at_1",
-            "user": "amandawilson@at_1.com"
+            "cna": "value_14",
+            "user": "janetdean@value_14.com"
         },
         "time": {
-            "created": "2016-02-28T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2018-09-01T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:50.000000Z"
         },
-        "cve_id": "CVE-2019-0007",
-        "cve_year": 2019,
+        "cve_id": "CVE-2016-0010",
+        "cve_year": 2016,
+        "state": "PUBLIC",
+        "owning_cna": "value_14",
+        "reserved": "2018-09-01T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
+        },
+        "time": {
+            "created": "2018-06-03T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2017-0001",
+        "cve_year": 2017,
+        "state": "REJECT",
+        "owning_cna": "only_6",
+        "reserved": "2018-06-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "concern_8",
+            "user": "jasongray@concern_8.com"
+        },
+        "time": {
+            "created": "2016-01-14T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2017-0002",
+        "cve_year": 2017,
+        "state": "PUBLIC",
+        "owning_cna": "concern_8",
+        "reserved": "2016-01-14T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "here_1",
+            "user": "jamesfreeman@here_1.com"
+        },
+        "time": {
+            "created": "2016-11-25T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:51.000000Z"
+        },
+        "cve_id": "CVE-2017-0003",
+        "cve_year": 2017,
         "state": "RESERVED",
-        "owning_cna": "at_1",
-        "reserved": "2016-02-28T00:00:00.000000Z"
+        "owning_cna": "here_1",
+        "reserved": "2016-11-25T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "imagine_16",
-            "user": "sherrylopez@imagine_16.com"
-        },
-        "time": {
-            "created": "2012-07-08T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2019-0008",
-        "cve_year": 2019,
-        "state": "REJECT",
-        "owning_cna": "imagine_16",
-        "reserved": "2012-07-08T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
-        },
-        "time": {
-            "created": "2017-05-08T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
-        },
-        "cve_id": "CVE-2019-0009",
-        "cve_year": 2019,
-        "state": "RESERVED",
-        "owning_cna": "guy_12",
-        "reserved": "2017-05-08T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "pressure_10",
-            "user": "christophersteele@pressure_10.com"
+            "cna": "cost_12",
+            "user": "codymurphy@cost_12.com"
         },
         "time": {
             "created": "2020-03-08T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:57.000000Z"
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
-        "cve_id": "CVE-2019-0010",
-        "cve_year": 2019,
-        "state": "RESERVED",
-        "owning_cna": "pressure_10",
+        "cve_id": "CVE-2017-0004",
+        "cve_year": 2017,
+        "state": "PUBLIC",
+        "owning_cna": "cost_12",
         "reserved": "2020-03-08T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
+            "cna": "whether_20",
+            "user": "nicolecallahan@whether_20.com"
         },
         "time": {
-            "created": "2015-03-01T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:58.000000Z"
+            "created": "2019-02-17T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:51.000000Z"
+        },
+        "cve_id": "CVE-2017-0005",
+        "cve_year": 2017,
+        "state": "REJECT",
+        "owning_cna": "whether_20",
+        "reserved": "2019-02-17T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whatever_18",
+            "user": "stevenvalentine@whatever_18.com"
+        },
+        "time": {
+            "created": "2018-02-08T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:51.000000Z"
+        },
+        "cve_id": "CVE-2017-0006",
+        "cve_year": 2017,
+        "state": "REJECT",
+        "owning_cna": "whatever_18",
+        "reserved": "2018-02-08T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
+        },
+        "time": {
+            "created": "2011-08-09T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2017-0007",
+        "cve_year": 2017,
+        "state": "PUBLIC",
+        "owning_cna": "magazine_15",
+        "reserved": "2011-08-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "accept_19",
+            "user": "stephenjohnson@accept_19.com"
+        },
+        "time": {
+            "created": "2011-07-24T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2017-0008",
+        "cve_year": 2017,
+        "state": "REJECT",
+        "owning_cna": "accept_19",
+        "reserved": "2011-07-24T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "raise_9",
+            "user": "ashleybradley@raise_9.com"
+        },
+        "time": {
+            "created": "2012-03-06T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2017-0009",
+        "cve_year": 2017,
+        "state": "RESERVED",
+        "owning_cna": "raise_9",
+        "reserved": "2012-03-06T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "ok_17",
+            "user": "dominiquefrench@ok_17.com"
+        },
+        "time": {
+            "created": "2015-03-03T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2017-0010",
+        "cve_year": 2017,
+        "state": "PUBLIC",
+        "owning_cna": "ok_17",
+        "reserved": "2015-03-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "quickly_7",
+            "user": "ashleyanderson@quickly_7.com"
+        },
+        "time": {
+            "created": "2020-04-10T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2018-0001",
+        "cve_year": 2018,
+        "state": "RESERVED",
+        "owning_cna": "quickly_7",
+        "reserved": "2020-04-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "concern_8",
+            "user": "jasongray@concern_8.com"
+        },
+        "time": {
+            "created": "2017-04-25T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2018-0002",
+        "cve_year": 2018,
+        "state": "RESERVED",
+        "owning_cna": "concern_8",
+        "reserved": "2017-04-25T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
+        },
+        "time": {
+            "created": "2013-04-06T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:52.000000Z"
+        },
+        "cve_id": "CVE-2018-0003",
+        "cve_year": 2018,
+        "state": "RESERVED",
+        "owning_cna": "only_6",
+        "reserved": "2013-04-06T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "concern_8",
+            "user": "jasongray@concern_8.com"
+        },
+        "time": {
+            "created": "2021-01-29T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2018-0004",
+        "cve_year": 2018,
+        "state": "PUBLIC",
+        "owning_cna": "concern_8",
+        "reserved": "2021-01-29T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
+        },
+        "time": {
+            "created": "2012-11-18T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2018-0005",
+        "cve_year": 2018,
+        "state": "RESERVED",
+        "owning_cna": "only_6",
+        "reserved": "2012-11-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
+        },
+        "time": {
+            "created": "2020-02-16T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2018-0006",
+        "cve_year": 2018,
+        "state": "PUBLIC",
+        "owning_cna": "magazine_15",
+        "reserved": "2020-02-16T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "christianromero@mitre.com"
+        },
+        "time": {
+            "created": "2020-08-18T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2018-0007",
+        "cve_year": 2018,
+        "state": "RESERVED",
+        "owning_cna": "mitre",
+        "reserved": "2020-08-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "whether_20",
+            "user": "nicolecallahan@whether_20.com"
+        },
+        "time": {
+            "created": "2013-12-24T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2018-0008",
+        "cve_year": 2018,
+        "state": "RESERVED",
+        "owning_cna": "whether_20",
+        "reserved": "2013-12-24T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
+        },
+        "time": {
+            "created": "2018-08-03T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:53.000000Z"
+        },
+        "cve_id": "CVE-2018-0009",
+        "cve_year": 2018,
+        "state": "RESERVED",
+        "owning_cna": "magazine_15",
+        "reserved": "2018-08-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "raise_9",
+            "user": "ashleybradley@raise_9.com"
+        },
+        "time": {
+            "created": "2012-12-16T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2018-0010",
+        "cve_year": 2018,
+        "state": "REJECT",
+        "owning_cna": "raise_9",
+        "reserved": "2012-12-16T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "cost_12",
+            "user": "codymurphy@cost_12.com"
+        },
+        "time": {
+            "created": "2018-01-08T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2019-0001",
+        "cve_year": 2019,
+        "state": "REJECT",
+        "owning_cna": "cost_12",
+        "reserved": "2018-01-08T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
+        },
+        "time": {
+            "created": "2011-09-01T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2019-0002",
+        "cve_year": 2019,
+        "state": "PUBLIC",
+        "owning_cna": "magazine_15",
+        "reserved": "2011-09-01T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "quickly_7",
+            "user": "ashleyanderson@quickly_7.com"
+        },
+        "time": {
+            "created": "2019-09-21T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2019-0003",
+        "cve_year": 2019,
+        "state": "REJECT",
+        "owning_cna": "quickly_7",
+        "reserved": "2019-09-21T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "song_3",
+            "user": "sandrabrown@song_3.com"
+        },
+        "time": {
+            "created": "2017-07-21T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2019-0004",
+        "cve_year": 2019,
+        "state": "RESERVED",
+        "owning_cna": "song_3",
+        "reserved": "2017-07-21T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "raise_9",
+            "user": "ashleybradley@raise_9.com"
+        },
+        "time": {
+            "created": "2013-01-20T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2019-0005",
+        "cve_year": 2019,
+        "state": "RESERVED",
+        "owning_cna": "raise_9",
+        "reserved": "2013-01-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "cost_12",
+            "user": "codymurphy@cost_12.com"
+        },
+        "time": {
+            "created": "2013-02-18T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:54.000000Z"
+        },
+        "cve_id": "CVE-2019-0006",
+        "cve_year": 2019,
+        "state": "RESERVED",
+        "owning_cna": "cost_12",
+        "reserved": "2013-02-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "from_11",
+            "user": "kimmiller@from_11.com"
+        },
+        "time": {
+            "created": "2019-08-13T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2019-0007",
+        "cve_year": 2019,
+        "state": "RESERVED",
+        "owning_cna": "from_11",
+        "reserved": "2019-08-13T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "opportunity_13",
+            "user": "colleentorres@opportunity_13.com"
+        },
+        "time": {
+            "created": "2019-06-18T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2019-0008",
+        "cve_year": 2019,
+        "state": "RESERVED",
+        "owning_cna": "opportunity_13",
+        "reserved": "2019-06-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "concern_8",
+            "user": "jasongray@concern_8.com"
+        },
+        "time": {
+            "created": "2021-01-09T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:54.000000Z"
+        },
+        "cve_id": "CVE-2019-0009",
+        "cve_year": 2019,
+        "state": "RESERVED",
+        "owning_cna": "concern_8",
+        "reserved": "2021-01-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "man_5",
+            "user": "jeffreyfigueroa@man_5.com"
+        },
+        "time": {
+            "created": "2017-04-06T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
+        },
+        "cve_id": "CVE-2019-0010",
+        "cve_year": 2019,
+        "state": "REJECT",
+        "owning_cna": "man_5",
+        "reserved": "2017-04-06T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "difference_16",
+            "user": "rebeccahenry@difference_16.com"
+        },
+        "time": {
+            "created": "2015-09-09T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2020-0001",
         "cve_year": 2020,
-        "state": "RESERVED",
-        "owning_cna": "safe_15",
-        "reserved": "2015-03-01T00:00:00.000000Z"
+        "state": "PUBLIC",
+        "owning_cna": "difference_16",
+        "reserved": "2015-09-09T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
         },
         "time": {
-            "created": "2014-06-11T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:58.000000Z"
+            "created": "2014-06-29T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2020-0002",
         "cve_year": 2020,
-        "state": "RESERVED",
-        "owning_cna": "guy_12",
-        "reserved": "2014-06-11T00:00:00.000000Z"
+        "state": "REJECT",
+        "owning_cna": "only_6",
+        "reserved": "2014-06-29T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
+            "cna": "difference_16",
+            "user": "rebeccahenry@difference_16.com"
         },
         "time": {
-            "created": "2015-02-20T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2015-07-18T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:55.000000Z"
         },
         "cve_id": "CVE-2020-0003",
         "cve_year": 2020,
-        "state": "PUBLIC",
-        "owning_cna": "front_11",
-        "reserved": "2015-02-20T00:00:00.000000Z"
+        "state": "RESERVED",
+        "owning_cna": "difference_16",
+        "reserved": "2015-07-18T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "left_2",
-            "user": "josephleon@left_2.com"
+            "cna": "raise_9",
+            "user": "ashleybradley@raise_9.com"
         },
         "time": {
-            "created": "2020-02-21T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2021-03-15T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2020-0004",
         "cve_year": 2020,
-        "state": "RESERVED",
-        "owning_cna": "left_2",
-        "reserved": "2020-02-21T00:00:00.000000Z"
+        "state": "REJECT",
+        "owning_cna": "raise_9",
+        "reserved": "2021-03-15T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "easy_5",
-            "user": "vernonvazquez@easy_5.com"
+            "cna": "value_14",
+            "user": "janetdean@value_14.com"
         },
         "time": {
-            "created": "2016-10-16T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2020-03-10T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2020-0005",
         "cve_year": 2020,
-        "state": "RESERVED",
-        "owning_cna": "easy_5",
-        "reserved": "2016-10-16T00:00:00.000000Z"
+        "state": "PUBLIC",
+        "owning_cna": "value_14",
+        "reserved": "2020-03-10T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "at_1",
-            "user": "amandawilson@at_1.com"
+            "cna": "ok_17",
+            "user": "dominiquefrench@ok_17.com"
         },
         "time": {
-            "created": "2011-08-31T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2017-03-27T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2020-0006",
         "cve_year": 2020,
         "state": "PUBLIC",
-        "owning_cna": "at_1",
-        "reserved": "2011-08-31T00:00:00.000000Z"
+        "owning_cna": "ok_17",
+        "reserved": "2017-03-27T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "pressure_10",
-            "user": "christophersteele@pressure_10.com"
+            "cna": "only_6",
+            "user": "davidmcguire@only_6.com"
         },
         "time": {
-            "created": "2013-10-31T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2018-08-26T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2020-0007",
         "cve_year": 2020,
         "state": "RESERVED",
-        "owning_cna": "pressure_10",
-        "reserved": "2013-10-31T00:00:00.000000Z"
+        "owning_cna": "only_6",
+        "reserved": "2018-08-26T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "attorney_13",
-            "user": "jessicaburnett@attorney_13.com"
+            "cna": "from_11",
+            "user": "kimmiller@from_11.com"
         },
         "time": {
-            "created": "2012-01-10T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:59.000000Z"
+            "created": "2014-11-13T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2020-0008",
         "cve_year": 2020,
-        "state": "REJECT",
-        "owning_cna": "attorney_13",
-        "reserved": "2012-01-10T00:00:00.000000Z"
+        "state": "RESERVED",
+        "owning_cna": "from_11",
+        "reserved": "2014-11-13T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
+            "cna": "quickly_7",
+            "user": "ashleyanderson@quickly_7.com"
         },
         "time": {
-            "created": "2020-11-18T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2015-09-09T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2020-0009",
         "cve_year": 2020,
         "state": "RESERVED",
-        "owning_cna": "safe_15",
-        "reserved": "2020-11-18T00:00:00.000000Z"
+        "owning_cna": "quickly_7",
+        "reserved": "2015-09-09T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
+            "cna": "raise_9",
+            "user": "ashleybradley@raise_9.com"
         },
         "time": {
-            "created": "2012-10-07T00:00:00.000000Z",
-            "modified": "2021-03-18T15:34:59.000000Z"
+            "created": "2021-02-07T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2020-0010",
         "cve_year": 2020,
-        "state": "RESERVED",
-        "owning_cna": "front_11",
-        "reserved": "2012-10-07T00:00:00.000000Z"
+        "state": "REJECT",
+        "owning_cna": "raise_9",
+        "reserved": "2021-02-07T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "after_3",
-            "user": "adamcox@after_3.com"
+            "cna": "song_3",
+            "user": "sandrabrown@song_3.com"
         },
         "time": {
-            "created": "2018-04-06T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2011-05-20T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2021-0001",
         "cve_year": 2021,
-        "state": "REJECT",
-        "owning_cna": "after_3",
-        "reserved": "2018-04-06T00:00:00.000000Z"
+        "state": "RESERVED",
+        "owning_cna": "song_3",
+        "reserved": "2011-05-20T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "safe_15",
-            "user": "allisonthomas@safe_15.com"
+            "cna": "whatever_18",
+            "user": "stevenvalentine@whatever_18.com"
         },
         "time": {
-            "created": "2011-11-11T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2013-09-01T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2021-0002",
         "cve_year": 2021,
         "state": "RESERVED",
-        "owning_cna": "safe_15",
-        "reserved": "2011-11-11T00:00:00.000000Z"
+        "owning_cna": "whatever_18",
+        "reserved": "2013-09-01T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "front_11",
-            "user": "sandrapreston@front_11.com"
+            "cna": "raise_9",
+            "user": "ashleybradley@raise_9.com"
         },
         "time": {
-            "created": "2018-07-07T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2013-11-04T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2021-0003",
         "cve_year": 2021,
         "state": "REJECT",
-        "owning_cna": "front_11",
-        "reserved": "2018-07-07T00:00:00.000000Z"
+        "owning_cna": "raise_9",
+        "reserved": "2013-11-04T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "central_20",
-            "user": "shanejimenez@central_20.com"
+            "cna": "today_2",
+            "user": "franciscoanderson@today_2.com"
         },
         "time": {
-            "created": "2018-01-16T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2020-08-02T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:57.000000Z"
         },
         "cve_id": "CVE-2021-0004",
         "cve_year": 2021,
-        "state": "RESERVED",
-        "owning_cna": "central_20",
-        "reserved": "2018-01-16T00:00:00.000000Z"
+        "state": "PUBLIC",
+        "owning_cna": "today_2",
+        "reserved": "2020-08-02T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "television_9",
-            "user": "marybond@television_9.com"
+            "cna": "man_5",
+            "user": "jeffreyfigueroa@man_5.com"
         },
         "time": {
-            "created": "2019-12-18T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2018-02-01T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2021-0005",
         "cve_year": 2021,
-        "state": "PUBLIC",
-        "owning_cna": "television_9",
-        "reserved": "2019-12-18T00:00:00.000000Z"
+        "state": "RESERVED",
+        "owning_cna": "man_5",
+        "reserved": "2018-02-01T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "guy_12",
-            "user": "anthonyvalenzuela@guy_12.com"
+            "cna": "magazine_15",
+            "user": "jameshansen@magazine_15.com"
         },
         "time": {
-            "created": "2016-06-02T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2013-12-15T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2021-0006",
         "cve_year": 2021,
         "state": "RESERVED",
-        "owning_cna": "guy_12",
-        "reserved": "2016-06-02T00:00:00.000000Z"
+        "owning_cna": "magazine_15",
+        "reserved": "2013-12-15T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "at_1",
-            "user": "amandawilson@at_1.com"
+            "cna": "whether_20",
+            "user": "nicolecallahan@whether_20.com"
         },
         "time": {
-            "created": "2019-05-11T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2015-01-06T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:57.000000Z"
         },
         "cve_id": "CVE-2021-0007",
         "cve_year": 2021,
         "state": "RESERVED",
-        "owning_cna": "at_1",
-        "reserved": "2019-05-11T00:00:00.000000Z"
+        "owning_cna": "whether_20",
+        "reserved": "2015-01-06T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "some_19",
-            "user": "melaniejones@some_19.com"
+            "cna": "here_1",
+            "user": "jamesfreeman@here_1.com"
         },
         "time": {
-            "created": "2018-04-29T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2018-07-31T00:00:00.000000Z",
+            "modified": "2021-04-21T02:08:58.000000Z"
         },
         "cve_id": "CVE-2021-0008",
         "cve_year": 2021,
         "state": "REJECT",
-        "owning_cna": "some_19",
-        "reserved": "2018-04-29T00:00:00.000000Z"
+        "owning_cna": "here_1",
+        "reserved": "2018-07-31T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "imagine_16",
-            "user": "sherrylopez@imagine_16.com"
+            "cna": "concern_8",
+            "user": "jasongray@concern_8.com"
         },
         "time": {
-            "created": "2018-01-22T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:00.000000Z"
+            "created": "2017-11-01T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2021-0009",
         "cve_year": 2021,
-        "state": "RESERVED",
-        "owning_cna": "imagine_16",
-        "reserved": "2018-01-22T00:00:00.000000Z"
+        "state": "PUBLIC",
+        "owning_cna": "concern_8",
+        "reserved": "2017-11-01T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "television_9",
-            "user": "marybond@television_9.com"
+            "cna": "whatever_18",
+            "user": "stevenvalentine@whatever_18.com"
         },
         "time": {
-            "created": "2016-10-23T00:00:00.000000Z",
-            "modified": "2021-03-18T15:35:08.984553Z"
+            "created": "2020-05-09T00:00:00.000000Z",
+            "modified": "2021-04-21T02:09:05.156373Z"
         },
         "cve_id": "CVE-2021-0010",
         "cve_year": 2021,
         "state": "RESERVED",
-        "owning_cna": "television_9",
-        "reserved": "2016-10-23T00:00:00.000000Z"
+        "owning_cna": "whatever_18",
+        "reserved": "2020-05-09T00:00:00.000000Z"
     }
 ]

--- a/datadump/pre-population/cves.json
+++ b/datadump/pre-population/cves.json
@@ -1,80 +1,8 @@
 [
     {
         "time": {
-            "created": "2011-04-14T00:00:00.000000Z",
+            "created": "2012-06-07T00:00:00.000000Z",
             "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-1999-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-10-19T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-1999-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Center your expert at let."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-06-21T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-1999-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Authority maybe child wind significant drive over. Certainly stage project same local scene later return."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-08-11T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:21.658190+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -89,7 +17,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "First people available parent appear different."
+                        "value": "Organization speak concern buy available fish."
                     }
                 ]
             }
@@ -97,31 +25,7 @@
     },
     {
         "time": {
-            "created": "2016-12-27T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-1999-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Must ago agree. Art notice produce data."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-02-10T00:00:00.000000Z",
+            "created": "2020-03-31T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -130,175 +34,14 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-1999-0006",
-                "ASSIGNER": "sandrapreston@front_11.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Turner, Brady and Davis",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "maintain",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "lose, minute, view, know, owner, girl"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Reduced foreground functionalities"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "EARLY",
-                        "name": "Ryan Miller",
-                        "url": "http://ray-jackson.net/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Nathaniel Leon",
-                        "url": "https://haney.com/homepage/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Detail heavy democratic campaign. Ground article other environmental official."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-09-10T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-1999-0007",
-                "ASSIGNER": "allisonthomas@safe_15.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Perez-Mccarty",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "already",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "most, kitchen, information, rise, fast, than"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Reduced foreground functionalities"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "FAR",
-                        "name": "Elizabeth Sampson",
-                        "url": "http://www.joyce.com/posts/categories/app/about.php"
-                    },
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Kathy Rodriguez",
-                        "url": "http://casey.com/main.asp"
-                    },
-                    {
-                        "refsource": "SEAT",
-                        "name": "Ricardo Anderson",
-                        "url": "https://www.harrington.biz/wp-content/tags/about.php"
-                    },
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Joseph Armstrong",
-                        "url": "http://www.henderson.com/tag/list/explore/post.htm"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Laura Miller",
-                        "url": "https://simpson.com/terms/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Base decide product situation west economy. Important consumer wear leader wrong east."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-05-27T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-1999-0008",
                 "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
+                "STATE": "REJECT"
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                        "value": "Car national short including cut. Wait government discussion option knowledge already. State hotel option yourself nature test point."
                     }
                 ]
             }
@@ -306,8 +49,8 @@
     },
     {
         "time": {
-            "created": "2012-01-19T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:22.442228+00:00"
+            "created": "2013-08-09T00:00:00.000000Z",
+            "modified": null
         },
         "cve": {
             "data_type": "CVE",
@@ -322,7 +65,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Research dark way paper. Your deep establish quality hit happy. Girl watch here where meet."
+                        "value": "Lead drop another use. Trial talk each discussion gun I million. Figure character history."
                     }
                 ]
             }
@@ -330,7 +73,7 @@
     },
     {
         "time": {
-            "created": "2021-02-16T00:00:00.000000Z",
+            "created": "2015-09-20T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -339,46 +82,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-1999-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Reveal name way girl buy else of. Read effort rock dinner board quality artist. Under attorney level after."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-12-22T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2000-0001",
-                "ASSIGNER": "anthonyvalenzuela@guy_12.com",
+                "ASSIGNER": "kimmiller@from_11.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Fisher LLC",
+                            "vendor_name": "Graves PLC",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "dinner",
+                                        "product_name": "either",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "describe, century, weight"
+                                                    "version_value": "small, center, board, stand, visit, attack"
                                                 }
                                             ]
                                         }
@@ -395,7 +114,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "n/a"
+                                "value": "Open-source 6thgeneration standardization"
                             }
                         ]
                     }
@@ -404,49 +123,19 @@
             "references": {
                 "reference_data": [
                     {
+                        "refsource": "DARK",
+                        "name": "Marcia Johnson",
+                        "url": "https://smith-perkins.net/tags/terms.jsp"
+                    },
+                    {
                         "refsource": "CONFIRM",
-                        "name": "https://mooney.info/explore/tag/blog/faq.html",
-                        "url": "https://mooney.info/explore/tag/blog/faq.html"
+                        "name": "https://www.morales.com/tags/main/home.asp",
+                        "url": "https://www.morales.com/tags/main/home.asp"
                     },
                     {
-                        "refsource": "WAIT",
-                        "name": "Kyle Sullivan",
-                        "url": "https://www.arnold-grant.info/explore/app/category.php"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Michael Robinson",
-                        "url": "https://www.miller.com/terms/"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Marvin Wood",
-                        "url": "https://www.juarez-roth.info/categories/search/tags/register/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Nathaniel Leon",
-                        "url": "https://haney.com/homepage/"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Jessica Johnson",
-                        "url": "https://www.stewart.com/"
-                    },
-                    {
-                        "refsource": "ADD",
-                        "name": "Sheena Calhoun",
-                        "url": "https://www.stone.net/"
-                    },
-                    {
-                        "refsource": "MACHINE",
-                        "name": "April Garrett",
-                        "url": "https://www.miles.net/about.jsp"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Lynn Glover",
-                        "url": "http://www.klein-howard.biz/about.html"
+                        "refsource": "HAPPY",
+                        "name": "Mr. Matthew Nguyen MD",
+                        "url": "https://www.decker.com/explore/blog/faq.jsp"
                     }
                 ]
             },
@@ -454,7 +143,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Man key writer clearly. Performance receive see little."
+                        "value": "Stand away record however administration. Ball particular remember chance effort."
                     }
                 ]
             }
@@ -462,7 +151,31 @@
     },
     {
         "time": {
-            "created": "2017-02-03T00:00:00.000000Z",
+            "created": "2013-04-10T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:21.211813+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2000-0001",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Social hotel letter cover pull less you might. Pretty several hand magazine decide appear activity beat. Save true again end memory yard growth. Hard push least."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-11-30T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -478,7 +191,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Door until seek soon rate some. Opportunity whom everybody."
+                        "value": "Whether subject increase field few. Determine bar across cause. Husband item our case card director. Figure floor camera style region site low."
                     }
                 ]
             }
@@ -486,55 +199,7 @@
     },
     {
         "time": {
-            "created": "2017-05-20T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2000-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Choose popular wife fine. Protect town once. Course risk goal war. Sport save today analysis."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-03-02T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2000-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Difficult whatever process economy increase perform if century. Start speech spring rate decade while sea great. Stuff suffer power or receive account."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-03-01T00:00:00.000000Z",
+            "created": "2011-07-10T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -543,14 +208,78 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2000-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
+                "ASSIGNER": "williammorris@certain_10.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Noble Group",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "green",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "determine"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Cross-platform logistical artificial intelligence"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "http://www.thompson-gibson.info/post.htm",
+                        "url": "http://www.thompson-gibson.info/post.htm"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "Sara Erickson",
+                        "url": "http://www.williams.com/"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Matthew Gonzales",
+                        "url": "https://www.ross-jackson.com/privacy/"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Mary Morales",
+                        "url": "http://www.adams-ramirez.com/search/"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Jeffrey Davis",
+                        "url": "https://miller.info/"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                        "value": "Build system class cost clear shoulder year. Order radio money story office card."
                     }
                 ]
             }
@@ -558,8 +287,8 @@
     },
     {
         "time": {
-            "created": "2019-07-05T00:00:00.000000Z",
-            "modified": null
+            "created": "2019-10-19T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:22.007071+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -567,114 +296,6 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2000-0006",
-                "ASSIGNER": "sherrylopez@imagine_16.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Lewis-Serrano",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "herself",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "style, current, this"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Robust non-volatile middleware"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "EARLY",
-                        "name": "Lydia Martin",
-                        "url": "http://brown.org/index.html"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Shawn Peterson",
-                        "url": "https://www.green-rojas.com/posts/categories/about/"
-                    },
-                    {
-                        "refsource": "SEAT",
-                        "name": "Eugene Levy",
-                        "url": "https://tate-sanchez.com/homepage.jsp"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Nathaniel Leon",
-                        "url": "https://haney.com/homepage/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Amy Campbell",
-                        "url": "https://www.johnson.info/categories/list/privacy/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Melinda Levine",
-                        "url": "http://taylor.com/homepage/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Jamie Turner",
-                        "url": "https://www.aguilar-martinez.org/author.jsp"
-                    },
-                    {
-                        "refsource": "ADD",
-                        "name": "Sheena Calhoun",
-                        "url": "https://www.stone.net/"
-                    },
-                    {
-                        "refsource": "SEAT",
-                        "name": "Diana Reynolds",
-                        "url": "https://www.edwards.com/category/wp-content/list/about/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Probably I matter set list drug. Challenge music difference along experience care others. Everybody deep never federal treat table eye issue."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-02-07T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:23.963133+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2000-0007",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -682,7 +303,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "I professional site herself recently behavior. Situation institution meeting recognize successful."
+                        "value": "Century magazine up glass land even analysis. Language would piece level bank interest. Long sell small everyone single possible."
                     }
                 ]
             }
@@ -690,7 +311,7 @@
     },
     {
         "time": {
-            "created": "2017-08-31T00:00:00.000000Z",
+            "created": "2016-02-22T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -698,101 +319,23 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2000-0008",
-                "ASSIGNER": "williambeck@reveal_18.com",
+                "ID": "CVE-2000-0007",
+                "ASSIGNER": "dominiquefrench@ok_17.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Wilkerson-Rodriguez",
+                            "vendor_name": "Cox Group",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "break",
+                                        "product_name": "stop",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "black, argue, explain"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Customizable 3rdgeneration productivity"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Barry Frank",
-                        "url": "https://www.mcdaniel-roberts.biz/search.htm"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Kristen Ferguson",
-                        "url": "http://www.williams.info/"
-                    },
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Gabrielle Henry",
-                        "url": "https://www.johnson-white.com/main/blog/register.htm"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Suddenly people field science look. Quite measure win miss author summer argue something. Relationship identify foreign realize."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-05-28T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2000-0009",
-                "ASSIGNER": "pennyhodge@them_17.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Harmon-Powell",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "make",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "no, dinner, everything, movie"
+                                                    "version_value": "pay, success, police, difficult, but"
                                                 }
                                             ]
                                         }
@@ -818,24 +361,44 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "EARLY",
-                        "name": "Lydia Martin",
-                        "url": "http://brown.org/index.html"
+                        "refsource": "HAPPY",
+                        "name": "Christopher Lewis",
+                        "url": "https://www.saunders-wright.com/"
                     },
                     {
-                        "refsource": "CONFIRM",
-                        "name": "http://www.johnson.com/login.php",
-                        "url": "http://www.johnson.com/login.php"
+                        "refsource": "BALL",
+                        "name": "April Silva",
+                        "url": "http://henry.biz/category/register/"
                     },
                     {
-                        "refsource": "TEND",
-                        "name": "Laura Jackson",
-                        "url": "http://garcia.com/tags/search/"
+                        "refsource": "PARTICULAR",
+                        "name": "Catherine Adams",
+                        "url": "https://www.sanchez.com/posts/posts/app/author/"
                     },
                     {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Laura Miller",
-                        "url": "https://simpson.com/terms/"
+                        "refsource": "GENERATION",
+                        "name": "Jared Reyes",
+                        "url": "https://www.holloway.biz/"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Joshua Walls",
+                        "url": "https://www.arroyo.biz/post/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "Karen Ray",
+                        "url": "https://www.ruiz.org/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "Katherine Richard",
+                        "url": "https://www.holland.biz/tag/app/about/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
                     }
                 ]
             },
@@ -843,7 +406,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Seat high score democratic next resource. Middle small according effort stock. Pattern society gun yes draw her."
+                        "value": "Above take building behavior. Land into themselves especially toward brother risk."
                     }
                 ]
             }
@@ -851,8 +414,91 @@
     },
     {
         "time": {
-            "created": "2019-11-13T00:00:00.000000Z",
-            "modified": null
+            "created": "2012-01-13T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:22.454789+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2000-0009",
+                "ASSIGNER": "stevenvalentine@whatever_18.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Roberts-Martin",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "soon",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "almost, clear, whom, character, through, interesting"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "De-engineered uniform open system"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "http://www.thompson-gibson.info/post.htm",
+                        "url": "http://www.thompson-gibson.info/post.htm"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "April Silva",
+                        "url": "http://henry.biz/category/register/"
+                    },
+                    {
+                        "refsource": "THESE",
+                        "name": "Jeffrey Davis",
+                        "url": "http://www.wright-lamb.com/index.html"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Catherine Adams",
+                        "url": "https://www.sanchez.com/posts/posts/app/author/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Student clear effect radio man day writer city. True why article source fire wide."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2014-06-02T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:22.634323+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -860,14 +506,78 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2000-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
+                "ASSIGNER": "davidmcguire@only_6.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Kelly-Singh",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "theory",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "friend, rich, conference, performance, lawyer, central"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "n/a"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "DARK",
+                        "name": "Emily Gutierrez",
+                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
+                    },
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Angelica Delgado",
+                        "url": "https://perry.com/register.html"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://escobar.com/homepage.php",
+                        "url": "http://escobar.com/homepage.php"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Jared Reyes",
+                        "url": "https://www.holloway.biz/"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "Allison Jensen",
+                        "url": "https://www.miller.com/terms.htm"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                        "value": "Capital behind without discuss city by owner clearly. Author various stay trade stand people run."
                     }
                 ]
             }
@@ -875,8 +585,8 @@
     },
     {
         "time": {
-            "created": "2016-08-13T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:24.633146+00:00"
+            "created": "2011-08-26T00:00:00.000000Z",
+            "modified": null
         },
         "cve": {
             "data_type": "CVE",
@@ -884,14 +594,98 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2001-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
+                "ASSIGNER": "jamesvaldez@technology_4.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Ballard Inc",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "reveal",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "figure, answer"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Total systemic portal"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Angela Anderson",
+                        "url": "http://drake.net/search.jsp"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Karen Rogers",
+                        "url": "https://www.willis.biz/list/tags/main/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Brett Krause",
+                        "url": "http://curtis-campbell.com/"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Kayla Hill",
+                        "url": "http://smith.net/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Marcia Johnson",
+                        "url": "https://smith-perkins.net/tags/terms.jsp"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Jeffrey Garcia",
+                        "url": "http://www.vega-fuentes.com/search/list/about/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.morales.com/tags/main/home.asp",
+                        "url": "https://www.morales.com/tags/main/home.asp"
+                    },
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Samantha Heath MD",
+                        "url": "http://knapp.com/blog/blog/category.php"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "John Sullivan",
+                        "url": "http://www.palmer.com/author/"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Take market across maintain."
+                        "value": "School already true share attention of well. Also responsibility down forward piece voice mission. Ability morning seem deal."
                     }
                 ]
             }
@@ -899,32 +693,8 @@
     },
     {
         "time": {
-            "created": "2015-02-26T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2001-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Walk bank remain audience true. Growth marriage cultural skill turn ten war."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-09-17T00:00:00.000000Z",
-            "modified": null
+            "created": "2011-12-13T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:23.282017+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -939,7 +709,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "During argue old. Good decision air professor animal. Break have area you billion again. Fine both school six role."
+                        "value": "Raise arm crime product safe husband American. Defense from market red him not local. Son outside opportunity war plan best."
                     }
                 ]
             }
@@ -947,244 +717,7 @@
     },
     {
         "time": {
-            "created": "2013-07-24T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2001-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Player physical north child military. Form write team attorney war minute apply. Then admit forward act."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-05-24T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2001-0005",
-                "ASSIGNER": "shanejimenez@central_20.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Lewis, Bell and Hansen",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "arm",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "heavy, education, provide"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "WAIT",
-                        "name": "Kyle Sullivan",
-                        "url": "https://www.arnold-grant.info/explore/app/category.php"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://whitehead-lopez.net/app/list/search/login/",
-                        "url": "https://whitehead-lopez.net/app/list/search/login/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Reflect top so good easy agent their. Must bring during when century. Economic able million way."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-03-31T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:25.347928+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2001-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Late factor if idea onto. For its lead state half skin garden. Hour effect southern detail thank."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-06-10T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2001-0007",
-                "ASSIGNER": "jessicaburnett@attorney_13.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Jacobs, Ford and Greene",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "commercial",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "trade, five, stop, less, any"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Reduced foreground functionalities"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CASE",
-                        "name": "Kristen Ferguson",
-                        "url": "http://www.williams.info/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Test them family power green. Young public life possible. Detail picture street thought live almost voice."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-12-25T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:25.751485+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2001-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Soon either once build land. Soldier they forward a build stand network."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-11-05T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2001-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Eight reveal sort wish note wind could suddenly. Off cup two rate second green cup. Consider unit cause be simple several."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-10-08T00:00:00.000000Z",
+            "created": "2014-09-02T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -1200,7 +733,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "City civil southern art."
+                        "value": "Protect risk whose every skill. Drug leave he everybody."
                     }
                 ]
             }
@@ -1208,55 +741,7 @@
     },
     {
         "time": {
-            "created": "2019-01-30T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:26.199467+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2002-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-06-01T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2002-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Man these short effect letter. Politics door car throughout indicate. Gas ask sell help plan."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-11-14T00:00:00.000000Z",
+            "created": "2021-03-21T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -1265,46 +750,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2002-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Bag simple phone itself government available. Itself determine painting past wait."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-07-22T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2002-0004",
-                "ASSIGNER": "adamcox@after_3.com",
+                "ASSIGNER": "jasongray@concern_8.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Simon, Garza and Berry",
+                            "vendor_name": "Smith-Cooper",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "remain",
+                                        "product_name": "nature",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "board, deep, never, window, happy, strong, much, cultural, Mrs"
+                                                    "version_value": "sound, bar, word, change, usually, new, result, their, anything"
                                                 }
                                             ]
                                         }
@@ -1330,4277 +791,17 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "EARLY",
-                        "name": "Ryan Miller",
-                        "url": "http://ray-jackson.net/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Robin Perry",
-                        "url": "https://macias-young.com/terms/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Subject edge above act part. Method study maybe hundred safe. Remember sit and attorney."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-12-26T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2002-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Fly pay campaign writer environment stock accept site. My bit third stand about."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-08-30T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2002-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Result job career. Arrive people yet military training off similar suggest. Catch here future let."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-12-21T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2002-0007",
-                "ASSIGNER": "shanejimenez@central_20.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Lara, Knapp and Vazquez",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "information",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "any, game, view, morning"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "SEAT",
-                        "name": "Ricardo Anderson",
-                        "url": "https://www.harrington.biz/wp-content/tags/about.php"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Prepare local toward finish discuss behavior. Central usually dream treat car. Financial instead top author."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-07-20T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2002-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-08-21T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2002-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Police town several two return minute would condition. Employee media lead scientist record green."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-12-09T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:27.595187+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2002-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Argue various open number attorney laugh door. Someone training lay result from join."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-11-24T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2003-0001",
-                "ASSIGNER": "melaniejones@some_19.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Garcia PLC",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "court",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "gas, agreement, under, yeah"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "TEND",
-                        "name": "Misty Hoffman",
-                        "url": "http://www.carr-sanchez.com/"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Jason Knapp",
-                        "url": "https://www.grimes.org/wp-content/explore/category/faq.php"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Field center policy natural marriage skin. True little again certain nearly run enjoy."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-11-27T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2003-0002",
-                "ASSIGNER": "melaniejones@some_19.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Sanchez, Meyers and Collier",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "foot",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "three, take, off, class, film, card, look, upon, agreement"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.barajas-williams.com/about.html",
-                        "url": "http://www.barajas-williams.com/about.html"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Shawn Peterson",
-                        "url": "https://www.green-rojas.com/posts/categories/about/"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Laura Jackson",
-                        "url": "http://garcia.com/tags/search/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Coach begin research a director role ten military. Eight some analysis traditional grow they exactly."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-05-08T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2003-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2021-03-03T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2003-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Seem rich join. Shake daughter itself fire. Enjoy senior onto unit get skill ball."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-06-05T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2003-0005",
-                "ASSIGNER": "sherrylopez@imagine_16.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Lopez, Morrison and Turner",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "create",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "record"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Customizable 3rdgeneration productivity"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.miller-herrera.com/posts/blog/category.html",
-                        "url": "http://www.miller-herrera.com/posts/blog/category.html"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Ryan Miller",
-                        "url": "http://ray-jackson.net/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Vickie Macdonald",
-                        "url": "https://www.haas-rosario.biz/author/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Goal short activity nearly entire. Serve myself after fly somebody though program. Also short bed significant."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-06-04T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2003-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "May know easy front animal really list. Police economic start share middle. Choose citizen American pay improve full."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-03-10T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:28.458736+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2003-0007",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Person seven maybe beat. Full until test produce fear hold describe."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-09-12T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2003-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Anyone unit much finish approach hope. Total fill explain culture. Night from six two gun theory grow."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-02-12T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2003-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Without simple can truth control dog. Heart investment always executive red assume next tell. Theory recent situation whom."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-10-15T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:29.031926+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2003-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-12-01T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2004-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Daughter work degree. Like student various magazine pay scene capital Mrs. Tend your watch bring newspaper professional."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-11-23T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2004-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Person seven know body prove happy. Interview size week."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-11-17T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2004-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Near sport eye call save. Teach avoid wall cost. While form those almost style since."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-07-19T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2004-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-11-26T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2004-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-05-19T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2004-0006",
-                "ASSIGNER": "sherrylopez@imagine_16.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Sherman-Montes",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "trial",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "next, difficult"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Virtual system-worthy alliance"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "FAR",
-                        "name": "Elizabeth Sampson",
-                        "url": "http://www.joyce.com/posts/categories/app/about.php"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.barajas-williams.com/about.html",
-                        "url": "http://www.barajas-williams.com/about.html"
-                    },
-                    {
-                        "refsource": "ADD",
-                        "name": "Eric Ortiz",
-                        "url": "http://sanchez.com/tag/category/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Melinda Levine",
-                        "url": "http://taylor.com/homepage/"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Kristen Ferguson",
-                        "url": "http://www.williams.info/"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Monica Long",
-                        "url": "http://collier-ramirez.net/category.htm"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Donna Medina",
-                        "url": "http://jackson.biz/search/category/category/login/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Large nothing agreement participant. Suggest rich myself. Feeling father total nature like ahead."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2011-08-07T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2004-0007",
-                "ASSIGNER": "adamcox@after_3.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Bond, Ward and Blevins",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "want",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "seem, those, Mrs, always, spring, likely"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Reduced foreground functionalities"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.barajas-williams.com/about.html",
-                        "url": "http://www.barajas-williams.com/about.html"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://www.glover.net/",
-                        "url": "https://www.glover.net/"
-                    },
-                    {
-                        "refsource": "SEAT",
-                        "name": "Eugene Levy",
-                        "url": "https://tate-sanchez.com/homepage.jsp"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Nathaniel Leon",
-                        "url": "https://haney.com/homepage/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://clark.com/main/categories/login.asp",
-                        "url": "https://clark.com/main/categories/login.asp"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Tyler Bentley",
-                        "url": "https://www.reese-reyes.net/categories/faq/"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Jason Knapp",
-                        "url": "https://www.grimes.org/wp-content/explore/category/faq.php"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Monica Long",
-                        "url": "http://collier-ramirez.net/category.htm"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Inside represent must."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-12-08T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2004-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-01-21T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2004-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Not whose visit evidence two."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-08-07T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:30.729903+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2004-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Type box drug central. Arrive commercial scientist mention."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-09-01T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:30.992315+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2005-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Return interesting college receive amount. Quite successful research. Indicate manager reveal bit from interest. What would ever."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-11-27T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:31.154144+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2005-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "High maintain personal instead possible that strong. Organization only likely treatment happy probably large."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-07-21T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:31.365436+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2005-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "College the debate significant. Instead wrong bag feel doctor."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-10-15T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2005-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Food data left research. Fear than right election expect to nature. Poor west participant center."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-12-15T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2005-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-06-13T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2005-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Live notice specific performance project. Pressure event food just sea."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-12-16T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2005-0007",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Role employee party believe. Argue thing cultural author benefit car. Project television life admit."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-06-29T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2005-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-08-20T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2005-0009",
-                "ASSIGNER": "sandrapreston@front_11.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Barber Inc",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "large",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "drug, quality, sometimes, still, character, trouble"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Reduced foreground functionalities"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "FAR",
-                        "name": "Elizabeth Sampson",
-                        "url": "http://www.joyce.com/posts/categories/app/about.php"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Michelle Poole",
-                        "url": "https://www.fitzpatrick-buckley.biz/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Robin Perry",
-                        "url": "https://macias-young.com/terms/"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "http://www.johnson.com/login.php",
-                        "url": "http://www.johnson.com/login.php"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Kristen Ferguson",
-                        "url": "http://www.williams.info/"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Tyler Bentley",
-                        "url": "https://www.reese-reyes.net/categories/faq/"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Jeffrey Moses",
-                        "url": "https://hubbard.com/homepage/"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Monica Long",
-                        "url": "http://collier-ramirez.net/category.htm"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Donna Medina",
-                        "url": "http://jackson.biz/search/category/category/login/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Next wide skill believe bed particularly throw. Ask themselves teacher catch fill southern here. Kitchen goal various."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-02-06T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2005-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-12-02T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2006-0001",
-                "ASSIGNER": "sherrylopez@imagine_16.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Brown-Campos",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "operation",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "matter, government, court, standard, speak, management, number, reach, than"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "EARLY",
-                        "name": "Melinda Levine",
-                        "url": "http://taylor.com/homepage/"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Misty Hoffman",
-                        "url": "http://www.carr-sanchez.com/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://hunter.com/",
-                        "url": "http://hunter.com/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Robert Garcia",
-                        "url": "http://medina-green.com/author/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Which me push book often sing. Certainly information deep performance marriage common."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2011-09-20T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:33.144810+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2006-0002",
-                "ASSIGNER": "emilyperez@media_7.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Smith, Roy and Matthews",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "operation",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "scientist, arrive, successful, here"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Robust non-volatile middleware"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.miller-herrera.com/posts/blog/category.html",
-                        "url": "http://www.miller-herrera.com/posts/blog/category.html"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Michelle Poole",
-                        "url": "https://www.fitzpatrick-buckley.biz/"
-                    },
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Kathy Rodriguez",
-                        "url": "http://casey.com/main.asp"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "James Blevins",
-                        "url": "https://long.com/homepage/"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Laura Jackson",
-                        "url": "http://garcia.com/tags/search/"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Barry Frank",
-                        "url": "https://www.mcdaniel-roberts.biz/search.htm"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Jamie Turner",
-                        "url": "https://www.aguilar-martinez.org/author.jsp"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Misty Hoffman",
-                        "url": "http://www.carr-sanchez.com/"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Jessica Johnson",
-                        "url": "https://www.stewart.com/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Robert Garcia",
-                        "url": "http://medina-green.com/author/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Vickie Macdonald",
-                        "url": "https://www.haas-rosario.biz/author/"
-                    },
-                    {
-                        "refsource": "ADD",
-                        "name": "Anthony Dean",
-                        "url": "http://www.king.biz/tags/wp-content/homepage/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Require bill better successful. Ever front approach wide defense and. Clearly forget loss north vote together."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-04-18T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2006-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Over occur sense number remain. This likely loss tree."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-07-24T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:33.455950+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2006-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Kitchen day ability just avoid. Few religious old sound. Money one out event hundred result air decision."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-08-21T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2006-0005",
-                "ASSIGNER": "christophersteele@pressure_10.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Anderson-Blackwell",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "team",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "hard, service, attorney, test, study, over, wind"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://mooney.info/explore/tag/blog/faq.html",
-                        "url": "https://mooney.info/explore/tag/blog/faq.html"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Elizabeth Sampson",
-                        "url": "http://www.joyce.com/posts/categories/app/about.php"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Shawn Peterson",
-                        "url": "https://www.green-rojas.com/posts/categories/about/"
-                    },
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Kathy Rodriguez",
-                        "url": "http://casey.com/main.asp"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Robin Perry",
-                        "url": "https://macias-young.com/terms/"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Marvin Wood",
-                        "url": "https://www.juarez-roth.info/categories/search/tags/register/"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "James Blevins",
-                        "url": "https://long.com/homepage/"
-                    },
-                    {
-                        "refsource": "SEAT",
-                        "name": "Ricardo Anderson",
-                        "url": "https://www.harrington.biz/wp-content/tags/about.php"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://clark.com/main/categories/login.asp",
-                        "url": "https://clark.com/main/categories/login.asp"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Jessica Johnson",
-                        "url": "https://www.stewart.com/"
-                    },
-                    {
-                        "refsource": "ADD",
-                        "name": "Sheena Calhoun",
-                        "url": "https://www.stone.net/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Economy rise exactly admit system record huge."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-05-18T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2006-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Bed apply project deep stand. Bed range build. Religious beyond low interview."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-08-05T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2006-0007",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-03-05T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2006-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Officer yes few eat treatment night career. Trouble book alone focus but."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-09-25T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2006-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Also light ok my environmental not."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-08-08T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2006-0010",
-                "ASSIGNER": "jeremiahlloyd@either_4.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Wilson, Franco and Bowman",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "reduce",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "fall, cost, again, west, culture, foreign, party, area"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Robust non-volatile middleware"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "EARLY",
-                        "name": "Ryan Miller",
-                        "url": "http://ray-jackson.net/"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Kyle Sullivan",
-                        "url": "https://www.arnold-grant.info/explore/app/category.php"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Sandra Duran MD",
-                        "url": "https://www.dominguez-thomas.net/app/search/about.html"
-                    },
-                    {
-                        "refsource": "ADD",
-                        "name": "Sheena Calhoun",
-                        "url": "https://www.stone.net/"
-                    },
-                    {
-                        "refsource": "MACHINE",
-                        "name": "April Garrett",
-                        "url": "https://www.miles.net/about.jsp"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Tyler Bentley",
-                        "url": "https://www.reese-reyes.net/categories/faq/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Robert Garcia",
-                        "url": "http://medina-green.com/author/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Most for turn must last represent themselves. Ask value course turn office."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-02-11T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2007-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Western notice give member film player."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-12-29T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2007-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Picture near be tonight task."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-06-15T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:35.284082+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2007-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-05-01T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2007-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Garden should employee. Change ready close treatment process leader eight."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-12-16T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2007-0005",
-                "ASSIGNER": "emilyperez@media_7.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Valenzuela, Sexton and Fisher",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "water",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "form, certain"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Customizable 3rdgeneration productivity"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "TEND",
-                        "name": "Laura Jackson",
-                        "url": "http://garcia.com/tags/search/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Robert Garcia",
-                        "url": "http://medina-green.com/author/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Attention range institution respond occur. Charge involve including movement throughout Congress."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2011-12-09T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2007-0006",
-                "ASSIGNER": "sandrapreston@front_11.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Rogers PLC",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "leg",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "knowledge, month, local, now, actually"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Customizable 3rdgeneration productivity"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "FAR",
-                        "name": "Elizabeth Sampson",
-                        "url": "http://www.joyce.com/posts/categories/app/about.php"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Amy Campbell",
-                        "url": "https://www.johnson.info/categories/list/privacy/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://whitehead-lopez.net/app/list/search/login/",
-                        "url": "https://whitehead-lopez.net/app/list/search/login/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Decide number far. Black about employee continue meet. Such character debate less low."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-06-24T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2007-0007",
-                "ASSIGNER": "allisonthomas@safe_15.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Garrett-Higgins",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "western",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "require, dream, name, treatment, scientist, weight"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Customer-focused full-range productivity"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CASE",
-                        "name": "Shawn Peterson",
-                        "url": "https://www.green-rojas.com/posts/categories/about/"
-                    },
-                    {
-                        "refsource": "ADD",
-                        "name": "Eric Ortiz",
-                        "url": "http://sanchez.com/tag/category/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Ryan Miller",
-                        "url": "http://ray-jackson.net/"
-                    },
-                    {
-                        "refsource": "SEAT",
-                        "name": "Ricardo Anderson",
-                        "url": "https://www.harrington.biz/wp-content/tags/about.php"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Barry Frank",
-                        "url": "https://www.mcdaniel-roberts.biz/search.htm"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Misty Hoffman",
-                        "url": "http://www.carr-sanchez.com/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Robert Garcia",
-                        "url": "http://medina-green.com/author/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Lynn Glover",
-                        "url": "http://www.klein-howard.biz/about.html"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Jeffrey Moses",
-                        "url": "https://hubbard.com/homepage/"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Donna Medina",
-                        "url": "http://jackson.biz/search/category/category/login/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "By just draw growth serious us matter hold. Decision mind including support north. As room administration return edge."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-08-27T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2007-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Deep base artist effort middle way. Letter page figure when agree office official."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-09-26T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2007-0009",
-                "ASSIGNER": "adamcox@after_3.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Perez, Brown and Parker",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "explain",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "serve, work, right, poor, reality, light, language"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Customer-focused full-range productivity"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CASE",
-                        "name": "Shawn Peterson",
-                        "url": "https://www.green-rojas.com/posts/categories/about/"
-                    },
-                    {
-                        "refsource": "ADD",
-                        "name": "Eric Ortiz",
-                        "url": "http://sanchez.com/tag/category/"
-                    },
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Kathy Rodriguez",
-                        "url": "http://casey.com/main.asp"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Mason Jimenez",
-                        "url": "https://www.white.com/privacy.asp"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.ramirez-fisher.biz/wp-content/list/index.html",
-                        "url": "http://www.ramirez-fisher.biz/wp-content/list/index.html"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://whitehead-lopez.net/app/list/search/login/",
-                        "url": "https://whitehead-lopez.net/app/list/search/login/"
-                    },
-                    {
-                        "refsource": "MACHINE",
-                        "name": "April Garrett",
-                        "url": "https://www.miles.net/about.jsp"
-                    },
-                    {
-                        "refsource": "SEAT",
-                        "name": "Diana Reynolds",
-                        "url": "https://www.edwards.com/category/wp-content/list/about/"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Jeffrey Moses",
-                        "url": "https://hubbard.com/homepage/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Situation use fact issue. Dream far item necessary whom family could. Foreign strong while song suddenly exactly their."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-09-02T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2007-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "More accept onto decision ok. Room mean on fill gun them modern. Total ability later wonder."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-01-07T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2008-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Live piece section player understand before hospital. Help fish here. Bag town state side. Evidence entire official its yes exactly sport."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-01-21T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2008-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "News responsibility day with will. Recent city past but produce. South yes responsibility trip lot despite."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-11-22T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2008-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Owner paper reduce bed financial rock. Ball piece great employee thousand ability gas."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2011-12-01T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2008-0004",
-                "ASSIGNER": "sandrapreston@front_11.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Robertson-Eaton",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "argue",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "do, player, with, describe, challenge, century, face"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Customizable 3rdgeneration productivity"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CASE",
-                        "name": "Shawn Peterson",
-                        "url": "https://www.green-rojas.com/posts/categories/about/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://www.glover.net/",
-                        "url": "https://www.glover.net/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Amy Campbell",
-                        "url": "https://www.johnson.info/categories/list/privacy/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://clark.com/main/categories/login.asp",
-                        "url": "https://clark.com/main/categories/login.asp"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Although family hospital rest outside exist detail. Place again there."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-10-25T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:37.031501+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2008-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Husband need different because. Music number back wide. Test necessary style TV figure."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-11-05T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2008-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "May benefit professor real body. Hotel reality reach rise start nearly purpose. Whatever mean conference."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-06-18T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2008-0007",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Change business rock travel. Official which need. Figure suffer edge author score."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-10-22T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2008-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Go chance bad decision. Father remember poor all. Process inside something choose by."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-12-29T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2008-0009",
-                "ASSIGNER": "vernonvazquez@easy_5.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Lopez, Hernandez and Cardenas",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "her",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "Mr, talk, quickly, less, white, position, spring, third, country"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Customer-focused full-range productivity"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CASE",
-                        "name": "Michelle Poole",
-                        "url": "https://www.fitzpatrick-buckley.biz/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Ryan Miller",
-                        "url": "http://ray-jackson.net/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.ramirez-fisher.biz/wp-content/list/index.html",
-                        "url": "http://www.ramirez-fisher.biz/wp-content/list/index.html"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Nathaniel Leon",
-                        "url": "https://haney.com/homepage/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Amy Campbell",
-                        "url": "https://www.johnson.info/categories/list/privacy/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Melinda Levine",
-                        "url": "http://taylor.com/homepage/"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Misty Hoffman",
-                        "url": "http://www.carr-sanchez.com/"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Jeffrey Moses",
-                        "url": "https://hubbard.com/homepage/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Vickie Macdonald",
-                        "url": "https://www.haas-rosario.biz/author/"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Donna Medina",
-                        "url": "http://jackson.biz/search/category/category/login/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "We degree concern five. Wonder place wide class wife safe several take."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2011-06-23T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2008-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Sea would radio TV arm rock best. Need economic member determine leader space. Political describe too teach."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-06-21T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:37.998883+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2009-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-12-26T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:38.171250+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2009-0002",
-                "ASSIGNER": "josephleon@left_2.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Bautista, Montgomery and Bruce",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "school",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "daughter, a, respond"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Customer-focused full-range productivity"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CASE",
-                        "name": "Michelle Poole",
-                        "url": "https://www.fitzpatrick-buckley.biz/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.barajas-williams.com/about.html",
-                        "url": "http://www.barajas-williams.com/about.html"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Ryan Miller",
-                        "url": "http://ray-jackson.net/"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Barry Frank",
-                        "url": "https://www.mcdaniel-roberts.biz/search.htm"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Jamie Turner",
-                        "url": "https://www.aguilar-martinez.org/author.jsp"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Jessica Johnson",
-                        "url": "https://www.stewart.com/"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Kristen Ferguson",
-                        "url": "http://www.williams.info/"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Tyler Bentley",
-                        "url": "https://www.reese-reyes.net/categories/faq/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Casey Arellano",
-                        "url": "http://davis.com/"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Jeffrey Moses",
-                        "url": "https://hubbard.com/homepage/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Building inside them live. Score hold light establish. Election young church art scientist."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-12-30T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2009-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "College all make southern play positive. Right far cold wonder necessary expert approach."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-06-27T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:38.533909+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2009-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Laugh various paper ever arm. Practice religious toward."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-06-12T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2009-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Admit adult girl fact. Challenge arm him sound author. Authority better or later table."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-10-19T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2009-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Question sign fight project another. Project care special."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-06-29T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2009-0007",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-02-23T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2009-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-12-01T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:39.273005+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2009-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Receive ask rise movement account article they. Others party himself reflect them. Charge field debate great condition."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-03-14T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:39.481420+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2009-0010",
-                "ASSIGNER": "marybond@television_9.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Spears-Hall",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "help",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "notice"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Customizable 3rdgeneration productivity"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://mooney.info/explore/tag/blog/faq.html",
-                        "url": "https://mooney.info/explore/tag/blog/faq.html"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Shawn Peterson",
-                        "url": "https://www.green-rojas.com/posts/categories/about/"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Laura Jackson",
-                        "url": "http://garcia.com/tags/search/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://clark.com/main/categories/login.asp",
-                        "url": "https://clark.com/main/categories/login.asp"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://hunter.com/",
-                        "url": "http://hunter.com/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Robert Garcia",
-                        "url": "http://medina-green.com/author/"
-                    },
-                    {
-                        "refsource": "SEAT",
-                        "name": "Diana Reynolds",
-                        "url": "https://www.edwards.com/category/wp-content/list/about/"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Jason Knapp",
-                        "url": "https://www.grimes.org/wp-content/explore/category/faq.php"
-                    },
-                    {
-                        "refsource": "ADD",
-                        "name": "Anthony Dean",
-                        "url": "http://www.king.biz/tags/wp-content/homepage/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Life phone own heart statement game enjoy too. Risk people land last send group. Many finally by present ability great note name."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-07-16T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Response stop participant these know. Alone recently reality executive."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-06-07T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Anything soon student garden civil. Clear left ten return sit on sense really. Glass find admit road."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-05-24T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:39.887661+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Position everyone mean music scientist. Baby include until forget reach blue student."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-01-17T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Ever cause happy around happy. Production order class use figure western. Stock ready race require."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-06-20T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0005",
-                "ASSIGNER": "sherrylopez@imagine_16.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "French, Phillips and Burns",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "visit",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "remain, growth, commercial"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Customer-focused full-range productivity"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.miller-herrera.com/posts/blog/category.html",
-                        "url": "http://www.miller-herrera.com/posts/blog/category.html"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Elizabeth Sampson",
-                        "url": "http://www.joyce.com/posts/categories/app/about.php"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.ramirez-fisher.biz/wp-content/list/index.html",
-                        "url": "http://www.ramirez-fisher.biz/wp-content/list/index.html"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Sort need single team."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-06-25T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Standard music program rise play."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-03-15T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:40.483955+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0007",
-                "ASSIGNER": "vincentaguilar@tend_14.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Rogers and Sons",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "both",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "movement, stop, century, of, music, recognize, leader, attention, cause"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Reduced foreground functionalities"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CASE",
-                        "name": "Shawn Peterson",
-                        "url": "https://www.green-rojas.com/posts/categories/about/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Ryan Miller",
-                        "url": "http://ray-jackson.net/"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Kyle Sullivan",
-                        "url": "https://www.arnold-grant.info/explore/app/category.php"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://www.glover.net/",
-                        "url": "https://www.glover.net/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Robin Perry",
-                        "url": "https://macias-young.com/terms/"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Mason Jimenez",
-                        "url": "https://www.white.com/privacy.asp"
-                    },
-                    {
-                        "refsource": "SEAT",
-                        "name": "Ricardo Anderson",
-                        "url": "https://www.harrington.biz/wp-content/tags/about.php"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Barry Frank",
-                        "url": "https://www.mcdaniel-roberts.biz/search.htm"
-                    },
-                    {
-                        "refsource": "SEAT",
-                        "name": "Diana Reynolds",
-                        "url": "https://www.edwards.com/category/wp-content/list/about/"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Monica Long",
-                        "url": "http://collier-ramirez.net/category.htm"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Accept focus woman issue decision. Fight receive fly account."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-05-05T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-10-30T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Up day smile middle growth. Woman since senior cell remember at thought. Cut agency require effect story small term."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-02-15T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Two spend truth. Remain operation material center ability big. Everyone two figure law. Out often service loss soon hold."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-07-30T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-02-23T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-08-10T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:41.692641+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-04-28T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Foot air produce could. Speech bit pressure already expert. Subject identify with experience father. Current treatment system indeed conference cause."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-04-12T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Home include TV. Account realize do garden. Continue else response around."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-07-28T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2021-02-20T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:42.480653+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0007",
-                "ASSIGNER": "vernonvazquez@easy_5.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Foster-Smith",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "her",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "station"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Virtual system-worthy alliance"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CASE",
-                        "name": "Shawn Peterson",
-                        "url": "https://www.green-rojas.com/posts/categories/about/"
-                    },
-                    {
-                        "refsource": "ADD",
-                        "name": "Eric Ortiz",
-                        "url": "http://sanchez.com/tag/category/"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Kyle Sullivan",
-                        "url": "https://www.arnold-grant.info/explore/app/category.php"
-                    },
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Kathy Rodriguez",
-                        "url": "http://casey.com/main.asp"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.ramirez-fisher.biz/wp-content/list/index.html",
-                        "url": "http://www.ramirez-fisher.biz/wp-content/list/index.html"
-                    },
-                    {
-                        "refsource": "SEAT",
-                        "name": "Ricardo Anderson",
-                        "url": "https://www.harrington.biz/wp-content/tags/about.php"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Barry Frank",
-                        "url": "https://www.mcdaniel-roberts.biz/search.htm"
-                    },
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Joseph Armstrong",
-                        "url": "http://www.henderson.com/tag/list/explore/post.htm"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Casey Arellano",
-                        "url": "http://davis.com/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://hunter.com/",
-                        "url": "http://hunter.com/"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Jason Knapp",
-                        "url": "https://www.grimes.org/wp-content/explore/category/faq.php"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Article all about. Get owner cut event appear court find ahead."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-04-19T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:42.564736+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Yourself sing art from yourself leg. Which agent late simple concern say detail."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-11-25T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Such language low miss friend."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-07-31T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:42.845956+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Sign draw wear there trip current model strategy. Goal agreement support reach station despite head plan. Amount speak season administration."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-03-14T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:43.103994+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2012-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Lot become leg teach kind treatment. Technology I western end than. Camera five without may present often."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2021-02-21T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2012-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-01-02T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2012-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-06-03T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:43.690257+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2012-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-11-29T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2012-0005",
-                "ASSIGNER": "josephleon@left_2.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Valentine-Lowe",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "hit",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "likely, authority, Congress, by, arm, kind"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "EARLY",
-                        "name": "Lydia Martin",
-                        "url": "http://brown.org/index.html"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.miller-herrera.com/posts/blog/category.html",
-                        "url": "http://www.miller-herrera.com/posts/blog/category.html"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Shawn Peterson",
-                        "url": "https://www.green-rojas.com/posts/categories/about/"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Kyle Sullivan",
-                        "url": "https://www.arnold-grant.info/explore/app/category.php"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "http://www.johnson.com/login.php",
-                        "url": "http://www.johnson.com/login.php"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Mason Jimenez",
-                        "url": "https://www.white.com/privacy.asp"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Jamie Turner",
-                        "url": "https://www.aguilar-martinez.org/author.jsp"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://clark.com/main/categories/login.asp",
-                        "url": "https://clark.com/main/categories/login.asp"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Misty Hoffman",
-                        "url": "http://www.carr-sanchez.com/"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Donna Medina",
-                        "url": "http://jackson.biz/search/category/category/login/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Show smile thousand generation choice threat draw. Development maybe act message. Others court hot poor reveal study."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-07-05T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2012-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Until never number large sea ever. Theory successful fact son window star than. Article suggest gas suggest."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-01-09T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2012-0007",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-02-20T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2012-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-03-04T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2012-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-05-31T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:44.843488+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2012-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Then catch night church physical western prove. Serve including choice idea sing Mrs security. About strong fight high him step. Staff act must."
+                        "refsource": "BECAUSE",
+                        "name": "Kristina Carter",
+                        "url": "http://www.pennington.com/explore/index/"
                     }
                 ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-02-25T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2013-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                        "value": "Discuss control information. Guess guy begin recognize situation. Institution experience southern."
                     }
                 ]
             }
@@ -5616,31 +817,7 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2013-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-01-27T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2013-0003",
+                "ID": "CVE-2002-0004",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -5648,7 +825,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Military the else stock reflect in wrong send. Admit event experience job."
+                        "value": "Rich goal team federal instead exist. Billion another onto beat partner life hear."
                     }
                 ]
             }
@@ -5656,7 +833,7 @@
     },
     {
         "time": {
-            "created": "2014-09-30T00:00:00.000000Z",
+            "created": "2020-01-09T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -5664,23 +841,23 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2013-0004",
-                "ASSIGNER": "amandawilson@at_1.com",
+                "ID": "CVE-2002-0007",
+                "ASSIGNER": "rebeccahenry@difference_16.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Evans PLC",
+                            "vendor_name": "Chapman, Gonzalez and Wade",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "interview",
+                                        "product_name": "begin",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "general, particular, much, enough, perhaps, teach"
+                                                    "version_value": "third, him"
                                                 }
                                             ]
                                         }
@@ -5697,7 +874,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "n/a"
+                                "value": "Open-source 6thgeneration standardization"
                             }
                         ]
                     }
@@ -5706,59 +883,14 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "EARLY",
-                        "name": "Michael Robinson",
-                        "url": "https://www.miller.com/terms/"
-                    },
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Kathy Rodriguez",
-                        "url": "http://casey.com/main.asp"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Nathaniel Leon",
-                        "url": "https://haney.com/homepage/"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Barry Frank",
-                        "url": "https://www.mcdaniel-roberts.biz/search.htm"
-                    },
-                    {
                         "refsource": "MISC",
-                        "name": "https://clark.com/main/categories/login.asp",
-                        "url": "https://clark.com/main/categories/login.asp"
+                        "name": "http://escobar.com/homepage.php",
+                        "url": "http://escobar.com/homepage.php"
                     },
                     {
-                        "refsource": "TEND",
-                        "name": "Misty Hoffman",
-                        "url": "http://www.carr-sanchez.com/"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Kristen Ferguson",
-                        "url": "http://www.williams.info/"
-                    },
-                    {
-                        "refsource": "ADD",
-                        "name": "Sheena Calhoun",
-                        "url": "https://www.stone.net/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://hunter.com/",
-                        "url": "http://hunter.com/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Vickie Macdonald",
-                        "url": "https://www.haas-rosario.biz/author/"
-                    },
-                    {
-                        "refsource": "ADD",
-                        "name": "Anthony Dean",
-                        "url": "http://www.king.biz/tags/wp-content/homepage/"
+                        "refsource": "HAPPY",
+                        "name": "Mr. Matthew Nguyen MD",
+                        "url": "https://www.decker.com/explore/blog/faq.jsp"
                     }
                 ]
             },
@@ -5766,7 +898,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Product audience see bring message. Receive his meet present when movie writer. Opportunity him sister family analysis arrive technology."
+                        "value": "Until likely tell very again child. Assume firm then close place. Beat coach past available Mr along."
                     }
                 ]
             }
@@ -5774,7 +906,7 @@
     },
     {
         "time": {
-            "created": "2014-09-23T00:00:00.000000Z",
+            "created": "2014-05-03T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -5782,7 +914,7 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2013-0005",
+                "ID": "CVE-2002-0009",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -5790,7 +922,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Thank myself prepare may purpose challenge forget blood. Word professional this. Future exactly subject work significant."
+                        "value": "Discussion line whether themselves. Firm her apply forget course discuss establish. Population show court every crime."
                     }
                 ]
             }
@@ -5798,7 +930,7 @@
     },
     {
         "time": {
-            "created": "2012-03-07T00:00:00.000000Z",
+            "created": "2016-02-08T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -5806,7 +938,7 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2013-0006",
+                "ID": "CVE-2002-0010",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -5814,7 +946,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Leave single well surface fight. Amount according important once away. Tv number bring security film address also ten."
+                        "value": "Single car attention. Soon college fight key. Need cause billion school money director."
                     }
                 ]
             }
@@ -5822,7 +954,7 @@
     },
     {
         "time": {
-            "created": "2018-01-09T00:00:00.000000Z",
+            "created": "2014-03-04T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -5830,7 +962,90 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2013-0007",
+                "ID": "CVE-2003-0003",
+                "ASSIGNER": "rebeccahenry@difference_16.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Williams PLC",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "city",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "end, evening, style"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Cross-platform logistical artificial intelligence"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Troy Gutierrez",
+                        "url": "http://richards.com/post/"
+                    },
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Angelica Delgado",
+                        "url": "https://perry.com/register.html"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Mr. Matthew Nguyen MD",
+                        "url": "https://www.decker.com/explore/blog/faq.jsp"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "Karen Ray",
+                        "url": "https://www.ruiz.org/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Bar spring support town old act where. Laugh issue situation have suddenly."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2021-03-12T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2003-0006",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -5838,7 +1053,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Sit hard international player there. Decision everyone walk good."
+                        "value": "With general art institution southern miss. Argue maybe expect those those support. Painting car compare this believe such collection."
                     }
                 ]
             }
@@ -5846,7 +1061,7 @@
     },
     {
         "time": {
-            "created": "2016-11-13T00:00:00.000000Z",
+            "created": "2017-08-09T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -5854,56 +1069,8 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2013-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Military expect skin. Office remember about lay subject huge represent. Information machine because question almost model fast. Whether hear wait home."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-02-07T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2013-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Power growth capital pass. Major chance might form international nor. Spring improve deal term high practice."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-08-26T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2013-0010",
-                "ASSIGNER": "angelajohnson@mitre.com",
+                "ID": "CVE-2003-0007",
+                "ASSIGNER": "christianromero@mitre.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
@@ -5944,24 +1111,49 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "EARLY",
-                        "name": "Lydia Martin",
-                        "url": "http://brown.org/index.html"
+                        "refsource": "THESE",
+                        "name": "Michael Carroll",
+                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
                     },
                     {
-                        "refsource": "EARLY",
-                        "name": "Michael Robinson",
-                        "url": "https://www.miller.com/terms/"
+                        "refsource": "MISC",
+                        "name": "https://clark.biz/",
+                        "url": "https://clark.biz/"
                     },
                     {
-                        "refsource": "AUDIENCE",
-                        "name": "Joseph Armstrong",
-                        "url": "http://www.henderson.com/tag/list/explore/post.htm"
+                        "refsource": "ITEM",
+                        "name": "Eric Thompson",
+                        "url": "https://nunez.com/blog/homepage.html"
                     },
                     {
-                        "refsource": "AUDIENCE",
-                        "name": "Gabrielle Henry",
-                        "url": "https://www.johnson-white.com/main/blog/register.htm"
+                        "refsource": "THOUGH",
+                        "name": "Sara Erickson",
+                        "url": "http://www.williams.com/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "April Silva",
+                        "url": "http://henry.biz/category/register/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://www.mcgee.biz/index/",
+                        "url": "http://www.mcgee.biz/index/"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Erin Taylor",
+                        "url": "http://www.miller.com/search/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Scott Wise",
+                        "url": "http://www.gardner.com/main/post/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "Karen Ray",
+                        "url": "https://www.ruiz.org/"
                     }
                 ]
             },
@@ -5969,7 +1161,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Eight into any door."
+                        "value": "Opportunity cost today save indicate modern rise. Program pretty sister teacher bed."
                     }
                 ]
             }
@@ -5977,23 +1169,92 @@
     },
     {
         "time": {
-            "created": "2020-03-28T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:46.929696+00:00"
+            "created": "2013-10-27T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:27.820280+00:00"
         },
         "cve": {
             "data_type": "CVE",
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2014-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
+                "ID": "CVE-2003-0008",
+                "ASSIGNER": "colleentorres@opportunity_13.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Hayden-Griffin",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "share",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "month, soldier, card, usually, parent, until, gun, yes"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Digitized eco-centric frame"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "THESE",
+                        "name": "Michael Carroll",
+                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Patrick Ross",
+                        "url": "http://www.aguilar.com/"
+                    },
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Angelica Delgado",
+                        "url": "https://perry.com/register.html"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://escobar.com/homepage.php",
+                        "url": "http://escobar.com/homepage.php"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Scott Wise",
+                        "url": "http://www.gardner.com/main/post/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "Katherine Richard",
+                        "url": "https://www.holland.biz/tag/app/about/"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Answer my education performance much doctor kind. Purpose audience help try business country. Street three military raise between."
+                        "value": "Design large event get consider. Past tell own song evidence. Far despite rather role nothing class thus."
                     }
                 ]
             }
@@ -6001,7 +1262,7 @@
     },
     {
         "time": {
-            "created": "2013-07-16T00:00:00.000000Z",
+            "created": "2012-09-04T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -6009,7 +1270,7 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2014-0002",
+                "ID": "CVE-2003-0009",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -6017,7 +1278,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Situation late campaign team throw reality. National ago keep surface son season white. Stay scientist early employee sea."
+                        "value": "Note yes drop long serve matter. Agreement simply community they. Claim for page drive computer enjoy."
                     }
                 ]
             }
@@ -6025,8 +1286,2812 @@
     },
     {
         "time": {
-            "created": "2013-04-28T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:47.208120+00:00"
+            "created": "2018-11-17T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:28.116039+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2003-0010",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "New job agent drug. Less little two church. Doctor free value."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2016-12-23T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2004-0005",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Everyone remain certain firm provide impact. Worker quite blood behavior current."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2018-06-02T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2004-0006",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Various surface manage organization. Republican total for defense. Above want seat environment."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2017-10-07T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2004-0007",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Exist cause style lawyer. Shake environment decade treat full because at step. Draw environmental head minute approach. Team party avoid recent film it."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-07-28T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2004-0010",
+                "ASSIGNER": "codymurphy@cost_12.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Smith-Howe",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "instead",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "board, somebody, morning, business, television, with, she, both"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "De-engineered uniform open system"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.reynolds.com/posts/main/explore/author.htm",
+                        "url": "https://www.reynolds.com/posts/main/explore/author.htm"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "http://www.thompson-gibson.info/post.htm",
+                        "url": "http://www.thompson-gibson.info/post.htm"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Eric Thompson",
+                        "url": "https://nunez.com/blog/homepage.html"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Logan Vazquez",
+                        "url": "http://wilson.com/main/blog/login.asp"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Dr. Roger Patterson Jr.",
+                        "url": "http://rodriguez.com/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Discover mother figure line time water. Yeah take firm capital. Business strong body position. Light travel administration administration to determine feel."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2015-01-22T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:30.202642+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2005-0003",
+                "ASSIGNER": "ashleybradley@raise_9.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Hansen Inc",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "family",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "better, general, himself, most, nearly, information, most"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "De-engineered uniform open system"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "DARK",
+                        "name": "Emily Gutierrez",
+                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Mary Morales",
+                        "url": "http://www.adams-ramirez.com/search/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Logan Vazquez",
+                        "url": "http://wilson.com/main/blog/login.asp"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Job determine perform work language. Industry news picture record."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2016-10-04T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2005-0005",
+                "ASSIGNER": "williammorris@certain_10.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Jones, Mitchell and Sims",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "treat",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "decision, structure, agency, wait"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "n/a"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "MISC",
+                        "name": "https://clark.biz/",
+                        "url": "https://clark.biz/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "Tammy Phillips",
+                        "url": "https://lee.com/posts/register/"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "Sara Erickson",
+                        "url": "http://www.williams.com/"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Matthew Gonzales",
+                        "url": "https://www.ross-jackson.com/privacy/"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Mary Morales",
+                        "url": "http://www.adams-ramirez.com/search/"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Jared Reyes",
+                        "url": "https://www.holloway.biz/"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Amy Morgan",
+                        "url": "https://hart.com/list/post.php"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Dr. Roger Patterson Jr.",
+                        "url": "http://rodriguez.com/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.morales.com/tags/main/home.asp",
+                        "url": "https://www.morales.com/tags/main/home.asp"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Matthew Wheeler",
+                        "url": "http://www.davis.org/"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Joshua Walls",
+                        "url": "https://www.arroyo.biz/post/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Store story hard. Cultural sea art school set recent. Measure explain computer worry. Consumer specific indeed know pick very fact."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2018-08-14T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:30.860142+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2005-0006",
+                "ASSIGNER": "sandrabrown@song_3.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Cross-Allen",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "lay",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "improve, ok, number, somebody, it, effort, PM, fund"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Cross-platform logistical artificial intelligence"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Jared Reyes",
+                        "url": "https://www.holloway.biz/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Jeffrey Garcia",
+                        "url": "http://www.vega-fuentes.com/search/list/about/"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Amy Morgan",
+                        "url": "https://hart.com/list/post.php"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Mr. Matthew Nguyen MD",
+                        "url": "https://www.decker.com/explore/blog/faq.jsp"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "John Sullivan",
+                        "url": "http://www.palmer.com/author/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "You ground family keep within."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2017-01-11T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2005-0008",
+                "ASSIGNER": "dominiquefrench@ok_17.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Brown PLC",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "sometimes",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "hair, firm, chair"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "De-engineered uniform open system"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Catherine Adams",
+                        "url": "https://www.sanchez.com/posts/posts/app/author/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Culture ever woman. Benefit meet public certainly whose."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-12-31T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:31.242774+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2005-0009",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Glass point yard stop clearly. Bag car time response game. Garden yard above upon so particular."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2012-11-18T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2006-0001",
+                "ASSIGNER": "sandrabrown@song_3.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Rios, Nichols and Bradley",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "evidence",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "religious, seven, pull, bit"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Digitized eco-centric frame"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Kristina Carter",
+                        "url": "http://www.pennington.com/explore/index/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.reynolds.com/posts/main/explore/author.htm",
+                        "url": "https://www.reynolds.com/posts/main/explore/author.htm"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://willis.info/main/",
+                        "url": "https://willis.info/main/"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Christopher Lewis",
+                        "url": "https://www.saunders-wright.com/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Emily Gutierrez",
+                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Logan Vazquez",
+                        "url": "http://wilson.com/main/blog/login.asp"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Jared Reyes",
+                        "url": "https://www.holloway.biz/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Jeffrey Garcia",
+                        "url": "http://www.vega-fuentes.com/search/list/about/"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Erin Taylor",
+                        "url": "http://www.miller.com/search/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Physical cause along health shake return. Political art store guy how reach throughout. Sit market serve city myself difficult."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-01-23T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2006-0004",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Purpose share that spend black. Color seven when hold."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2017-09-07T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2006-0005",
+                "ASSIGNER": "rebeccahenry@difference_16.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Perry Group",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "computer",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "full, resource, represent, friend, somebody, decade, minute, join"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Digitized eco-centric frame"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "THESE",
+                        "name": "Michael Carroll",
+                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Jeffrey Garcia",
+                        "url": "http://www.vega-fuentes.com/search/list/about/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Scott Wise",
+                        "url": "http://www.gardner.com/main/post/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Republican tough lawyer left make yard control. Nearly rich east structure bad smile. None somebody central across fight."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2015-01-22T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2006-0006",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Financial behavior appear make cultural."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-02-26T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2006-0007",
+                "ASSIGNER": "jeffreyfigueroa@man_5.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Lozano-Brown",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "down",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "blue, own, rate"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Open-source 6thgeneration standardization"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "DARK",
+                        "name": "Jeffrey Garcia",
+                        "url": "http://www.vega-fuentes.com/search/list/about/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Other least true discussion who. Second build too use page heavy hope computer."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2016-12-18T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:33.317397+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2007-0002",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Quite lose low loss among describe since. Attack leave provide. Expert order better quality his southern stand."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2012-02-13T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2007-0004",
+                "ASSIGNER": "stephenjohnson@accept_19.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Lucas, Jones and Glass",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "per",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "person, kind"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "De-engineered uniform open system"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "http://www.thompson-gibson.info/post.htm",
+                        "url": "http://www.thompson-gibson.info/post.htm"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Karen Rogers",
+                        "url": "https://www.willis.biz/list/tags/main/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://willis.info/main/",
+                        "url": "https://willis.info/main/"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "Sara Erickson",
+                        "url": "http://www.williams.com/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "April Silva",
+                        "url": "http://henry.biz/category/register/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Kathleen Garcia",
+                        "url": "http://www.morris.com/app/index/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Emily Gutierrez",
+                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Amy Morgan",
+                        "url": "https://hart.com/list/post.php"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.morales.com/tags/main/home.asp",
+                        "url": "https://www.morales.com/tags/main/home.asp"
+                    },
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Samantha Heath MD",
+                        "url": "http://knapp.com/blog/blog/category.php"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Pass pay say million. Seven affect create mention. But manage give thus image."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2016-07-30T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2007-0008",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Yet little trial beautiful her then. Team upon successful same."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-03-15T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2007-0010",
+                "ASSIGNER": "nicolecallahan@whether_20.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Vargas, Collins and Parker",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "compare",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "ok, thing, peace, late, improve"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Total systemic portal"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "THESE",
+                        "name": "Michael Carroll",
+                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://www.andrews.com/faq/",
+                        "url": "https://www.andrews.com/faq/"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Matthew Gonzales",
+                        "url": "https://www.ross-jackson.com/privacy/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://hall.biz/",
+                        "url": "https://hall.biz/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Logan Vazquez",
+                        "url": "http://wilson.com/main/blog/login.asp"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Jeffrey Garcia",
+                        "url": "http://www.vega-fuentes.com/search/list/about/"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "Allison Jensen",
+                        "url": "https://www.miller.com/terms.htm"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "John Sullivan",
+                        "url": "http://www.palmer.com/author/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Should pay finally over find build. Thing find always entire try. Season actually let."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2015-10-28T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2008-0003",
+                "ASSIGNER": "jeffreyfigueroa@man_5.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Hubbard Inc",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "past",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "medical, my"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "n/a"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.reynolds.com/posts/main/explore/author.htm",
+                        "url": "https://www.reynolds.com/posts/main/explore/author.htm"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://clark.biz/",
+                        "url": "https://clark.biz/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://www.andrews.com/faq/",
+                        "url": "https://www.andrews.com/faq/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Emily Gutierrez",
+                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Erin Taylor",
+                        "url": "http://www.miller.com/search/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Instead maybe staff sea wall. Brother more factor defense he. Very strategy mother surface professional protect."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-07-13T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:35.637722+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2008-0005",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Institution grow management gas require star. Most board need Congress spring bag responsibility course."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-01-26T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2008-0006",
+                "ASSIGNER": "nicolecallahan@whether_20.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Larsen-Allen",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "morning",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "into"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Cross-platform logistical artificial intelligence"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "ITEM",
+                        "name": "Eric Thompson",
+                        "url": "https://nunez.com/blog/homepage.html"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Logan Vazquez",
+                        "url": "http://wilson.com/main/blog/login.asp"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Matthew Wheeler",
+                        "url": "http://www.davis.org/"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Mr. Matthew Nguyen MD",
+                        "url": "https://www.decker.com/explore/blog/faq.jsp"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Difficult concern wrong stage. Year home true. Project ok store spend."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2011-11-17T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2008-0010",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Industry idea trade everyone court. Agent sister test we."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2014-04-04T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2009-0001",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Oil once senior so head ago give. Statement idea arrive concern."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2012-09-13T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:37.176885+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2009-0003",
+                "ASSIGNER": "sandrabrown@song_3.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Chung, Carroll and Gibson",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "wait",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "treatment, then, should, culture, factor, in, town"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Cross-platform logistical artificial intelligence"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Kristina Carter",
+                        "url": "http://www.pennington.com/explore/index/"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Angela Anderson",
+                        "url": "http://drake.net/search.jsp"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://www.mendoza-ruiz.com/search/main/posts/terms.html",
+                        "url": "http://www.mendoza-ruiz.com/search/main/posts/terms.html"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://www.andrews.com/faq/",
+                        "url": "https://www.andrews.com/faq/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://hall.biz/",
+                        "url": "https://hall.biz/"
+                    },
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Angelica Delgado",
+                        "url": "https://perry.com/register.html"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Jared Reyes",
+                        "url": "https://www.holloway.biz/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Dr. Roger Patterson Jr.",
+                        "url": "http://rodriguez.com/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Race vote change tell apply. Capital answer fund."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2014-03-17T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2009-0004",
+                "ASSIGNER": "colleentorres@opportunity_13.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Smith-Johnson",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "yourself",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "maintain, box, than, memory, service"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Total systemic portal"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Patrick Ross",
+                        "url": "http://www.aguilar.com/"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "Sara Erickson",
+                        "url": "http://www.williams.com/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "April Silva",
+                        "url": "http://henry.biz/category/register/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Marcia Johnson",
+                        "url": "https://smith-perkins.net/tags/terms.jsp"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Mr. Matthew Nguyen MD",
+                        "url": "https://www.decker.com/explore/blog/faq.jsp"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "John Sullivan",
+                        "url": "http://www.palmer.com/author/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Charge record action. Stop the significant level."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-04-24T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:37.579993+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2009-0005",
+                "ASSIGNER": "stephenjohnson@accept_19.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Miller-Rivas",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "teach",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "worry, office, away, future, ok, different, teacher, news, various"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "n/a"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Patrick Ross",
+                        "url": "http://www.aguilar.com/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://willis.info/main/",
+                        "url": "https://willis.info/main/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://www.andrews.com/faq/",
+                        "url": "https://www.andrews.com/faq/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Emily Gutierrez",
+                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://escobar.com/homepage.php",
+                        "url": "http://escobar.com/homepage.php"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Jared Reyes",
+                        "url": "https://www.holloway.biz/"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Matthew Wheeler",
+                        "url": "http://www.davis.org/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Include specific four. Across consumer response heart continue start study."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2012-06-27T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2009-0006",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Us growth could respond unit professional fact. Pretty west last behind. Lawyer watch teacher morning movement effort current."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2012-10-06T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:38.706568+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2010-0002",
+                "ASSIGNER": "jamesvaldez@technology_4.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Wilkins, Macias and Stout",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "option",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "other, drop, heart, your, indicate, role, difficult, direction"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "n/a"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "THESE",
+                        "name": "Michael Carroll",
+                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://clark.biz/",
+                        "url": "https://clark.biz/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Brett Krause",
+                        "url": "http://curtis-campbell.com/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Kathleen Garcia",
+                        "url": "http://www.morris.com/app/index/"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Mary Morales",
+                        "url": "http://www.adams-ramirez.com/search/"
+                    },
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Angelica Delgado",
+                        "url": "https://perry.com/register.html"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Matthew Wheeler",
+                        "url": "http://www.davis.org/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "Karen Ray",
+                        "url": "https://www.ruiz.org/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Wear majority once society fish approach. Understand art describe personal."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2014-03-08T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2010-0005",
+                "ASSIGNER": "stevenvalentine@whatever_18.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Watson, Martin and Moore",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "nature",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "change, pull, society, at, position, join"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Digitized eco-centric frame"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Kristina Carter",
+                        "url": "http://www.pennington.com/explore/index/"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Troy Gutierrez",
+                        "url": "http://richards.com/post/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://clark.biz/",
+                        "url": "https://clark.biz/"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Christopher Lewis",
+                        "url": "https://www.saunders-wright.com/"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "Sara Erickson",
+                        "url": "http://www.williams.com/"
+                    },
+                    {
+                        "refsource": "THESE",
+                        "name": "Jeffrey Davis",
+                        "url": "http://www.wright-lamb.com/index.html"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://www.mcgee.biz/index/",
+                        "url": "http://www.mcgee.biz/index/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Logan Vazquez",
+                        "url": "http://wilson.com/main/blog/login.asp"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Mr. Matthew Nguyen MD",
+                        "url": "https://www.decker.com/explore/blog/faq.jsp"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Joshua Walls",
+                        "url": "https://www.arroyo.biz/post/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "Katherine Richard",
+                        "url": "https://www.holland.biz/tag/app/about/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Debate available risk yet. Science collection possible."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2011-10-24T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:39.354523+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2010-0006",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Under visit pressure. Admit traditional stop."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-06-26T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2010-0007",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Child stop develop street nature practice east federal. Success off everybody challenge."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2017-02-19T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2010-0009",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Determine instead each claim respond place middle. Front operation sister difference life religious."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2015-09-04T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2010-0010",
+                "ASSIGNER": "franciscoanderson@today_2.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Thomas, Wilson and Wiley",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "serve",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "when"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "n/a"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Kristina Carter",
+                        "url": "http://www.pennington.com/explore/index/"
+                    },
+                    {
+                        "refsource": "THESE",
+                        "name": "Michael Carroll",
+                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Eric Thompson",
+                        "url": "https://nunez.com/blog/homepage.html"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Kathleen Garcia",
+                        "url": "http://www.morris.com/app/index/"
+                    },
+                    {
+                        "refsource": "THESE",
+                        "name": "Jeffrey Davis",
+                        "url": "http://www.wright-lamb.com/index.html"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://hall.biz/",
+                        "url": "https://hall.biz/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Catherine Adams",
+                        "url": "https://www.sanchez.com/posts/posts/app/author/"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Jeffrey Davis",
+                        "url": "https://miller.info/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Scott Wise",
+                        "url": "http://www.gardner.com/main/post/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Community individual like."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2013-12-20T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2011-0001",
+                "ASSIGNER": "stevenvalentine@whatever_18.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Cooke, Parker and Le",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "carry",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "fly"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Total systemic portal"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Troy Gutierrez",
+                        "url": "http://richards.com/post/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://clark.biz/",
+                        "url": "https://clark.biz/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Brett Krause",
+                        "url": "http://curtis-campbell.com/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://www.andrews.com/faq/",
+                        "url": "https://www.andrews.com/faq/"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Mary Morales",
+                        "url": "http://www.adams-ramirez.com/search/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Marcia Johnson",
+                        "url": "https://smith-perkins.net/tags/terms.jsp"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Jared Reyes",
+                        "url": "https://www.holloway.biz/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.morales.com/tags/main/home.asp",
+                        "url": "https://www.morales.com/tags/main/home.asp"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Scott Wise",
+                        "url": "http://www.gardner.com/main/post/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Value world modern treat when federal leave. Manager worker however door sell she."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2014-10-10T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:40.678339+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2011-0003",
+                "ASSIGNER": "jamesvaldez@technology_4.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Harris and Sons",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "well",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "finish, crime, certainly, deep, public, writer, consider, window, hold"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Open-source 6thgeneration standardization"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "BALL",
+                        "name": "Tammy Phillips",
+                        "url": "https://lee.com/posts/register/"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Eric Thompson",
+                        "url": "https://nunez.com/blog/homepage.html"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Brett Krause",
+                        "url": "http://curtis-campbell.com/"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Christopher Lewis",
+                        "url": "https://www.saunders-wright.com/"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "Sara Erickson",
+                        "url": "http://www.williams.com/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Emily Gutierrez",
+                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
+                    },
+                    {
+                        "refsource": "THESE",
+                        "name": "Jeffrey Davis",
+                        "url": "http://www.wright-lamb.com/index.html"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://hall.biz/",
+                        "url": "https://hall.biz/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Catherine Adams",
+                        "url": "https://www.sanchez.com/posts/posts/app/author/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.morales.com/tags/main/home.asp",
+                        "url": "https://www.morales.com/tags/main/home.asp"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Treatment give Democrat allow. Popular loss teach leader. Between factor blood light deal picture official."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-08-13T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2011-0004",
+                "ASSIGNER": "davidmcguire@only_6.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Cardenas, Adkins and Moore",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "final",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "entire, line"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "De-engineered uniform open system"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "MISC",
+                        "name": "http://escobar.com/homepage.php",
+                        "url": "http://escobar.com/homepage.php"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Suffer born on Democrat service."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-08-14T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2011-0005",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Parent across recognize early different me. Already recent must threat newspaper building. Treat question ever whole."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2016-01-18T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2011-0008",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Several you young peace despite particularly instead. Get shake lose theory world run take. Model experience politics so."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2017-03-22T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:41.850550+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2011-0009",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Well reality history believe force. Tell anyone drop. Push one out short."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2015-05-03T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2012-0001",
+                "ASSIGNER": "christianromero@mitre.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "n/a",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "n/a"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "vendor_name": "n/a"
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "n/a"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Kristina Carter",
+                        "url": "http://www.pennington.com/explore/index/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://willis.info/main/",
+                        "url": "https://willis.info/main/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://escobar.com/homepage.php",
+                        "url": "http://escobar.com/homepage.php"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Jeffrey Garcia",
+                        "url": "http://www.vega-fuentes.com/search/list/about/"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Jeffrey Davis",
+                        "url": "https://miller.info/"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Matthew Wheeler",
+                        "url": "http://www.davis.org/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Home whose first. Together positive decision perform appear scientist. Certainly painting beat hope themselves response."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2017-05-15T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:43.216533+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2012-0008",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Grow impact time thing. Less quality image spring environment poor."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2016-10-07T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2013-0005",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Shake cause forward appear later American impact. Strategy benefit those get. This campaign agent parent process TV."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2018-05-15T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2013-0007",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Teacher treatment number."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2018-09-28T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:44.814266+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2013-0008",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Drug yes middle around culture. Stand skin only arrive store. Tend wide might study task."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2012-07-16T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2013-0009",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Career improve material mention interview direction. Garden individual support seat sit poor. Positive middle mind where own several."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2016-12-12T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2013-0010",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Network live yard participant evening."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-10-24T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2014-0001",
+                "ASSIGNER": "stevenvalentine@whatever_18.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Brown-Benton",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "environment",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "goal, picture"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Total systemic portal"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.reynolds.com/posts/main/explore/author.htm",
+                        "url": "https://www.reynolds.com/posts/main/explore/author.htm"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Angela Anderson",
+                        "url": "http://drake.net/search.jsp"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://clark.biz/",
+                        "url": "https://clark.biz/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://hall.biz/",
+                        "url": "https://hall.biz/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Sister born important. Be gun world paper future relate. Establish special early."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2016-08-25T00:00:00.000000Z",
+            "modified": null
         },
         "cve": {
             "data_type": "CVE",
@@ -6041,7 +4106,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Second indicate enjoy personal owner without peace. Position form painting them official sound watch. Painting subject short keep. Require everything forward interest school."
+                        "value": "Program trouble offer huge space war. Same country different community choice strong apply in."
                     }
                 ]
             }
@@ -6049,8 +4114,8 @@
     },
     {
         "time": {
-            "created": "2014-04-24T00:00:00.000000Z",
-            "modified": null
+            "created": "2016-05-24T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:45.907401+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -6058,22 +4123,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2014-0004",
-                "ASSIGNER": "vincentaguilar@tend_14.com",
+                "ASSIGNER": "franciscoanderson@today_2.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Lambert-Nichols",
+                            "vendor_name": "Davis, Johnson and Jacobson",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "choose",
+                                        "product_name": "by",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "debate"
+                                                    "version_value": "break, rock, goal, reflect, father, bag, foreign, place, door"
                                                 }
                                             ]
                                         }
@@ -6090,7 +4155,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Customizable 3rdgeneration productivity"
+                                "value": "Open-source 6thgeneration standardization"
                             }
                         ]
                     }
@@ -6099,24 +4164,54 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "FAR",
-                        "name": "Elizabeth Sampson",
-                        "url": "http://www.joyce.com/posts/categories/app/about.php"
+                        "refsource": "GENERATION",
+                        "name": "Troy Gutierrez",
+                        "url": "http://richards.com/post/"
                     },
                     {
-                        "refsource": "FAR",
-                        "name": "Amy Campbell",
-                        "url": "https://www.johnson.info/categories/list/privacy/"
+                        "refsource": "DARK",
+                        "name": "Karen Rogers",
+                        "url": "https://www.willis.biz/list/tags/main/"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Eric Thompson",
+                        "url": "https://nunez.com/blog/homepage.html"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Kathleen Garcia",
+                        "url": "http://www.morris.com/app/index/"
+                    },
+                    {
+                        "refsource": "THESE",
+                        "name": "Jeffrey Davis",
+                        "url": "http://www.wright-lamb.com/index.html"
+                    },
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Angelica Delgado",
+                        "url": "https://perry.com/register.html"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Kristy Lewis",
+                        "url": "http://www.berry-romero.com/search/tags/category/privacy.php"
                     },
                     {
                         "refsource": "MISC",
-                        "name": "https://whitehead-lopez.net/app/list/search/login/",
-                        "url": "https://whitehead-lopez.net/app/list/search/login/"
+                        "name": "http://escobar.com/homepage.php",
+                        "url": "http://escobar.com/homepage.php"
                     },
                     {
-                        "refsource": "EARLY",
-                        "name": "Robert Garcia",
-                        "url": "http://medina-green.com/author/"
+                        "refsource": "ITEM",
+                        "name": "Matthew Wheeler",
+                        "url": "http://www.davis.org/"
+                    },
+                    {
+                        "refsource": "THESE",
+                        "name": "Bradley Mckee",
+                        "url": "https://jones.com/post.asp"
                     }
                 ]
             },
@@ -6124,7 +4219,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Help sign through note from statement yet. Light remain during speak language step. Customer before that yes feel total simply."
+                        "value": "Six scientist ever official wait not treatment. What wish big. Suddenly smile wide brother interest model reduce."
                     }
                 ]
             }
@@ -6132,8 +4227,8 @@
     },
     {
         "time": {
-            "created": "2011-03-22T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:47.627212+00:00"
+            "created": "2019-03-05T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:46.100573+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -6141,14 +4236,68 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2014-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
+                "ASSIGNER": "jameshansen@magazine_15.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Pitts, Williams and Hurst",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "century",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "issue, hotel, me, speak, list, dog"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Cross-platform logistical artificial intelligence"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Kathleen Garcia",
+                        "url": "http://www.morris.com/app/index/"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Jared Reyes",
+                        "url": "https://www.holloway.biz/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Sing red individual."
+                        "value": "Position green let amount small rest without nice. Cold doctor no meet road national itself. Stuff student economy behavior happy."
                     }
                 ]
             }
@@ -6156,8 +4305,8 @@
     },
     {
         "time": {
-            "created": "2019-07-31T00:00:00.000000Z",
-            "modified": null
+            "created": "2016-02-05T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:46.142113+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -6165,46 +4314,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2014-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Star he prepare movement interest happen. Significant community start system take study lay. Care area skin already tell improve pretty."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-03-29T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2014-0007",
-                "ASSIGNER": "anthonyvalenzuela@guy_12.com",
+                "ASSIGNER": "williammorris@certain_10.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Blanchard LLC",
+                            "vendor_name": "Collins PLC",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "better",
+                                        "product_name": "science",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "skin, forward, game, down, recognize, look, eat, exist"
+                                                    "version_value": "plant"
                                                 }
                                             ]
                                         }
@@ -6230,9 +4355,9 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "CASE",
-                        "name": "Donna Medina",
-                        "url": "http://jackson.biz/search/category/category/login/"
+                        "refsource": "BILL",
+                        "name": "Matthew Gonzales",
+                        "url": "https://www.ross-jackson.com/privacy/"
                     }
                 ]
             },
@@ -6240,7 +4365,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Hand top lose news east order one finally. Rock ahead concern choice democratic treat film."
+                        "value": "Them not add recent. Attack listen officer develop level tax understand own. Mouth hold item newspaper land interview social behavior."
                     }
                 ]
             }
@@ -6248,8 +4373,8 @@
     },
     {
         "time": {
-            "created": "2015-01-22T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:48.127955+00:00"
+            "created": "2019-01-31T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:46.455629+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -6258,13 +4383,13 @@
             "CVE_data_meta": {
                 "ID": "CVE-2014-0008",
                 "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
+                "STATE": "REJECT"
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                        "value": "Itself answer much free team few name."
                     }
                 ]
             }
@@ -6272,8 +4397,8 @@
     },
     {
         "time": {
-            "created": "2018-01-13T00:00:00.000000Z",
-            "modified": null
+            "created": "2019-05-20T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:46.663022+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -6281,14 +4406,93 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2014-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
+                "ASSIGNER": "stevenvalentine@whatever_18.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Fernandez and Sons",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "foreign",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "heart, stuff, rate, receive"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Digitized eco-centric frame"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Troy Gutierrez",
+                        "url": "http://richards.com/post/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "Tammy Phillips",
+                        "url": "https://lee.com/posts/register/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://willis.info/main/",
+                        "url": "https://willis.info/main/"
+                    },
+                    {
+                        "refsource": "THESE",
+                        "name": "Jeffrey Davis",
+                        "url": "http://www.wright-lamb.com/index.html"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Jeffrey Garcia",
+                        "url": "http://www.vega-fuentes.com/search/list/about/"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "John Sullivan",
+                        "url": "http://www.palmer.com/author/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "Katherine Richard",
+                        "url": "https://www.holland.biz/tag/app/about/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                        "value": "Bit professional force."
                     }
                 ]
             }
@@ -6296,56 +4500,8 @@
     },
     {
         "time": {
-            "created": "2021-03-06T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2014-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Order our wish draw understand movement new. Lead development city move such buy season."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-12-20T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:48.815743+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2015-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Deep evidence individual show newspaper. Law employee lead in bag similar federal. Western fund everything condition look."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-04-21T00:00:00.000000Z",
-            "modified": null
+            "created": "2012-08-10T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:47.060724+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -6354,13 +4510,13 @@
             "CVE_data_meta": {
                 "ID": "CVE-2015-0002",
                 "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
+                "STATE": "REJECT"
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
+                        "value": "Agreement sign evening mission make tonight team. Whose spring unit sit design."
                     }
                 ]
             }
@@ -6368,32 +4524,8 @@
     },
     {
         "time": {
-            "created": "2015-10-01T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2015-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2011-10-01T00:00:00.000000Z",
-            "modified": null
+            "created": "2015-06-23T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:47.421911+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -6408,7 +4540,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Skin smile field south firm new. Realize less expert production. Human interesting return father happen."
+                        "value": "He natural fall finish receive. Out clearly community speech. Happy against impact concern summer history."
                     }
                 ]
             }
@@ -6416,271 +4548,7 @@
     },
     {
         "time": {
-            "created": "2015-03-13T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2015-0005",
-                "ASSIGNER": "shanejimenez@central_20.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Park and Sons",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "oil",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "foot, the, person, manage, perhaps, modern, American, model, evening"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Robust non-volatile middleware"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Mason Jimenez",
-                        "url": "https://www.white.com/privacy.asp"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://whitehead-lopez.net/app/list/search/login/",
-                        "url": "https://whitehead-lopez.net/app/list/search/login/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Melinda Levine",
-                        "url": "http://taylor.com/homepage/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Jamie Turner",
-                        "url": "https://www.aguilar-martinez.org/author.jsp"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Misty Hoffman",
-                        "url": "http://www.carr-sanchez.com/"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Laura Miller",
-                        "url": "https://simpson.com/terms/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Robert Garcia",
-                        "url": "http://medina-green.com/author/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Service blue suggest laugh range. Style war student computer."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-05-08T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2015-0006",
-                "ASSIGNER": "marybond@television_9.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Lopez LLC",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "perform",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "present"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Reduced foreground functionalities"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "EARLY",
-                        "name": "Ryan Miller",
-                        "url": "http://ray-jackson.net/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://clark.com/main/categories/login.asp",
-                        "url": "https://clark.com/main/categories/login.asp"
-                    },
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Gabrielle Henry",
-                        "url": "https://www.johnson-white.com/main/blog/register.htm"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Casey Arellano",
-                        "url": "http://davis.com/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://hunter.com/",
-                        "url": "http://hunter.com/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Robert Garcia",
-                        "url": "http://medina-green.com/author/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Entire act expert. Nearly discover all here firm ground."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-06-04T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2015-0007",
-                "ASSIGNER": "emilyperez@media_7.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Diaz-Marshall",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "hold",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "total, never, crime, ask, huge"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Joseph Armstrong",
-                        "url": "http://www.henderson.com/tag/list/explore/post.htm"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Monica Long",
-                        "url": "http://collier-ramirez.net/category.htm"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Worker write hundred world team stay development memory. Author image interview experience human five TV real. Three who school pressure here."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-12-07T00:00:00.000000Z",
+            "created": "2013-03-20T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -6696,7 +4564,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Central issue whole daughter base exactly room. Protect describe day if read management daughter meeting."
+                        "value": "Result but risk agreement never. Four skill something tend none rather. Radio perhaps letter series quality money."
                     }
                 ]
             }
@@ -6704,55 +4572,7 @@
     },
     {
         "time": {
-            "created": "2013-06-25T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2015-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Free million find tend because quality region. Call act wall international vote Democrat. Himself development perhaps practice here allow much crime."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-09-13T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:50.274780+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2015-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-07-23T00:00:00.000000Z",
+            "created": "2013-09-19T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -6761,118 +4581,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2016-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Turn environment growth challenge PM. Life industry door maybe phone mission."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-06-18T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2016-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Behind light compare interest director create. Fast reduce movement north."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-08-31T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2016-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Social sound difference inside shake five animal. During same fish."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-10-15T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2016-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Condition growth responsibility trade look black. Put attorney air thousand tell actually. Ball least receive challenge attention read there. Coach city decision upon address agent other."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-06-19T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2016-0005",
-                "ASSIGNER": "vincentaguilar@tend_14.com",
+                "ASSIGNER": "stevenvalentine@whatever_18.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Dickerson Inc",
+                            "vendor_name": "Escobar, Padilla and Henderson",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "lead",
+                                        "product_name": "international",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "name, guess, too, field, when, fight, receive"
+                                                    "version_value": "per, star, cover, no, less, item, year, green, any"
                                                 }
                                             ]
                                         }
@@ -6889,7 +4613,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Robust non-volatile middleware"
+                                "value": "Total systemic portal"
                             }
                         ]
                     }
@@ -6898,204 +4622,64 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "CASE",
-                        "name": "Shawn Peterson",
-                        "url": "https://www.green-rojas.com/posts/categories/about/"
+                        "refsource": "THESE",
+                        "name": "Michael Carroll",
+                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
                     },
                     {
-                        "refsource": "EARLY",
-                        "name": "Michael Robinson",
-                        "url": "https://www.miller.com/terms/"
+                        "refsource": "BALL",
+                        "name": "April Silva",
+                        "url": "http://henry.biz/category/register/"
                     },
                     {
-                        "refsource": "TEND",
-                        "name": "Misty Hoffman",
-                        "url": "http://www.carr-sanchez.com/"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Laura Miller",
-                        "url": "https://simpson.com/terms/"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Monica Long",
-                        "url": "http://collier-ramirez.net/category.htm"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Donna Medina",
-                        "url": "http://jackson.biz/search/category/category/login/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Forward second sense light morning visit over. Newspaper party finally."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2011-12-03T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2016-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2011-08-03T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2016-0007",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-04-15T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2016-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-09-02T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2016-0009",
-                "ASSIGNER": "vincentaguilar@tend_14.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Smith LLC",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "point",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "network, local, help, child"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://mooney.info/explore/tag/blog/faq.html",
-                        "url": "https://mooney.info/explore/tag/blog/faq.html"
+                        "refsource": "THESE",
+                        "name": "Jeffrey Davis",
+                        "url": "http://www.wright-lamb.com/index.html"
                     },
                     {
                         "refsource": "MISC",
-                        "name": "http://www.barajas-williams.com/about.html",
-                        "url": "http://www.barajas-williams.com/about.html"
+                        "name": "http://www.mcgee.biz/index/",
+                        "url": "http://www.mcgee.biz/index/"
                     },
                     {
-                        "refsource": "CONFIRM",
-                        "name": "http://www.johnson.com/login.php",
-                        "url": "http://www.johnson.com/login.php"
-                    },
-                    {
-                        "refsource": "ADD",
-                        "name": "Sheena Calhoun",
-                        "url": "https://www.stone.net/"
-                    },
-                    {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Tyler Bentley",
-                        "url": "https://www.reese-reyes.net/categories/faq/"
+                        "refsource": "DARK",
+                        "name": "Marcia Johnson",
+                        "url": "https://smith-perkins.net/tags/terms.jsp"
                     },
                     {
                         "refsource": "MISC",
-                        "name": "http://hunter.com/",
-                        "url": "http://hunter.com/"
+                        "name": "http://escobar.com/homepage.php",
+                        "url": "http://escobar.com/homepage.php"
                     },
                     {
-                        "refsource": "TEND",
-                        "name": "Jason Knapp",
-                        "url": "https://www.grimes.org/wp-content/explore/category/faq.php"
+                        "refsource": "BILL",
+                        "name": "Erin Taylor",
+                        "url": "http://www.miller.com/search/"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Amy Morgan",
+                        "url": "https://hart.com/list/post.php"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Matthew Wheeler",
+                        "url": "http://www.davis.org/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Scott Wise",
+                        "url": "http://www.gardner.com/main/post/"
+                    },
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Samantha Heath MD",
+                        "url": "http://knapp.com/blog/blog/category.php"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "John Sullivan",
+                        "url": "http://www.palmer.com/author/"
                     }
                 ]
             },
@@ -7103,851 +4687,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Upon table field degree."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-10-22T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2016-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-07-14T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2017-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Student money he. North rate forward here conference animal."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-12-04T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2017-0002",
-                "ASSIGNER": "adamcox@after_3.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Alvarez, Davis and Johnson",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "body",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "effort, turn, onto, physical, size"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Reduced foreground functionalities"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CASE",
-                        "name": "Shawn Peterson",
-                        "url": "https://www.green-rojas.com/posts/categories/about/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Amy Campbell",
-                        "url": "https://www.johnson.info/categories/list/privacy/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Casey Arellano",
-                        "url": "http://davis.com/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "House why business season opportunity bar and shoulder. Form reach green. Air movie continue."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-05-03T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2017-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Personal seem officer interest security. Pretty walk since discuss."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-12-15T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2017-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Wish total benefit. Executive list expect early daughter."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-10-07T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:53.502701+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2017-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2011-08-30T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2017-0006",
-                "ASSIGNER": "nicholaswhite@probably_6.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Stone, Wright and Shaffer",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "clearly",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "work, relate, blood, its, work"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Reduced foreground functionalities"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "MISC",
-                        "name": "https://www.glover.net/",
-                        "url": "https://www.glover.net/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Robin Perry",
-                        "url": "https://macias-young.com/terms/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Amy Campbell",
-                        "url": "https://www.johnson.info/categories/list/privacy/"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Melinda Levine",
-                        "url": "http://taylor.com/homepage/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://clark.com/main/categories/login.asp",
-                        "url": "https://clark.com/main/categories/login.asp"
-                    },
-                    {
-                        "refsource": "MACHINE",
-                        "name": "April Garrett",
-                        "url": "https://www.miles.net/about.jsp"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://hunter.com/",
-                        "url": "http://hunter.com/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Provide investment subject sure follow sister employee. Life these treat they can. Mr whom spring today technology physical beat."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-10-10T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2017-0007",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Pressure again pressure like city eight theory current. Camera stay defense animal career. Tax child attention need."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-03-11T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2017-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-08-11T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2017-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Actually number lawyer technology sell standard. Some specific each computer suddenly nature. Marriage year news itself probably mother debate notice."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-02-08T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2017-0010",
-                "ASSIGNER": "jeremiahlloyd@either_4.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Williams, Green and Martin",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "material",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "trial, state"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Virtual system-worthy alliance"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Kathy Rodriguez",
-                        "url": "http://casey.com/main.asp"
-                    },
-                    {
-                        "refsource": "SEAT",
-                        "name": "Eugene Levy",
-                        "url": "https://tate-sanchez.com/homepage.jsp"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Marvin Wood",
-                        "url": "https://www.juarez-roth.info/categories/search/tags/register/"
-                    },
-                    {
-                        "refsource": "WAIT",
-                        "name": "Sandra Duran MD",
-                        "url": "https://www.dominguez-thomas.net/app/search/about.html"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Melinda Levine",
-                        "url": "http://taylor.com/homepage/"
-                    },
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Joseph Armstrong",
-                        "url": "http://www.henderson.com/tag/list/explore/post.htm"
-                    },
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Gabrielle Henry",
-                        "url": "https://www.johnson-white.com/main/blog/register.htm"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Donna Medina",
-                        "url": "http://jackson.biz/search/category/category/login/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Fear decade project amount pressure between until instead. Gun along blood still discuss me create."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-05-15T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:54.597982+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2018-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Word against hit offer concern. Today difficult light clearly."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-04-30T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2018-0002",
-                "ASSIGNER": "vernonvazquez@easy_5.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Pacheco, Allen and Stevenson",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "share",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "together, foreign, the, item"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Virtual system-worthy alliance"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "EARLY",
-                        "name": "Lydia Martin",
-                        "url": "http://brown.org/index.html"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.miller-herrera.com/posts/blog/category.html",
-                        "url": "http://www.miller-herrera.com/posts/blog/category.html"
-                    },
-                    {
-                        "refsource": "EARLY",
-                        "name": "Ryan Miller",
-                        "url": "http://ray-jackson.net/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Robin Perry",
-                        "url": "https://macias-young.com/terms/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://clark.com/main/categories/login.asp",
-                        "url": "https://clark.com/main/categories/login.asp"
-                    },
-                    {
-                        "refsource": "CASE",
-                        "name": "Kristen Ferguson",
-                        "url": "http://www.williams.info/"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Jason Knapp",
-                        "url": "https://www.grimes.org/wp-content/explore/category/faq.php"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Surface rate behind marriage itself professional yet. Vote important seat lay PM."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-05-02T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2018-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-10-04T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:55.148034+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2018-0004",
-                "ASSIGNER": "vernonvazquez@easy_5.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "James, Gutierrez and Lee",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "start",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "food, itself, true, several, everything, well, training, medical, agree"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Robust non-volatile middleware"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CASE",
-                        "name": "Shawn Peterson",
-                        "url": "https://www.green-rojas.com/posts/categories/about/"
-                    },
-                    {
-                        "refsource": "FAR",
-                        "name": "Robin Perry",
-                        "url": "https://macias-young.com/terms/"
-                    },
-                    {
-                        "refsource": "TEND",
-                        "name": "Laura Jackson",
-                        "url": "http://garcia.com/tags/search/"
-                    },
-                    {
-                        "refsource": "AUDIENCE",
-                        "name": "Gabrielle Henry",
-                        "url": "https://www.johnson-white.com/main/blog/register.htm"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Gun word future just here. Professor matter college."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-10-07T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:55.382887+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2018-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-05-02T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:55.510298+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2018-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Here event case simple they. Listen way certain likely suddenly sing government. Simple note expert bill."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-12-14T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2018-0007",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Ready strong reveal against paper result value here."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-06-14T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2018-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-03-11T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:56.024029+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2018-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-01-11T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:56.084059+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2018-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Force debate serious improve in. Majority bit election teach attorney few. Fact by only ready father often reduce. Authority seat upon play."
+                        "value": "Stage leave answer message. Buy protect her notice recent guess attack."
                     }
                 ]
             }
@@ -7963,23 +4703,23 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2019-0001",
-                "ASSIGNER": "williambeck@reveal_18.com",
+                "ID": "CVE-2016-0003",
+                "ASSIGNER": "jameshansen@magazine_15.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Ortega and Sons",
+                            "vendor_name": "Brock-West",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "story",
+                                        "product_name": "lay",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "admit, argue, there, tell, lawyer, west"
+                                                    "version_value": "leg, drop, hair, sit, create, like, price"
                                                 }
                                             ]
                                         }
@@ -7996,7 +4736,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Customer-focused full-range productivity"
+                                "value": "Total systemic portal"
                             }
                         ]
                     }
@@ -8005,9 +4745,44 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "CASE",
-                        "name": "Michelle Poole",
-                        "url": "https://www.fitzpatrick-buckley.biz/"
+                        "refsource": "GENERATION",
+                        "name": "Troy Gutierrez",
+                        "url": "http://richards.com/post/"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "Sara Erickson",
+                        "url": "http://www.williams.com/"
+                    },
+                    {
+                        "refsource": "THESE",
+                        "name": "Jeffrey Davis",
+                        "url": "http://www.wright-lamb.com/index.html"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Mary Morales",
+                        "url": "http://www.adams-ramirez.com/search/"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Matthew Wheeler",
+                        "url": "http://www.davis.org/"
+                    },
+                    {
+                        "refsource": "THESE",
+                        "name": "Bradley Mckee",
+                        "url": "https://jones.com/post.asp"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "Katherine Richard",
+                        "url": "https://www.holland.biz/tag/app/about/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
                     }
                 ]
             },
@@ -8015,7 +4790,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Cut see tough which. Wide leave mind. Other where without large continue Mrs life protect."
+                        "value": "Available site throw nothing successful social. Message small sometimes involve his drug pass. Some pull require person four debate right. Try lay phone anyone."
                     }
                 ]
             }
@@ -8023,7 +4798,7 @@
     },
     {
         "time": {
-            "created": "2013-04-16T00:00:00.000000Z",
+            "created": "2015-12-09T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -8031,7 +4806,7 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2019-0002",
+                "ID": "CVE-2016-0005",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -8039,7 +4814,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Administration first lot up step. Fact sea authority PM appear here seem. Food Mr former use."
+                        "value": "Any son administration dinner analysis general can. Evening option month. Business less leave actually."
                     }
                 ]
             }
@@ -8047,15 +4822,15 @@
     },
     {
         "time": {
-            "created": "2014-02-20T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:56.677683+00:00"
+            "created": "2015-06-24T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:49.739324+00:00"
         },
         "cve": {
             "data_type": "CVE",
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2019-0003",
+                "ID": "CVE-2016-0006",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -8063,7 +4838,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Within discover my cold economy child."
+                        "value": "Conference star push community provide trouble. Few easy but."
                     }
                 ]
             }
@@ -8071,23 +4846,112 @@
     },
     {
         "time": {
-            "created": "2013-02-10T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:56.952259+00:00"
+            "created": "2020-02-07T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:49.988306+00:00"
         },
         "cve": {
             "data_type": "CVE",
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2019-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
+                "ID": "CVE-2016-0007",
+                "ASSIGNER": "kimmiller@from_11.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Burns PLC",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "apply",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "central, technology, him, public"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Digitized eco-centric frame"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "THESE",
+                        "name": "Michael Carroll",
+                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "April Silva",
+                        "url": "http://henry.biz/category/register/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://www.andrews.com/faq/",
+                        "url": "https://www.andrews.com/faq/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Emily Gutierrez",
+                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://hall.biz/",
+                        "url": "https://hall.biz/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://www.mcgee.biz/index/",
+                        "url": "http://www.mcgee.biz/index/"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Amy Morgan",
+                        "url": "https://hart.com/list/post.php"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Dr. Roger Patterson Jr.",
+                        "url": "http://rodriguez.com/"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Joshua Walls",
+                        "url": "https://www.arroyo.biz/post/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Good oil way into also position. Able central door care include paper."
+                        "value": "Media face return authority wear item another. Hard manager believe act measure side."
                     }
                 ]
             }
@@ -8095,7 +4959,7 @@
     },
     {
         "time": {
-            "created": "2011-09-26T00:00:00.000000Z",
+            "created": "2011-05-25T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -8103,15 +4967,89 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2019-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
+                "ID": "CVE-2016-0008",
+                "ASSIGNER": "jasongray@concern_8.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Smith-Page",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "should",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "morning, hand, mind, side, you, attorney, which, any"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Total systemic portal"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "MISC",
+                        "name": "http://www.mendoza-ruiz.com/search/main/posts/terms.html",
+                        "url": "http://www.mendoza-ruiz.com/search/main/posts/terms.html"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Karen Rogers",
+                        "url": "https://www.willis.biz/list/tags/main/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://willis.info/main/",
+                        "url": "https://willis.info/main/"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Matthew Gonzales",
+                        "url": "https://www.ross-jackson.com/privacy/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://escobar.com/homepage.php",
+                        "url": "http://escobar.com/homepage.php"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.morales.com/tags/main/home.asp",
+                        "url": "https://www.morales.com/tags/main/home.asp"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "John Sullivan",
+                        "url": "http://www.palmer.com/author/"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Road test clearly look thus point discussion doctor. Against tonight assume certain program author trial player. Series financial few east court environmental."
+                        "value": "When home pick here. Toward land week."
                     }
                 ]
             }
@@ -8119,15 +5057,15 @@
     },
     {
         "time": {
-            "created": "2017-09-27T00:00:00.000000Z",
-            "modified": null
+            "created": "2020-01-18T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:50.470691+00:00"
         },
         "cve": {
             "data_type": "CVE",
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2019-0006",
+                "ID": "CVE-2016-0009",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -8135,7 +5073,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Citizen hope meet ok. Tonight within town spring performance we leader."
+                        "value": "Clearly show admit color role. Wind old have scene also."
                     }
                 ]
             }
@@ -8143,23 +5081,97 @@
     },
     {
         "time": {
-            "created": "2016-02-28T00:00:00.000000Z",
-            "modified": null
+            "created": "2018-09-01T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:50.617098+00:00"
         },
         "cve": {
             "data_type": "CVE",
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2019-0007",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
+                "ID": "CVE-2016-0010",
+                "ASSIGNER": "janetdean@value_14.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Gonzalez, Warren and Keith",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "world",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "me, later, sort, light, writer"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Digitized eco-centric frame"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.reynolds.com/posts/main/explore/author.htm",
+                        "url": "https://www.reynolds.com/posts/main/explore/author.htm"
+                    },
+                    {
+                        "refsource": "THESE",
+                        "name": "Michael Carroll",
+                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "April Silva",
+                        "url": "http://henry.biz/category/register/"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Mary Morales",
+                        "url": "http://www.adams-ramirez.com/search/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Marcia Johnson",
+                        "url": "https://smith-perkins.net/tags/terms.jsp"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Jared Reyes",
+                        "url": "https://www.holloway.biz/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Dr. Roger Patterson Jr.",
+                        "url": "http://rodriguez.com/"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "News question art face candidate our low. Mr school will group area budget either. Eye role wrong base center through like whatever."
+                        "value": "Administration away upon indeed. Success community and I story drive single."
                     }
                 ]
             }
@@ -8167,7 +5179,7 @@
     },
     {
         "time": {
-            "created": "2012-07-08T00:00:00.000000Z",
+            "created": "2018-06-03T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -8175,7 +5187,7 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2019-0008",
+                "ID": "CVE-2017-0001",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -8183,7 +5195,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "City wind program seek still style bar. Card set between tough specific again than visit."
+                        "value": "And season member million. No majority follow. Collection scene drive."
                     }
                 ]
             }
@@ -8191,7 +5203,7 @@
     },
     {
         "time": {
-            "created": "2017-05-08T00:00:00.000000Z",
+            "created": "2016-01-14T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -8199,15 +5211,94 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2019-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
+                "ID": "CVE-2017-0002",
+                "ASSIGNER": "jasongray@concern_8.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Robinson-Fischer",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "prove",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "one"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Total systemic portal"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://willis.info/main/",
+                        "url": "https://willis.info/main/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://hall.biz/",
+                        "url": "https://hall.biz/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Catherine Adams",
+                        "url": "https://www.sanchez.com/posts/posts/app/author/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://www.mcgee.biz/index/",
+                        "url": "http://www.mcgee.biz/index/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://escobar.com/homepage.php",
+                        "url": "http://escobar.com/homepage.php"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Erin Taylor",
+                        "url": "http://www.miller.com/search/"
+                    },
+                    {
+                        "refsource": "THESE",
+                        "name": "Bradley Mckee",
+                        "url": "https://jones.com/post.asp"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Institution station whom nearly. Summer yet prevent modern skin cover forward."
+                        "value": "Ten make left doctor practice however tough."
                     }
                 ]
             }
@@ -8216,78 +5307,6 @@
     {
         "time": {
             "created": "2020-03-08T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:57.947996+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2019-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Country hour young mind from debate laugh. Chair fight only down time relate arrive hard."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-03-01T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:58.084202+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2020-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Up onto present even social. Politics he much door somebody ever."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-06-11T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:58.218846+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2020-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Else language red financial trip form art. Employee alone support. Ten good suddenly attorney stay house window."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-02-20T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -8295,23 +5314,23 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2020-0003",
-                "ASSIGNER": "sandrapreston@front_11.com",
+                "ID": "CVE-2017-0004",
+                "ASSIGNER": "codymurphy@cost_12.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Stafford Inc",
+                            "vendor_name": "Manning and Sons",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "dinner",
+                                        "product_name": "thus",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "compare, research, industry, mother, key"
+                                                    "version_value": "general, with, apply, partner, good, story, return"
                                                 }
                                             ]
                                         }
@@ -8328,7 +5347,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Robust non-volatile middleware"
+                                "value": "Cross-platform logistical artificial intelligence"
                             }
                         ]
                     }
@@ -8337,29 +5356,29 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "EARLY",
-                        "name": "Michael Robinson",
-                        "url": "https://www.miller.com/terms/"
+                        "refsource": "DARK",
+                        "name": "Brett Krause",
+                        "url": "http://curtis-campbell.com/"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "Sara Erickson",
+                        "url": "http://www.williams.com/"
                     },
                     {
                         "refsource": "MISC",
-                        "name": "http://www.ramirez-fisher.biz/wp-content/list/index.html",
-                        "url": "http://www.ramirez-fisher.biz/wp-content/list/index.html"
+                        "name": "https://www.andrews.com/faq/",
+                        "url": "https://www.andrews.com/faq/"
                     },
                     {
-                        "refsource": "SEAT",
-                        "name": "Diana Reynolds",
-                        "url": "https://www.edwards.com/category/wp-content/list/about/"
+                        "refsource": "ITEM",
+                        "name": "Amy Morgan",
+                        "url": "https://hart.com/list/post.php"
                     },
                     {
-                        "refsource": "CASE",
-                        "name": "Donna Medina",
-                        "url": "http://jackson.biz/search/category/category/login/"
-                    },
-                    {
-                        "refsource": "ADD",
-                        "name": "Anthony Dean",
-                        "url": "http://www.king.biz/tags/wp-content/homepage/"
+                        "refsource": "BALL",
+                        "name": "Karen Ray",
+                        "url": "https://www.ruiz.org/"
                     }
                 ]
             },
@@ -8367,7 +5386,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Who sea protect at look clearly behavior. Impact trade carry kitchen. Bed contain ever old claim tree risk."
+                        "value": "Party truth heart me former act avoid country. Purpose teach Democrat left."
                     }
                 ]
             }
@@ -8375,39 +5394,15 @@
     },
     {
         "time": {
-            "created": "2020-02-21T00:00:00.000000Z",
-            "modified": null
+            "created": "2019-02-17T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:51.418178+00:00"
         },
         "cve": {
             "data_type": "CVE",
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2020-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-10-16T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2020-0005",
+                "ID": "CVE-2017-0005",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -8415,7 +5410,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Know that data meet go subject but improve."
+                        "value": "Involve ask important mother laugh along. Others white suffer three movement raise reveal."
                     }
                 ]
             }
@@ -8423,7 +5418,31 @@
     },
     {
         "time": {
-            "created": "2011-08-31T00:00:00.000000Z",
+            "created": "2018-02-08T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:51.575737+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2017-0006",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Include eat garden upon small night sign. Vote several thank then attorney trouble amount fund."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2011-08-09T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -8431,23 +5450,437 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2020-0006",
-                "ASSIGNER": "amandawilson@at_1.com",
+                "ID": "CVE-2017-0007",
+                "ASSIGNER": "jameshansen@magazine_15.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Brown, Hall and Stout",
+                            "vendor_name": "Robbins Group",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "decision",
+                                        "product_name": "on",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "important, no, line, country, shoulder"
+                                                    "version_value": "represent, movement, political, hair, itself, everybody, when"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "De-engineered uniform open system"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "DARK",
+                        "name": "Karen Rogers",
+                        "url": "https://www.willis.biz/list/tags/main/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Jeffrey Garcia",
+                        "url": "http://www.vega-fuentes.com/search/list/about/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "Katherine Richard",
+                        "url": "https://www.holland.biz/tag/app/about/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Front gun value country offer maintain break back. Movement move require onto. Executive herself right."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2011-07-24T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2017-0008",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Police every answer land pay next detail. Around case affect woman picture. According mouth action whom green admit nearly."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2015-03-03T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2017-0010",
+                "ASSIGNER": "dominiquefrench@ok_17.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Taylor Ltd",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "you",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "nice, small, see, pick, something, not, image, newspaper, American"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Digitized eco-centric frame"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "ITEM",
+                        "name": "Matthew Wheeler",
+                        "url": "http://www.davis.org/"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "John Sullivan",
+                        "url": "http://www.palmer.com/author/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Piece report here. Maybe wait society soon war toward our. Year country education couple board. Movement of gun phone building."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2021-01-29T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2018-0004",
+                "ASSIGNER": "jasongray@concern_8.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Combs, Mcbride and Henderson",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "more",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "shake, station, newspaper, true, three, cut, letter, hundred, family"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Open-source 6thgeneration standardization"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Angela Anderson",
+                        "url": "http://drake.net/search.jsp"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "http://www.thompson-gibson.info/post.htm",
+                        "url": "http://www.thompson-gibson.info/post.htm"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Christopher Lewis",
+                        "url": "https://www.saunders-wright.com/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "April Silva",
+                        "url": "http://henry.biz/category/register/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Kathleen Garcia",
+                        "url": "http://www.morris.com/app/index/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://www.mcgee.biz/index/",
+                        "url": "http://www.mcgee.biz/index/"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "John Sullivan",
+                        "url": "http://www.palmer.com/author/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Reality total course reveal. Work collection boy serve."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-02-16T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2018-0006",
+                "ASSIGNER": "jameshansen@magazine_15.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Carson-Collins",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "drop",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "my, game, crime, inside, experience, reason, scientist, plan, without"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "De-engineered uniform open system"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.reynolds.com/posts/main/explore/author.htm",
+                        "url": "https://www.reynolds.com/posts/main/explore/author.htm"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://www.mendoza-ruiz.com/search/main/posts/terms.html",
+                        "url": "http://www.mendoza-ruiz.com/search/main/posts/terms.html"
+                    },
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Patrick Ross",
+                        "url": "http://www.aguilar.com/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Emily Gutierrez",
+                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
+                    },
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Angelica Delgado",
+                        "url": "https://perry.com/register.html"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Defense box sport wear recent. Side nor describe inside bring."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2012-12-16T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2018-0010",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Price environment factor in around. Treatment true any reality owner. Firm there real who movement."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2018-01-08T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2019-0001",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Consider surface book pull low but. Form myself small quickly blood process that practice."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2011-09-01T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2019-0002",
+                "ASSIGNER": "jameshansen@magazine_15.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Hill, Williams and Wright",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "beautiful",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "put, water, place, soon, take, world"
                                                 }
                                             ]
                                         }
@@ -8473,9 +5906,44 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "EARLY",
-                        "name": "Jamie Turner",
-                        "url": "https://www.aguilar-martinez.org/author.jsp"
+                        "refsource": "BECAUSE",
+                        "name": "Kristina Carter",
+                        "url": "http://www.pennington.com/explore/index/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Karen Rogers",
+                        "url": "https://www.willis.biz/list/tags/main/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://www.andrews.com/faq/",
+                        "url": "https://www.andrews.com/faq/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://www.mcgee.biz/index/",
+                        "url": "http://www.mcgee.biz/index/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://escobar.com/homepage.php",
+                        "url": "http://escobar.com/homepage.php"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Erin Taylor",
+                        "url": "http://www.miller.com/search/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Dr. Roger Patterson Jr.",
+                        "url": "http://rodriguez.com/"
+                    },
+                    {
+                        "refsource": "THOUGH",
+                        "name": "Allison Jensen",
+                        "url": "https://www.miller.com/terms.htm"
                     }
                 ]
             },
@@ -8483,7 +5951,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Talk support peace move economy cultural economy. On despite argue director rest collection plan. Probably artist talk instead artist."
+                        "value": "Plan miss lay material. Little difficult rock though effect. History information purpose usually scientist dog simple."
                     }
                 ]
             }
@@ -8491,7 +5959,7 @@
     },
     {
         "time": {
-            "created": "2013-10-31T00:00:00.000000Z",
+            "created": "2019-09-21T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -8499,31 +5967,7 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2020-0007",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-01-10T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:59.064524+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2020-0008",
+                "ID": "CVE-2019-0003",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -8531,7 +5975,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Air source question space wonder."
+                        "value": "Occur become read door investment fund court two. Year Mr back star year hotel director. Quite few star."
                     }
                 ]
             }
@@ -8539,7 +5983,7 @@
     },
     {
         "time": {
-            "created": "2020-11-18T00:00:00.000000Z",
+            "created": "2017-04-06T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -8547,7 +5991,7 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2020-0009",
+                "ID": "CVE-2019-0010",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -8555,7 +5999,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Cost north form represent find. Positive while middle success stage hospital whom."
+                        "value": "Spend research key miss. System across ability quite college learn."
                     }
                 ]
             }
@@ -8563,31 +6007,7 @@
     },
     {
         "time": {
-            "created": "2012-10-07T00:00:00.000000Z",
-            "modified": "2021-03-18 15:34:59.377345+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2020-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-04-06T00:00:00.000000Z",
+            "created": "2015-09-09T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -8595,119 +6015,23 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2021-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Gun Democrat woman young. Summer myself amount institution stuff. Hand yourself fast another military interesting."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2011-11-11T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2021-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-07-07T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2021-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Industry indeed head nation situation blue."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-01-16T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2021-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Himself assume whether admit. Glass keep second themselves win officer. It without within tonight poor."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-12-18T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2021-0005",
-                "ASSIGNER": "marybond@television_9.com",
+                "ID": "CVE-2020-0001",
+                "ASSIGNER": "rebeccahenry@difference_16.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Curtis, Jones and Daniel",
+                            "vendor_name": "Ward, Brown and Vargas",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "world",
+                                        "product_name": "way",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "trip, quickly, writer, set, quality, easy, with, then"
+                                                    "version_value": "force, success, public, second, herself, those"
                                                 }
                                             ]
                                         }
@@ -8724,7 +6048,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Customer-focused full-range productivity"
+                                "value": "Open-source 6thgeneration standardization"
                             }
                         ]
                     }
@@ -8733,14 +6057,54 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "TEND",
-                        "name": "Marvin Wood",
-                        "url": "https://www.juarez-roth.info/categories/search/tags/register/"
+                        "refsource": "BECAUSE",
+                        "name": "Kristina Carter",
+                        "url": "http://www.pennington.com/explore/index/"
                     },
                     {
-                        "refsource": "TECHNOLOGY",
-                        "name": "Laura Miller",
-                        "url": "https://simpson.com/terms/"
+                        "refsource": "DARK",
+                        "name": "Karen Rogers",
+                        "url": "https://www.willis.biz/list/tags/main/"
+                    },
+                    {
+                        "refsource": "ITEM",
+                        "name": "Eric Thompson",
+                        "url": "https://nunez.com/blog/homepage.html"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Mary Morales",
+                        "url": "http://www.adams-ramirez.com/search/"
+                    },
+                    {
+                        "refsource": "BECAUSE",
+                        "name": "Angelica Delgado",
+                        "url": "https://perry.com/register.html"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Logan Vazquez",
+                        "url": "http://wilson.com/main/blog/login.asp"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://escobar.com/homepage.php",
+                        "url": "http://escobar.com/homepage.php"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Mr. Matthew Nguyen MD",
+                        "url": "https://www.decker.com/explore/blog/faq.jsp"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Scott Wise",
+                        "url": "http://www.gardner.com/main/post/"
+                    },
+                    {
+                        "refsource": "HAPPY",
+                        "name": "Joshua Walls",
+                        "url": "https://www.arroyo.biz/post/"
                     }
                 ]
             },
@@ -8748,7 +6112,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Edge western friend who theory line sport. Gas pick fine television town never from."
+                        "value": "Morning ask meeting whose could star. Low trade sing keep guy. Edge hair model ready notice door money baby."
                     }
                 ]
             }
@@ -8756,7 +6120,7 @@
     },
     {
         "time": {
-            "created": "2016-06-02T00:00:00.000000Z",
+            "created": "2014-06-29T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -8764,31 +6128,7 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2021-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "RESERVED"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "** RESERVED ** This candidate has been reserved by an organization or individual that will use it when announcing a new security problem. When the candidate has been publicized, the details for this candidate will be provided."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-05-11T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2021-0007",
+                "ID": "CVE-2020-0002",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -8796,7 +6136,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Me friend popular hour risk trouble. Sister relate enough daughter wind leader. Stuff enter green."
+                        "value": "Their five professor politics rate. Along per wide tree single. Kind discuss right interest our rich."
                     }
                 ]
             }
@@ -8804,8 +6144,304 @@
     },
     {
         "time": {
-            "created": "2018-04-29T00:00:00.000000Z",
+            "created": "2021-03-15T00:00:00.000000Z",
             "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2020-0004",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Something want such early prove popular miss. Song section peace senior organization artist. Our service entire law summer."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-03-10T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2020-0005",
+                "ASSIGNER": "janetdean@value_14.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Bolton, Hammond and Gordon",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "step",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "affect, home, edge, people, prove, whole"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Total systemic portal"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.reynolds.com/posts/main/explore/author.htm",
+                        "url": "https://www.reynolds.com/posts/main/explore/author.htm"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Emily Gutierrez",
+                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Quickly positive people evening base statement issue. Simply name campaign many mind center. Also clear majority which within technology."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2017-03-27T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2020-0006",
+                "ASSIGNER": "dominiquefrench@ok_17.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Wallace, Barajas and Mullins",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "manager",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "grow, happen, cause, soon, entire, wish, character"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "De-engineered uniform open system"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Catherine Adams",
+                        "url": "https://www.sanchez.com/posts/posts/app/author/"
+                    },
+                    {
+                        "refsource": "BILL",
+                        "name": "Erin Taylor",
+                        "url": "http://www.miller.com/search/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Treat note several single less available record. Away safe another good carry."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2021-02-07T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2020-0010",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Nearly bad right personal decide join. What represent money practice mission."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2013-11-04T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2021-0003",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Bank morning same pretty radio. Who join happy billion good lawyer chair."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-08-02T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:57.522905+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2021-0004",
+                "ASSIGNER": "franciscoanderson@today_2.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Myers, Snow and Christian",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "away",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "fine, sometimes, visit, various, two, maintain"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "De-engineered uniform open system"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "THESE",
+                        "name": "Michael Carroll",
+                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://clark.biz/",
+                        "url": "https://clark.biz/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Dr. Roger Patterson Jr.",
+                        "url": "http://rodriguez.com/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Deep all certain. Then send how dark pick specific. Not general face any cup."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2018-07-31T00:00:00.000000Z",
+            "modified": "2021-04-21 02:08:58.206514+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -8820,7 +6456,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Firm condition rather research. Night establish fall break great figure."
+                        "value": "Community red into model east. Success him use. Tough growth resource simply factor."
                     }
                 ]
             }
@@ -8828,31 +6464,7 @@
     },
     {
         "time": {
-            "created": "2018-01-22T00:00:00.000000Z",
-            "modified": "2021-03-18 15:35:00.982762+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2021-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Total music pressure hair. Age marriage or almost visit challenge sometimes. Discussion organization family ask subject them soldier war."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-10-23T00:00:00.000000Z",
+            "created": "2017-11-01T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -8860,15 +6472,99 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2021-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
+                "ID": "CVE-2021-0009",
+                "ASSIGNER": "jasongray@concern_8.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Valenzuela, Hughes and Ramirez",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "choice",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "girl, rest, view, cultural"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "De-engineered uniform open system"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "GENERATION",
+                        "name": "Angela Anderson",
+                        "url": "http://drake.net/search.jsp"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://www.mendoza-ruiz.com/search/main/posts/terms.html",
+                        "url": "http://www.mendoza-ruiz.com/search/main/posts/terms.html"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "April Silva",
+                        "url": "http://henry.biz/category/register/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://www.andrews.com/faq/",
+                        "url": "https://www.andrews.com/faq/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Catherine Adams",
+                        "url": "https://www.sanchez.com/posts/posts/app/author/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://www.mcgee.biz/index/",
+                        "url": "http://www.mcgee.biz/index/"
+                    },
+                    {
+                        "refsource": "DARK",
+                        "name": "Dr. Roger Patterson Jr.",
+                        "url": "http://rodriguez.com/"
+                    },
+                    {
+                        "refsource": "BALL",
+                        "name": "Karen Ray",
+                        "url": "https://www.ruiz.org/"
+                    },
+                    {
+                        "refsource": "PARTICULAR",
+                        "name": "Teresa Graves",
+                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Believe seat low suddenly do price. Example easy each central operation region."
+                        "value": "Live wind glass leader. Goal power well. Live just successful fund hot administration."
                     }
                 ]
             }

--- a/datadump/pre-population/orgs.json
+++ b/datadump/pre-population/orgs.json
@@ -9,11 +9,11 @@
         "name": "MITRE Corporation",
         "short_name": "mitre",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 601
+            "id_quota": 829
         }
     },
     {
@@ -22,14 +22,14 @@
                 "CNA"
             ]
         },
-        "name": "Gibbs, Thomas and Gross",
-        "short_name": "at_1",
+        "name": "Wise LLC",
+        "short_name": "here_1",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 1307
+            "id_quota": 511
         }
     },
     {
@@ -38,14 +38,14 @@
                 "CNA"
             ]
         },
-        "name": "Lara, Beck and Barr",
-        "short_name": "left_2",
+        "name": "Robinson-Johnson",
+        "short_name": "today_2",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 790
+            "id_quota": 736
         }
     },
     {
@@ -54,14 +54,14 @@
                 "CNA"
             ]
         },
-        "name": "Peck and Sons",
-        "short_name": "after_3",
+        "name": "Miller-Brown",
+        "short_name": "song_3",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 1417
+            "id_quota": 968
         }
     },
     {
@@ -70,14 +70,14 @@
                 "CNA"
             ]
         },
-        "name": "Vazquez-Adams",
-        "short_name": "either_4",
+        "name": "Mendez-Ramos",
+        "short_name": "technology_4",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 1049
+            "id_quota": 588
         }
     },
     {
@@ -86,14 +86,14 @@
                 "CNA"
             ]
         },
-        "name": "Ross, Green and Ward",
-        "short_name": "easy_5",
+        "name": "Sanchez Ltd",
+        "short_name": "man_5",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 613
+            "id_quota": 1323
         }
     },
     {
@@ -102,14 +102,14 @@
                 "CNA"
             ]
         },
-        "name": "Hamilton-Good",
-        "short_name": "probably_6",
+        "name": "Rose-Porter",
+        "short_name": "only_6",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 1046
+            "id_quota": 1204
         }
     },
     {
@@ -118,14 +118,14 @@
                 "CNA"
             ]
         },
-        "name": "Turner-Price",
-        "short_name": "media_7",
+        "name": "Schwartz Ltd",
+        "short_name": "quickly_7",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 532
+            "id_quota": 969
         }
     },
     {
@@ -134,27 +134,11 @@
                 "CNA"
             ]
         },
-        "name": "Turner Inc",
-        "short_name": "best_8",
+        "name": "Munoz-Davis",
+        "short_name": "concern_8",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
-        },
-        "policies": {
-            "id_quota": 1001
-        }
-    },
-    {
-        "authority": {
-            "active_roles": [
-                "CNA"
-            ]
-        },
-        "name": "Brown, Guzman and Cruz",
-        "short_name": "television_9",
-        "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
             "id_quota": 1292
@@ -166,14 +150,14 @@
                 "CNA"
             ]
         },
-        "name": "Calhoun and Sons",
-        "short_name": "pressure_10",
+        "name": "Robertson Group",
+        "short_name": "raise_9",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 793
+            "id_quota": 1409
         }
     },
     {
@@ -182,14 +166,14 @@
                 "CNA"
             ]
         },
-        "name": "Barry, Martinez and Bruce",
-        "short_name": "front_11",
+        "name": "Parker-Lucas",
+        "short_name": "certain_10",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 1017
+            "id_quota": 1200
         }
     },
     {
@@ -198,14 +182,14 @@
                 "CNA"
             ]
         },
-        "name": "Medina-Bridges",
-        "short_name": "guy_12",
+        "name": "Doyle-Arias",
+        "short_name": "from_11",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 1016
+            "id_quota": 1306
         }
     },
     {
@@ -214,14 +198,14 @@
                 "CNA"
             ]
         },
-        "name": "Mills Ltd",
-        "short_name": "attorney_13",
+        "name": "Buckley, Evans and Wilson",
+        "short_name": "cost_12",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 1076
+            "id_quota": 1315
         }
     },
     {
@@ -230,14 +214,14 @@
                 "CNA"
             ]
         },
-        "name": "Johnson, Braun and Williams",
-        "short_name": "tend_14",
+        "name": "Burke-Mayer",
+        "short_name": "opportunity_13",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 1347
+            "id_quota": 583
         }
     },
     {
@@ -246,14 +230,14 @@
                 "CNA"
             ]
         },
-        "name": "Owens-Norris",
-        "short_name": "safe_15",
+        "name": "Parker-Koch",
+        "short_name": "value_14",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 899
+            "id_quota": 926
         }
     },
     {
@@ -262,11 +246,59 @@
                 "CNA"
             ]
         },
-        "name": "Marquez Inc",
-        "short_name": "imagine_16",
+        "name": "Navarro-Salazar",
+        "short_name": "magazine_15",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
+        },
+        "policies": {
+            "id_quota": 1291
+        }
+    },
+    {
+        "authority": {
+            "active_roles": [
+                "CNA"
+            ]
+        },
+        "name": "Campbell-Murphy",
+        "short_name": "difference_16",
+        "time": {
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
+        },
+        "policies": {
+            "id_quota": 1399
+        }
+    },
+    {
+        "authority": {
+            "active_roles": [
+                "CNA"
+            ]
+        },
+        "name": "Gonzalez Ltd",
+        "short_name": "ok_17",
+        "time": {
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
+        },
+        "policies": {
+            "id_quota": 1138
+        }
+    },
+    {
+        "authority": {
+            "active_roles": [
+                "CNA"
+            ]
+        },
+        "name": "Holden-White",
+        "short_name": "whatever_18",
+        "time": {
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
             "id_quota": 609
@@ -278,14 +310,14 @@
                 "CNA"
             ]
         },
-        "name": "Simmons, Robinson and Schneider",
-        "short_name": "them_17",
+        "name": "Carrillo, Kennedy and Nielsen",
+        "short_name": "accept_19",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 638
+            "id_quota": 1231
         }
     },
     {
@@ -294,46 +326,14 @@
                 "CNA"
             ]
         },
-        "name": "Rodriguez Ltd",
-        "short_name": "reveal_18",
+        "name": "Acevedo and Sons",
+        "short_name": "whether_20",
         "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
+            "modified": "2021-04-21T02:09:07.389440Z",
+            "created": "2021-04-21T02:09:07.389440Z"
         },
         "policies": {
-            "id_quota": 587
-        }
-    },
-    {
-        "authority": {
-            "active_roles": [
-                "CNA"
-            ]
-        },
-        "name": "Watkins LLC",
-        "short_name": "some_19",
-        "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
-        },
-        "policies": {
-            "id_quota": 972
-        }
-    },
-    {
-        "authority": {
-            "active_roles": [
-                "CNA"
-            ]
-        },
-        "name": "Bailey, Rosales and Jones",
-        "short_name": "central_20",
-        "time": {
-            "modified": "2021-03-18T15:35:11.401619Z",
-            "created": "2021-03-18T15:35:11.401619Z"
-        },
-        "policies": {
-            "id_quota": 1424
+            "id_quota": 948
         }
     }
 ]

--- a/datadump/pre-population/users.json
+++ b/datadump/pre-population/users.json
@@ -4,15 +4,15 @@
         "cna_short_name": "mitre",
         "active": true,
         "name": {
-            "first": "Frederick",
-            "last": "Morgan",
+            "first": "Michael",
+            "last": "Pham",
             "middle": "R",
             "surname": "Mr.",
-            "suffix": "I"
+            "suffix": "II"
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -20,351 +20,351 @@
         "cna_short_name": "mitre",
         "active": true,
         "name": {
-            "first": "Anna",
-            "last": "Perez",
-            "middle": "C",
+            "first": "Brandon",
+            "last": "Larsen",
+            "middle": "T",
             "surname": "Lic.",
-            "suffix": "Sr."
+            "suffix": "Jr."
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
-        "username": "angelajohnson@mitre.com",
+        "username": "christianromero@mitre.com",
         "cna_short_name": "mitre",
         "active": true,
         "name": {
-            "first": "Angela",
-            "last": "Johnson",
+            "first": "Christian",
+            "last": "Romero",
+            "middle": "T",
+            "surname": "Lic.",
+            "suffix": ""
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "jamesfreeman@here_1.com",
+        "cna_short_name": "here_1",
+        "active": true,
+        "name": {
+            "first": "James",
+            "last": "Freeman",
+            "middle": "I",
+            "surname": "Prof.",
+            "suffix": "Sr."
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "franciscoanderson@today_2.com",
+        "cna_short_name": "today_2",
+        "active": true,
+        "name": {
+            "first": "Francisco",
+            "last": "Anderson",
+            "middle": "R",
+            "surname": "Lic.",
+            "suffix": "PhD"
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "sandrabrown@song_3.com",
+        "cna_short_name": "song_3",
+        "active": true,
+        "name": {
+            "first": "Sandra",
+            "last": "Brown",
+            "middle": "S",
+            "surname": "Dr.",
+            "suffix": "Sr."
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "jamesvaldez@technology_4.com",
+        "cna_short_name": "technology_4",
+        "active": true,
+        "name": {
+            "first": "James",
+            "last": "Valdez",
+            "middle": "C",
+            "surname": "Mrs.",
+            "suffix": "I"
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "jeffreyfigueroa@man_5.com",
+        "cna_short_name": "man_5",
+        "active": true,
+        "name": {
+            "first": "Jeffrey",
+            "last": "Figueroa",
+            "middle": "N",
+            "surname": "Dr.",
+            "suffix": "Sr."
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "davidmcguire@only_6.com",
+        "cna_short_name": "only_6",
+        "active": true,
+        "name": {
+            "first": "David",
+            "last": "Mcguire",
+            "middle": "B",
+            "surname": "Lic.",
+            "suffix": ""
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "ashleyanderson@quickly_7.com",
+        "cna_short_name": "quickly_7",
+        "active": true,
+        "name": {
+            "first": "Ashley",
+            "last": "Anderson",
+            "middle": "C",
+            "surname": "Mr.",
+            "suffix": ""
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "jasongray@concern_8.com",
+        "cna_short_name": "concern_8",
+        "active": true,
+        "name": {
+            "first": "Jason",
+            "last": "Gray",
+            "middle": "P",
+            "surname": "Mr.",
+            "suffix": "Jr."
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "ashleybradley@raise_9.com",
+        "cna_short_name": "raise_9",
+        "active": true,
+        "name": {
+            "first": "Ashley",
+            "last": "Bradley",
+            "middle": "P",
+            "surname": "Mrs.",
+            "suffix": "PhD"
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "williammorris@certain_10.com",
+        "cna_short_name": "certain_10",
+        "active": true,
+        "name": {
+            "first": "William",
+            "last": "Morris",
+            "middle": "R",
+            "surname": "",
+            "suffix": "Jr."
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "kimmiller@from_11.com",
+        "cna_short_name": "from_11",
+        "active": true,
+        "name": {
+            "first": "Kim",
+            "last": "Miller",
+            "middle": "D",
+            "surname": "Lic.",
+            "suffix": "II"
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "codymurphy@cost_12.com",
+        "cna_short_name": "cost_12",
+        "active": true,
+        "name": {
+            "first": "Cody",
+            "last": "Murphy",
+            "middle": "D",
+            "surname": "Miss",
+            "suffix": "I"
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "colleentorres@opportunity_13.com",
+        "cna_short_name": "opportunity_13",
+        "active": true,
+        "name": {
+            "first": "Colleen",
+            "last": "Torres",
             "middle": "A",
             "surname": "Prof.",
             "suffix": "Jr."
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
-        "username": "amandawilson@at_1.com",
-        "cna_short_name": "at_1",
+        "username": "janetdean@value_14.com",
+        "cna_short_name": "value_14",
         "active": true,
         "name": {
-            "first": "Amanda",
-            "last": "Wilson",
-            "middle": "H",
-            "surname": "Prof.",
-            "suffix": ""
+            "first": "Janet",
+            "last": "Dean",
+            "middle": "S",
+            "surname": "Miss",
+            "suffix": "III"
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
-        "username": "josephleon@left_2.com",
-        "cna_short_name": "left_2",
+        "username": "jameshansen@magazine_15.com",
+        "cna_short_name": "magazine_15",
         "active": true,
         "name": {
-            "first": "Joseph",
-            "last": "Leon",
-            "middle": "T",
-            "surname": "Mr.",
+            "first": "James",
+            "last": "Hansen",
+            "middle": "S",
+            "surname": "Mrs.",
+            "suffix": "I"
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "rebeccahenry@difference_16.com",
+        "cna_short_name": "difference_16",
+        "active": true,
+        "name": {
+            "first": "Rebecca",
+            "last": "Henry",
+            "middle": "B",
+            "surname": "Miss",
             "suffix": "PhD"
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
-        "username": "adamcox@after_3.com",
-        "cna_short_name": "after_3",
+        "username": "dominiquefrench@ok_17.com",
+        "cna_short_name": "ok_17",
         "active": true,
         "name": {
-            "first": "Adam",
-            "last": "Cox",
-            "middle": "W",
-            "surname": "Prof.",
-            "suffix": "Sr."
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "jeremiahlloyd@either_4.com",
-        "cna_short_name": "either_4",
-        "active": true,
-        "name": {
-            "first": "Jeremiah",
-            "last": "Lloyd",
-            "middle": "E",
-            "surname": "Mrs.",
-            "suffix": ""
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "vernonvazquez@easy_5.com",
-        "cna_short_name": "easy_5",
-        "active": true,
-        "name": {
-            "first": "Vernon",
-            "last": "Vazquez",
-            "middle": "W",
-            "surname": "Prof.",
-            "suffix": "II"
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "nicholaswhite@probably_6.com",
-        "cna_short_name": "probably_6",
-        "active": true,
-        "name": {
-            "first": "Nicholas",
-            "last": "White",
-            "middle": "P",
-            "surname": "Dr.",
-            "suffix": "II"
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "emilyperez@media_7.com",
-        "cna_short_name": "media_7",
-        "active": true,
-        "name": {
-            "first": "Emily",
-            "last": "Perez",
-            "middle": "M",
-            "surname": "Dr.",
-            "suffix": "Jr."
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "melanietaylor@best_8.com",
-        "cna_short_name": "best_8",
-        "active": true,
-        "name": {
-            "first": "Melanie",
-            "last": "Taylor",
-            "middle": "R",
-            "surname": "Lic.",
-            "suffix": "Jr."
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "marybond@television_9.com",
-        "cna_short_name": "television_9",
-        "active": true,
-        "name": {
-            "first": "Mary",
-            "last": "Bond",
-            "middle": "B",
-            "surname": "Lic.",
-            "suffix": ""
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "christophersteele@pressure_10.com",
-        "cna_short_name": "pressure_10",
-        "active": true,
-        "name": {
-            "first": "Christopher",
-            "last": "Steele",
-            "middle": "P",
-            "surname": "Dr.",
-            "suffix": "Jr."
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "sandrapreston@front_11.com",
-        "cna_short_name": "front_11",
-        "active": true,
-        "name": {
-            "first": "Sandra",
-            "last": "Preston",
-            "middle": "B",
-            "surname": "Dr.",
-            "suffix": "I"
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "anthonyvalenzuela@guy_12.com",
-        "cna_short_name": "guy_12",
-        "active": true,
-        "name": {
-            "first": "Anthony",
-            "last": "Valenzuela",
-            "middle": "F",
-            "surname": "Mr.",
-            "suffix": "I"
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "jessicaburnett@attorney_13.com",
-        "cna_short_name": "attorney_13",
-        "active": true,
-        "name": {
-            "first": "Jessica",
-            "last": "Burnett",
-            "middle": "C",
-            "surname": "Dr.",
-            "suffix": "Sr."
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "vincentaguilar@tend_14.com",
-        "cna_short_name": "tend_14",
-        "active": true,
-        "name": {
-            "first": "Vincent",
-            "last": "Aguilar",
-            "middle": "W",
-            "surname": "Dr.",
-            "suffix": "II"
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "allisonthomas@safe_15.com",
-        "cna_short_name": "safe_15",
-        "active": true,
-        "name": {
-            "first": "Allison",
-            "last": "Thomas",
-            "middle": "M",
-            "surname": "",
-            "suffix": "I"
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "sherrylopez@imagine_16.com",
-        "cna_short_name": "imagine_16",
-        "active": true,
-        "name": {
-            "first": "Sherry",
-            "last": "Lopez",
+            "first": "Dominique",
+            "last": "French",
             "middle": "T",
-            "surname": "Dr.",
+            "surname": "Prof.",
             "suffix": ""
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
-        "username": "pennyhodge@them_17.com",
-        "cna_short_name": "them_17",
+        "username": "stevenvalentine@whatever_18.com",
+        "cna_short_name": "whatever_18",
         "active": true,
         "name": {
-            "first": "Penny",
-            "last": "Hodge",
-            "middle": "S",
+            "first": "Steven",
+            "last": "Valentine",
+            "middle": "C",
             "surname": "Mr.",
-            "suffix": ""
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "williambeck@reveal_18.com",
-        "cna_short_name": "reveal_18",
-        "active": true,
-        "name": {
-            "first": "William",
-            "last": "Beck",
-            "middle": "G",
-            "surname": "Mrs.",
             "suffix": "Sr."
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
-        "username": "melaniejones@some_19.com",
-        "cna_short_name": "some_19",
+        "username": "stephenjohnson@accept_19.com",
+        "cna_short_name": "accept_19",
         "active": true,
         "name": {
-            "first": "Melanie",
-            "last": "Jones",
-            "middle": "P",
-            "surname": "Mrs.",
-            "suffix": "I"
+            "first": "Stephen",
+            "last": "Johnson",
+            "middle": "S",
+            "surname": "Miss",
+            "suffix": "Jr."
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
-        "username": "shanejimenez@central_20.com",
-        "cna_short_name": "central_20",
+        "username": "nicolecallahan@whether_20.com",
+        "cna_short_name": "whether_20",
         "active": true,
         "name": {
-            "first": "Shane",
-            "last": "Jimenez",
-            "middle": "F",
-            "surname": "Lic.",
-            "suffix": ""
+            "first": "Nicole",
+            "last": "Callahan",
+            "middle": "A",
+            "surname": "",
+            "suffix": "PhD"
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -374,13 +374,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "T",
-            "surname": "",
-            "suffix": "III"
+            "middle": "R",
+            "surname": "Miss",
+            "suffix": ""
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -390,13 +390,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "I",
-            "surname": "Lic.",
-            "suffix": "Jr."
+            "middle": "B",
+            "surname": "Miss",
+            "suffix": ""
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -406,13 +406,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "A",
-            "surname": "",
-            "suffix": ""
+            "middle": "L",
+            "surname": "Mr.",
+            "suffix": "I"
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -422,13 +422,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "D",
-            "surname": "Prof.",
-            "suffix": "Jr."
+            "middle": "S",
+            "surname": "Mrs.",
+            "suffix": "Sr."
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -438,13 +438,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "B",
-            "surname": "Lic.",
-            "suffix": "PhD"
+            "middle": "A",
+            "surname": "Mr.",
+            "suffix": "II"
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -454,13 +454,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "A",
-            "surname": "Dr.",
-            "suffix": "Sr."
+            "middle": "C",
+            "surname": "Prof.",
+            "suffix": "Jr."
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -470,13 +470,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "P",
-            "surname": "Mr.",
+            "middle": "W",
+            "surname": "Lic.",
             "suffix": "Sr."
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -486,13 +486,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "S",
+            "middle": "W",
             "surname": "Prof.",
             "suffix": ""
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -502,17 +502,33 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "G",
+            "middle": "S",
             "surname": "Dr.",
-            "suffix": ""
+            "suffix": "PhD"
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
         "username": "test_secretariat_8@mitre.org",
+        "cna_short_name": "mitre",
+        "active": true,
+        "name": {
+            "first": "",
+            "last": "",
+            "middle": "U",
+            "surname": "Prof.",
+            "suffix": ""
+        },
+        "time": {
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
+        }
+    },
+    {
+        "username": "test_secretariat_9@mitre.org",
         "cna_short_name": "mitre",
         "active": true,
         "name": {
@@ -523,24 +539,8 @@
             "suffix": "Sr."
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
-        }
-    },
-    {
-        "username": "test_secretariat_9@mitre.org",
-        "cna_short_name": "mitre",
-        "active": true,
-        "name": {
-            "first": "",
-            "last": "",
-            "middle": "P",
-            "surname": "Dr.",
-            "suffix": "II"
-        },
-        "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -550,13 +550,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "F",
+            "middle": "W",
             "surname": "Miss",
-            "suffix": "I"
+            "suffix": "III"
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -566,13 +566,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "E",
-            "surname": "Miss",
+            "middle": "P",
+            "surname": "",
             "suffix": "Jr."
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -582,13 +582,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "R",
-            "surname": "Mr.",
-            "suffix": "Sr."
+            "middle": "F",
+            "surname": "",
+            "suffix": ""
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -598,13 +598,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "S",
-            "surname": "Prof.",
+            "middle": "F",
+            "surname": "",
             "suffix": "III"
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -614,13 +614,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "D",
-            "surname": "Lic.",
-            "suffix": "Jr."
+            "middle": "C",
+            "surname": "Mrs.",
+            "suffix": "PhD"
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -630,13 +630,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "B",
-            "surname": "Lic.",
-            "suffix": "I"
+            "middle": "L",
+            "surname": "Mr.",
+            "suffix": "Jr."
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     },
     {
@@ -646,13 +646,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "T",
-            "surname": "Lic.",
-            "suffix": "II"
+            "middle": "H",
+            "surname": "Prof.",
+            "suffix": "Sr."
         },
         "time": {
-            "modified": "2021-03-18T15:35:12.713525Z",
-            "created": "2021-03-18T15:35:12.713525Z"
+            "modified": "2021-04-21T02:09:08.823615Z",
+            "created": "2021-04-21T02:09:08.823615Z"
         }
     }
 ]


### PR DESCRIPTION
A previous export of the data did not filter out `RESERVED` records, which wouldn't get included in the `Cve` collection for RSUS.