### PR TITLE
Updates the system's population scripts to use file streaming

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -483,6 +483,15 @@
         "@types/node": "*"
       }
     },
+    "JSONStream": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+      "requires": {
+        "jsonparse": "^1.2.0",
+        "through": ">=2.2.7 <3"
+      }
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -3076,6 +3085,11 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
+    },
     "jsonschema": {
       "version": "1.2.11",
       "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.11.tgz",
@@ -5488,8 +5502,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "express-validator": "^6.6.1",
     "helmet": "^3.21.2",
     "jsonschema": "<1.3.0",
+    "JSONStream": "^1.3.5",
     "kleur": "^4.1.1",
     "mongoose": "^5.11.9",
     "mongoose-aggregate-paginate-v2": "^1.0.42",

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,17 @@
-const express = require('express')
-const config = require('config')
 const cors = require('cors')
-const morgan = require('morgan')
-const mongoose = require('mongoose')
-const helmet = require('helmet')
-const mw = require('./middleware/middleware')
-const logger = require('./middleware/logger')
-const configureRoutes = require('./routes.config')
+const config = require('config')
+const express = require('express')
 const app = express()
+const helmet = require('helmet')
+const mongoose = require('mongoose')
+const morgan = require('morgan')
+
+const configureRoutes = require('./routes.config')
+const dbUtils = require('./utils/db')
 const errors = require('./utils/error')
+const logger = require('./middleware/logger')
+const mw = require('./middleware/middleware')
+
 const error = new errors.IDRError()
 require('dotenv').config() // This enables us to read from the .env file.
 
@@ -40,30 +43,8 @@ app.use((req, res, next) => {
   res.status(404).json(error.notFound())
 })
 
-// construct MongoDB connection string
-// assumes that host, port, database are always defined in default config, but
-// that username and password may not be
-const appEnv = process.env.NODE_ENV
-let dbUser, dbPassword
-
-if (process.env.MONGO_USER && process.env.MONGO_PASSWORD) {
-  dbUser = process.env.MONGO_USER
-  dbPassword = process.env.MONGO_PASSWORD
-} else {
-  dbUser = config.has(`${appEnv}.username`) ? config.get(`${appEnv}.username`) : false
-  dbPassword = config.has(`${appEnv}.password`) ? config.get(`${appEnv}.password`) : false
-}
-
-const dbHost = process.env.MONGO_HOST ? process.env.MONGO_HOST : config.get(`${appEnv}.host`)
-const dbPort = process.env.MONGO_PORT ? process.env.MONGO_PORT : config.get(`${appEnv}.port`)
-const dbName = config.get(`${appEnv}.database`)
-const dbLoginPrepend = (dbUser && dbPassword) ? `${dbUser}:${dbPassword}@` : ''
-const dbConnectionStr = `mongodb://${dbLoginPrepend}${dbHost}:${dbPort}/${dbName}`
-
-logger.info(`Using NODE_ENV '${process.env.NODE_ENV}' and app environment '${appEnv}'`)
-logger.info('Using dbName = ' + config.get(`${appEnv}.database`))
-
 // Connect to MongoDB database
+const dbConnectionStr = dbUtils.getMongoConnectionString()
 mongoose.connect(dbConnectionStr, {
   useNewUrlParser: true,
   useUnifiedTopology: true,

--- a/src/scripts/hashPasswords.js
+++ b/src/scripts/hashPasswords.js
@@ -4,17 +4,17 @@
  * in the database
  */
 
-const express = require('express')
-const config = require('config')
-const mongoose = require('mongoose')
-const app = express()
-const logger = require('../middleware/logger')
-const User = require('../model/user')
 const argon2 = require('argon2')
+const express = require('express')
+const app = express()
+const mongoose = require('mongoose')
 const uuidAPIKey = require('uuid-apikey')
+
+const logger = require('../middleware/logger')
 const errors = require('../utils/error')
+const User = require('../model/user')
+
 const error = new errors.IDRError()
-require('dotenv').config() // This enables us to read from the .env file.
 
 // Body Parser Middleware
 app.use(express.json()) // Allows us to handle raw JSON data
@@ -22,27 +22,8 @@ app.use(express.urlencoded({ extended: false })) // Allows us to handle url enco
 // Make mongoose connection available globally
 global.mongoose = mongoose
 
-// construct MongoDB connection string
-// assumes that host, port, database are always defined in default config, but
-// that username and password may not be
-const appEnv = process.env.NODE_ENV
-let dbUser, dbPassword
-
-if (process.env.MONGO_USER && process.env.MONGO_PASSWORD) {
-  dbUser = process.env.MONGO_USER
-  dbPassword = process.env.MONGO_PASSWORD
-} else {
-  dbUser = config.has(`${appEnv}.username`) ? config.get(`${appEnv}.username`) : false
-  dbPassword = config.has(`${appEnv}.password`) ? config.get(`${appEnv}.password`) : false
-}
-
-const dbHost = process.env.MONGO_HOST ? process.env.MONGO_HOST : config.get(`${appEnv}.host`)
-const dbPort = process.env.MONGO_PORT ? process.env.MONGO_PORT : config.get(`${appEnv}.port`)
-const dbName = config.get(`${appEnv}.database`)
-const dbLoginPrepend = (dbUser && dbPassword) ? `${dbUser}:${dbPassword}@` : ''
-const dbConnectionStr = `mongodb://${dbLoginPrepend}${dbHost}:${dbPort}/${dbName}`
-
 // Connect to MongoDB database
+const dbConnectionStr = dbUtils.getMongoConnectionString()
 mongoose.connect(dbConnectionStr, {
   useNewUrlParser: true,
   useUnifiedTopology: false,

--- a/src/scripts/populate-cve.js
+++ b/src/scripts/populate-cve.js
@@ -3,16 +3,19 @@
  * collection
  */
 
-const express = require('express')
 const config = require('config')
-const mongoose = require('mongoose')
+
+const express = require('express')
 const app = express()
+const mongoose = require('mongoose')
+
+const dataUtils = require('../utils/data')
+const errors = require('../utils/error')
 const logger = require('../middleware/logger')
 const Cve = require('../model/cve')
-const cveData = require('../../datadump/pre-population/cves')
-const ProgressBar = require('progress')
-const errors = require('../utils/error')
+
 const error = new errors.IDRError()
+
 require('dotenv').config() // This enables us to read from the .env file.
 
 // Body Parser Middleware
@@ -57,23 +60,10 @@ db.on('error', () => {
 })
 
 db.once('open', async () => {
-  // we're connected!
   logger.info(`Successfully connected to database ${dbName} at ${dbHost}:${dbPort}`)
 
-  // Ask user to confirm pre-population, which will prep MongoDB by removing the Cve-Id, Org, and User collections
-  const prompt = require('prompt-sync')({ sigint: true })
-  let userInput = prompt(
-    `Are you sure you wish to pre-populate the database for the ${appEnv} environment?` +
-    `Doing so will drop the 'Cve' collection in the ${dbName} database. (y/n) `
-  )
-
-  while (userInput.toLowerCase() !== 'n' && userInput.toLowerCase() !== 'y') {
-    console.log('Unrecognized Input')
-    userInput = prompt(
-      `Do you wish to pre-populate the database for the ${appEnv} environment?` +
-      `Doing so will drop the 'Cve', collection in the ${dbName} database. (y/n) `
-    )
-  }
+  // user needs to agree to an action that drops collections
+  const userInput = dataUtils.getUserPopulateInput()
 
   // dropping Cve collection
   // this may be more complex than necessary, but is kept similar to `src/scripts/populate.js`
@@ -95,39 +85,19 @@ db.once('open', async () => {
     })
 
     if (!names.includes('Cve')) {
-      await populateCveCollection()
-      logger.info('Successfully pre-populated the database!')
+      await dataUtils.populateCollection(
+        './datadump/pre-population/cves.json',
+        Cve
+      )
+      logger.info('Successfully populated CVE records!')
     } else {
-      logger.error('The database was not populated because some of the collections were not deleted.')
+      logger.error(
+        'The database was not populated because ' +
+        'some of the collections were not deleted.'
+      )
     }
   }
 
-  // close MongoDB connection
   mongoose.connection.close()
 })
 
-// Populating Cve collection
-async function populateCveCollection () {
-  const bar = new ProgressBar('Cve collection [:bar] :percent', {
-    complete: '=',
-    incomplete: ' ',
-    width: 40,
-    total: cveData.length
-  })
-
-  let batchCves = []
-  for (let i = 0; i < cveData.length; i++) {
-    const cve = cveData[i]
-    batchCves.push(cve)
-
-    const isLastItem = i === cveData.length - 1
-    if (i % 1000 === 0 || isLastItem) {
-      await Cve.insertMany(batchCves)
-      bar.tick(batchCves.length)
-      batchCves = []
-    }
-  }
-
-  // success!
-  logger.info('Cve collection populated')
-}

--- a/src/scripts/populate-cve.js
+++ b/src/scripts/populate-cve.js
@@ -41,7 +41,7 @@ db.once('open', async () => {
   logger.info('Successfully connected to database!')
 
   // user needs to agree to an action that drops collections
-  const userInput = dataUtils.getUserPopulateInput()
+  const userInput = dataUtils.getUserPopulateInput(['Cve'])
 
   // dropping Cve collection
   // this may be more complex than necessary, but is kept similar to `src/scripts/populate.js`

--- a/src/scripts/populate-cve.js
+++ b/src/scripts/populate-cve.js
@@ -3,20 +3,17 @@
  * collection
  */
 
-const config = require('config')
-
 const express = require('express')
 const app = express()
 const mongoose = require('mongoose')
 
 const dataUtils = require('../utils/data')
+const dbUtils = require('../utils/db')
 const errors = require('../utils/error')
 const logger = require('../middleware/logger')
 const Cve = require('../model/cve')
 
 const error = new errors.IDRError()
-
-require('dotenv').config() // This enables us to read from the .env file.
 
 // Body Parser Middleware
 app.use(express.json()) // Allows us to handle raw JSON data
@@ -24,27 +21,8 @@ app.use(express.urlencoded({ extended: false })) // Allows us to handle url enco
 // Make mongoose connection available globally
 global.mongoose = mongoose
 
-// construct MongoDB connection string
-// assumes that host, port, database are always defined in default config, but
-// that username and password may not be
-const appEnv = process.env.NODE_ENV
-let dbUser, dbPassword
-
-if (process.env.MONGO_USER && process.env.MONGO_PASSWORD) {
-  dbUser = process.env.MONGO_USER
-  dbPassword = process.env.MONGO_PASSWORD
-} else {
-  dbUser = config.has(`${appEnv}.username`) ? config.get(`${appEnv}.username`) : false
-  dbPassword = config.has(`${appEnv}.password`) ? config.get(`${appEnv}.password`) : false
-}
-
-const dbHost = process.env.MONGO_HOST ? process.env.MONGO_HOST : config.get(`${appEnv}.host`)
-const dbPort = process.env.MONGO_PORT ? process.env.MONGO_PORT : config.get(`${appEnv}.port`)
-const dbName = config.get(`${appEnv}.database`)
-const dbLoginPrepend = (dbUser && dbPassword) ? `${dbUser}:${dbPassword}@` : ''
-const dbConnectionStr = `mongodb://${dbLoginPrepend}${dbHost}:${dbPort}/${dbName}`
-
 // Connect to MongoDB database
+const dbConnectionStr = dbUtils.getMongoConnectionString()
 mongoose.connect(dbConnectionStr, {
   useNewUrlParser: true,
   useUnifiedTopology: false,
@@ -60,7 +38,7 @@ db.on('error', () => {
 })
 
 db.once('open', async () => {
-  logger.info(`Successfully connected to database ${dbName} at ${dbHost}:${dbPort}`)
+  logger.info('Successfully connected to database!')
 
   // user needs to agree to an action that drops collections
   const userInput = dataUtils.getUserPopulateInput()
@@ -76,6 +54,7 @@ db.once('open', async () => {
 
     if (names.includes('Cve')) {
       await db.dropCollection('Cve')
+      droppedCollections.push('Cve')
     }
 
     names = []

--- a/src/scripts/populate.js
+++ b/src/scripts/populate.js
@@ -3,27 +3,22 @@
  * database with static fixtures at `cve-services/datadump/pre-population`
  */
 
-const express = require('express')
 const config = require('config')
-const mongoose = require('mongoose')
-const uuid = require('uuid')
+const express = require('express')
 const app = express()
+const mongoose = require('mongoose')
+
+const dataUtils = require('../utils/data')
+const errors = require('../utils/error')
 const logger = require('../middleware/logger')
 const CveIdRange = require('../model/cve-id-range')
 const CveId = require('../model/cve-id')
 const Cve = require('../model/cve')
 const Org = require('../model/org')
 const User = require('../model/user')
-const argon2 = require('argon2')
-const cryptoRandomString = require('crypto-random-string')
-const CONSTANTS = require('../constants')
-const utils = require('../utils/utils')
-const fs = require('fs')
-const JSONStream = require('JSONStream')
-const util = require('util')
-const errors = require('../utils/error')
+
 const error = new errors.IDRError()
-const apiKeyFile = 'user-secret.txt'
+
 require('dotenv').config() // This enables us to read from the .env file.
 
 const populateTheseCollections = {
@@ -118,40 +113,39 @@ db.once('open', async () => {
       names.push(collection.name)
     })
 
-    // TODO: need to populate org, user, cve-id in that order given UUID links
-
-    if (!names.includes('Cve-Id-Range') && !names.includes('Cve-Id') && !names.includes('Cve') && !names.includes('Org') && !names.includes('User')) {
+    if (!names.includes('Cve-Id-Range') && !names.includes('Cve-Id') && !names.includes('Cve') &&
+        !names.includes('Org') && !names.includes('User')) {
       // Org
-      await populateCollection(
+      await dataUtils.populateCollection(
         './datadump/pre-population/orgs.json',
-        Org, newOrgTransform
+        Org, dataUtils.newOrgTransform
       )
 
       // User, depends on Org
-      const hash = await preprocessUserSecrets()
-      await populateCollection(
+      const hash = await dataUtils.preprocessUserSecrets()
+      await dataUtils.populateCollection(
         './datadump/pre-population/users.json',
-        User, newUserTransform, hash
+        User, dataUtils.newUserTransform, hash
       )
 
       let populatePromises = []
 
       // CVE ID Range
-      populatePromises.push(populateCollection(
+      populatePromises.push(dataUtils.populateCollection(
         './datadump/pre-population/cve-ids-range.json',
         CveIdRange
       ))
 
       // CVE
-      populatePromises.push(populateCollection(
+      populatePromises.push(dataUtils.populateCollection(
         './datadump/pre-population/cves.json',
         Cve
       ))
 
       // CVE ID, depends on User and Org
-      populatePromises.push(populateCollection(
+      populatePromises.push(dataUtils.populateCollection(
         './datadump/pre-population/cve-ids.json',
-        CveId, newCveIdTransform
+        CveId, dataUtils.newCveIdTransform
       ))
 
       // don't close database connection until all remaining populate
@@ -167,114 +161,3 @@ db.once('open', async () => {
     }
   }
 })
-
-async function preprocessUserSecrets () {
-  const color = require('kleur')
-
-  if (process.env.NODE_ENV === 'development') {
-    const secretKey = process.env.LOCAL_KEY
-    const hash = await argon2.hash(secretKey)
-
-    // provide secret to user in development
-    console.log(color.bold().black().bgWhite(
-      'Use the following API secret for all users:') + ' ' +
-      color.bold().black().italic().bgGreen(secretKey)
-    )
-
-    return hash
-  } else {
-    // delete file for user secrets if one already exists
-    fs.unlink(apiKeyFile, err => {
-      if (err && err.code !== 'ENOENT') {
-        logger.error(error.fileDeleteError(err))
-        mongoose.connection.close()
-      }
-    })
-
-    console.log(
-      color.bold().black().bgWhite('The users\' API secret can be found in:') + ' ' +
-      color.bold().black().italic().bgGreen(apiKeyFile)
-    )
-  }
-}
-
-async function newOrgTransform (org) {
-  org.UUID = uuid.v4()
-  org.inUse = false
-  return org
-}
-
-async function newUserTransform (user, hash) {
-  const tmpOrgUUID = await utils.getOrgUUID(user.cna_short_name)
-  user.org_UUID = tmpOrgUUID
-  user.UUID = uuid.v4()
-  user.authority = { active_roles: [] }
-
-  // shared secret key in development environments
-  if (process.env.NODE_ENV === 'development') {
-    user.secret = hash
-  } else {
-    const randomKey = cryptoRandomString({ length: CONSTANTS.CRYPTO_RANDOM_STRING_LENGTH })
-    user.secret = await argon2.hash(randomKey)
-
-    // write each user's API key to file
-    // necessary when standing up any new shared instance of the system
-    const payload = { username: user.username, secret: randomKey }
-    fs.writeFile(apiKeyFile, JSON.stringify(payload) + '\n', { flag: 'a' }, (err) => {
-      if (err) {
-        logger.error(error.fileWriteError(err))
-        mongoose.connection.close()
-      }
-    })
-  }
-
-  return user
-}
-
-async function newCveIdTransform (cveId) {
-  const tmpRequestingCnaUUID = await utils.getOrgUUID(cveId.requested_by.cna)
-  const tmpOwningCnaUUID = await utils.getOrgUUID(cveId.owning_cna)
-  const tmpUserUUID = await utils.getUserUUID(cveId.requested_by.user, tmpRequestingCnaUUID)
-  cveId.requested_by.cna = tmpRequestingCnaUUID
-  cveId.owning_cna = tmpOwningCnaUUID
-  cveId.requested_by.user = tmpUserUUID
-  return cveId
-}
-
-/* populates any collection given the file path for an input JSON,
- * the data model for the collection, a function that transforms the
- * data, and a hash that only gets use in the User collection
- */ 
-function populateCollection (filePath, dataModel, dataTransform = async function (x) {return x}, hash) {
-  const dataName = dataModel.collection.collectionName
-  logger.info(`Populating ${dataName} collection...`)
-  return new Promise(function (resolve, reject) {
-    // let batchData = []
-    let promises = []
-    fs.createReadStream(filePath, {encoding: 'utf8'})
-      .pipe(JSONStream.parse('*'))
-      .on('data', async function (data) {
-        this.pause()
-        data = await dataTransform(data, hash)
-        promises.push(dataModel.insertMany(data))
-        this.resume()
-        promisesShifter(promises)
-      })
-      .on('close', function () {
-        Promise.all(promises).then(function () {
-          logger.info(`${dataName} populated!`)
-          resolve()
-        })
-      })
-      .on('error', reject)
-  })
-}
-
-function promisesShifter (promises) {
-  if (promises) {
-    while (!util.inspect(promises[0]).includes('pending')) {
-      promises.shift()
-      if (promises.length == 0) { break }
-    }
-  }
-}

--- a/src/scripts/populate.js
+++ b/src/scripts/populate.js
@@ -4,6 +4,7 @@
  */
 
 const config = require('config')
+
 const express = require('express')
 const app = express()
 const mongoose = require('mongoose')
@@ -72,24 +73,8 @@ db.on('error', () => {
 db.once('open', async () => {
   logger.info(`Successfully connected to database ${dbName} at ${dbHost}:${dbPort}`)
 
-  // Ask user to confirm pre-population
-  // This will prep MongoDB by removing the Cve, Cve-Id-Range, Cve-Id,
-  // Org, and User collections
-  /*const prompt = require('prompt-sync')({ sigint: true })
-  let userInput = prompt(
-    `Are you sure you wish to pre-populate the database for the ${appEnv} environment? ` +
-    "Doing so will drop the 'Cve', 'Cve-Id-Range', 'Cve-Id', 'Org' and 'User' collections " +
-    `in the ${dbName} database. (y/n) `
-  )
-  while (userInput.toLowerCase() !== 'n' && userInput.toLowerCase() !== 'y') {
-    console.log('Unrecognized Input')
-    userInput = prompt(
-      `Do you wish to pre-populate the database for the ${appEnv} environment? ` +
-      "Doing so will drop the 'Cve', 'Cve-Id-Range', 'Cve-Id', 'Org' and 'User' collections " +
-      `in the ${dbName} database. (y/n) `
-    )
-  }*/
-  let userInput = 'y'
+  // script runner (currently) needs to agree to an action that drops collections
+  const userInput = dataUtils.getUserPopulateInput()
 
   // drops and re-populates collections
   if (userInput.toLowerCase() === 'y') {
@@ -157,7 +142,9 @@ db.once('open', async () => {
     } else {
       logger.error(
         'The database was not populated because ' +
-        'some of the collections were not deleted.')
+        'some of the collections were not deleted.'
+      )
+      mongoose.connection.close()
     }
   }
 })

--- a/src/scripts/populate.js
+++ b/src/scripts/populate.js
@@ -3,13 +3,12 @@
  * database with static fixtures at `cve-services/datadump/pre-population`
  */
 
-const config = require('config')
-
 const express = require('express')
 const app = express()
 const mongoose = require('mongoose')
 
 const dataUtils = require('../utils/data')
+const dbUtils = require('../utils/db')
 const errors = require('../utils/error')
 const logger = require('../middleware/logger')
 const CveIdRange = require('../model/cve-id-range')
@@ -19,8 +18,6 @@ const Org = require('../model/org')
 const User = require('../model/user')
 
 const error = new errors.IDRError()
-
-require('dotenv').config() // This enables us to read from the .env file.
 
 const populateTheseCollections = {
   'Cve': Cve,
@@ -36,27 +33,8 @@ app.use(express.urlencoded({ extended: false })) // Allows us to handle url enco
 // Make mongoose connection available globally
 global.mongoose = mongoose
 
-// construct MongoDB connection string
-// assumes that host, port, database are always defined in default config, but
-// that username and password may not be
-const appEnv = process.env.NODE_ENV
-let dbUser, dbPassword
-
-if (process.env.MONGO_USER && process.env.MONGO_PASSWORD) {
-  dbUser = process.env.MONGO_USER
-  dbPassword = process.env.MONGO_PASSWORD
-} else {
-  dbUser = config.has(`${appEnv}.username`) ? config.get(`${appEnv}.username`) : false
-  dbPassword = config.has(`${appEnv}.password`) ? config.get(`${appEnv}.password`) : false
-}
-
-const dbHost = process.env.MONGO_HOST ? process.env.MONGO_HOST : config.get(`${appEnv}.host`)
-const dbPort = process.env.MONGO_PORT ? process.env.MONGO_PORT : config.get(`${appEnv}.port`)
-const dbName = config.get(`${appEnv}.database`)
-const dbLoginPrepend = (dbUser && dbPassword) ? `${dbUser}:${dbPassword}@` : ''
-const dbConnectionStr = `mongodb://${dbLoginPrepend}${dbHost}:${dbPort}/${dbName}`
-
 // Connect to MongoDB database
+const dbConnectionStr = dbUtils.getMongoConnectionString()
 mongoose.connect(dbConnectionStr, {
   useNewUrlParser: true,
   useUnifiedTopology: false,
@@ -71,7 +49,7 @@ db.on('error', () => {
 })
 
 db.once('open', async () => {
-  logger.info(`Successfully connected to database ${dbName} at ${dbHost}:${dbPort}`)
+  logger.info('Successfully connected to database!')
 
   // script runner (currently) needs to agree to an action that drops collections
   const userInput = dataUtils.getUserPopulateInput()

--- a/src/scripts/populate.js
+++ b/src/scripts/populate.js
@@ -18,17 +18,21 @@ const argon2 = require('argon2')
 const cryptoRandomString = require('crypto-random-string')
 const CONSTANTS = require('../constants')
 const utils = require('../utils/utils')
-const cveIdRangeData = require('../../datadump/pre-population/cve-ids-range')
-const cveIdData = require('../../datadump/pre-population/cve-ids')
-const cveData = require('../../datadump/pre-population/cves')
-const orgData = require('../../datadump/pre-population/orgs')
-const userData = require('../../datadump/pre-population/users')
-const ProgressBar = require('progress')
 const fs = require('fs')
+const JSONStream = require('JSONStream')
+const util = require('util')
 const errors = require('../utils/error')
 const error = new errors.IDRError()
 const apiKeyFile = 'user-secret.txt'
 require('dotenv').config() // This enables us to read from the .env file.
+
+const populateTheseCollections = {
+  'Cve': Cve,
+  'Cve-Id-Range': CveIdRange,
+  'Cve-Id': CveId,
+  'User': User,
+  'Org': Org
+}
 
 // Body Parser Middleware
 app.use(express.json()) // Allows us to handle raw JSON data
@@ -63,7 +67,6 @@ mongoose.connect(dbConnectionStr, {
   useFindAndModify: false
 })
 
-// database connection
 const db = mongoose.connection
 
 db.on('error', () => {
@@ -72,27 +75,28 @@ db.on('error', () => {
 })
 
 db.once('open', async () => {
-  // we're connected!
   logger.info(`Successfully connected to database ${dbName} at ${dbHost}:${dbPort}`)
 
-  // Ask user to confirm pre-population, which will prep MongoDB by removing the Cve-Id, Org, and User collections
-  const prompt = require('prompt-sync')({ sigint: true })
+  // Ask user to confirm pre-population
+  // This will prep MongoDB by removing the Cve, Cve-Id-Range, Cve-Id,
+  // Org, and User collections
+  /*const prompt = require('prompt-sync')({ sigint: true })
   let userInput = prompt(
-    `Are you sure you wish to pre-populate the database for the ${appEnv} environment?` +
-    "Doing so will drop the 'Cve', 'Cve-Id-Range', 'Cve-Id', 'Org' and 'User' collections" +
+    `Are you sure you wish to pre-populate the database for the ${appEnv} environment? ` +
+    "Doing so will drop the 'Cve', 'Cve-Id-Range', 'Cve-Id', 'Org' and 'User' collections " +
     `in the ${dbName} database. (y/n) `
   )
-
   while (userInput.toLowerCase() !== 'n' && userInput.toLowerCase() !== 'y') {
     console.log('Unrecognized Input')
     userInput = prompt(
-      `Do you wish to pre-populate the database for the ${appEnv} environment?` +
-      "Doing so will drop the 'Cve', 'Cve-Id-Range', 'Cve-Id', 'Org' and 'User' collections" +
+      `Do you wish to pre-populate the database for the ${appEnv} environment? ` +
+      "Doing so will drop the 'Cve', 'Cve-Id-Range', 'Cve-Id', 'Org' and 'User' collections " +
       `in the ${dbName} database. (y/n) `
     )
-  }
+  }*/
+  let userInput = 'y'
 
-  // droping Cve-Id, Org, and User collections
+  // drops and re-populates collections
   if (userInput.toLowerCase() === 'y') {
     let names = []
     let collections = await db.db.listCollections().toArray()
@@ -100,24 +104,12 @@ db.once('open', async () => {
       names.push(collection.name)
     })
 
-    if (names.includes('Cve')) {
-      await db.dropCollection('Cve')
-    }
-
-    if (names.includes('Cve-Id-Range')) {
-      await db.dropCollection('Cve-Id-Range')
-    }
-
-    if (names.includes('Cve-Id')) {
-      await db.dropCollection('Cve-Id')
-    }
-
-    if (names.includes('Org')) {
-      await db.dropCollection('Org')
-    }
-
-    if (names.includes('User')) {
-      await db.dropCollection('User')
+    
+    for (const name in populateTheseCollections) {
+      if (names.includes(name)) {
+        logger.info(`Dropping ${name} collection !!!`)
+        await db.dropCollection(name)
+      }
     }
 
     names = []
@@ -126,217 +118,163 @@ db.once('open', async () => {
       names.push(collection.name)
     })
 
+    // TODO: need to populate org, user, cve-id in that order given UUID links
+
     if (!names.includes('Cve-Id-Range') && !names.includes('Cve-Id') && !names.includes('Cve') && !names.includes('Org') && !names.includes('User')) {
-      // assumes we have all files, since we will in production
+      // Org
+      await populateCollection(
+        './datadump/pre-population/orgs.json',
+        Org, newOrgTransform
+      )
 
-      // these are independent (require no UUID linking)
-      await populateCveIdRangeCollection()
-      await populateOrgCollection()
+      // User, depends on Org
+      const hash = await preprocessUserSecrets()
+      await populateCollection(
+        './datadump/pre-population/users.json',
+        User, newUserTransform, hash
+      )
 
-      // user collection depends on orgs
-      await populateUserCollection()
+      let populatePromises = []
 
-      // cve-id collection depends on users and orgs
-      await populateCveIdCollection()
+      // CVE ID Range
+      populatePromises.push(populateCollection(
+        './datadump/pre-population/cve-ids-range.json',
+        CveIdRange
+      ))
 
-      // cve collection could depend on all existing collections once its updated
-      await populateCveCollection()
+      // CVE
+      populatePromises.push(populateCollection(
+        './datadump/pre-population/cves.json',
+        Cve
+      ))
 
-      logger.info('Successfully pre-populated the database!')
+      // CVE ID, depends on User and Org
+      populatePromises.push(populateCollection(
+        './datadump/pre-population/cve-ids.json',
+        CveId, newCveIdTransform
+      ))
+
+      // don't close database connection until all remaining populate
+      // promises are resolved
+      Promise.all(populatePromises).then(function () {
+        logger.info('Successfully populated the database!')
+        mongoose.connection.close()
+      })
     } else {
-      logger.error('The database was not populated because some of the collections were not deleted.')
+      logger.error(
+        'The database was not populated because ' +
+        'some of the collections were not deleted.')
     }
   }
-
-  // close MongoDB connection
-  mongoose.connection.close()
 })
 
-async function populateCveIdRangeCollection () {
-  const bar = new ProgressBar('Cve-Id-Range collection [:bar] :percent', {
-    complete: '=',
-    incomplete: ' ',
-    width: 20,
-    total: cveIdRangeData.length
-  })
-
-  let batchCveIdRange = []
-  for (let i = 0; i < cveIdRangeData.length; i++) {
-    batchCveIdRange.push(cveIdRangeData[i])
-
-    const isLastItem = i === cveIdRangeData.length - 1
-    if (i % 1000 === 0 || isLastItem) {
-      await CveIdRange.insertMany(batchCveIdRange)
-      bar.tick(batchCveIdRange.length)
-      batchCveIdRange = []
-    }
-  }
-
-  logger.info('Cve-Id-Range collection populated')
-}
-
-// Populating Org collection
-async function populateOrgCollection () {
-  const bar = new ProgressBar('Org collection [:bar] :percent', {
-    complete: '=',
-    incomplete: ' ',
-    width: 40,
-    total: orgData.length
-  })
-
-  let batchOrgData = []
-  for (let i = 0; i < orgData.length; i++) {
-    const org = orgData[i]
-    org.UUID = uuid.v4()
-    org.inUse = false
-    batchOrgData.push(org)
-
-    const isLastItem = i === orgData.length - 1
-    if (i % 1000 === 0 || isLastItem) {
-      await Org.insertMany(batchOrgData)
-      bar.tick(batchOrgData.length)
-      batchOrgData = []
-    }
-  }
-
-  logger.info('Org collection populated')
-}
-
-// Populating User collection
-async function populateUserCollection () {
+async function preprocessUserSecrets () {
   const color = require('kleur')
-  let hash
-  let secretKey
 
   if (process.env.NODE_ENV === 'development') {
-    secretKey = process.env.LOCAL_KEY
-    hash = await argon2.hash(secretKey)
+    const secretKey = process.env.LOCAL_KEY
+    const hash = await argon2.hash(secretKey)
 
-    // provide secret to user
-    console.log(color.bold().black().bgWhite('Use the following API secret for all users:') + ' ' + color.bold().black().italic().bgGreen(secretKey))
+    // provide secret to user in development
+    console.log(color.bold().black().bgWhite(
+      'Use the following API secret for all users:') + ' ' +
+      color.bold().black().italic().bgGreen(secretKey)
+    )
+
+    return hash
   } else {
     // delete file for user secrets if one already exists
     fs.unlink(apiKeyFile, err => {
       if (err && err.code !== 'ENOENT') {
         logger.error(error.fileDeleteError(err))
-        // close MongoDB connection
         mongoose.connection.close()
       }
     })
 
-    console.log(color.bold().black().bgWhite('The users\' API secret can be found in:') + ' ' + color.bold().black().italic().bgGreen(apiKeyFile))
+    console.log(
+      color.bold().black().bgWhite('The users\' API secret can be found in:') + ' ' +
+      color.bold().black().italic().bgGreen(apiKeyFile)
+    )
   }
+}
 
-  const bar = new ProgressBar('User collection [:bar] :percent', {
-    complete: '=',
-    incomplete: ' ',
-    width: 40,
-    total: userData.length
-  })
+async function newOrgTransform (org) {
+  org.UUID = uuid.v4()
+  org.inUse = false
+  return org
+}
 
-  let batchUser = []
-  for (let i = 0; i < userData.length; i++) {
-    const user = userData[i]
-    batchUser.push(user)
+async function newUserTransform (user, hash) {
+  const tmpOrgUUID = await utils.getOrgUUID(user.cna_short_name)
+  user.org_UUID = tmpOrgUUID
+  user.UUID = uuid.v4()
+  user.authority = { active_roles: [] }
 
-    // no matter the environment, link User to Org by UUID
-    const tmpOrgUUID = await utils.getOrgUUID(user.cna_short_name)
-    user.org_UUID = tmpOrgUUID
-    user.UUID = uuid.v4()
-    user.authority = {
-      active_roles: []
-    }
+  // shared secret key in development environments
+  if (process.env.NODE_ENV === 'development') {
+    user.secret = hash
+  } else {
+    const randomKey = cryptoRandomString({ length: CONSTANTS.CRYPTO_RANDOM_STRING_LENGTH })
+    user.secret = await argon2.hash(randomKey)
 
-    if (process.env.NODE_ENV === 'development') {
-      user.secret = hash
-    } else {
-      const randomKey = cryptoRandomString({ length: CONSTANTS.CRYPTO_RANDOM_STRING_LENGTH })
-      user.secret = await argon2.hash(randomKey)
-
-      const payload = {
-        username: user.username,
-        secret: randomKey
+    // write each user's API key to file
+    // necessary when standing up any new shared instance of the system
+    const payload = { username: user.username, secret: randomKey }
+    fs.writeFile(apiKeyFile, JSON.stringify(payload) + '\n', { flag: 'a' }, (err) => {
+      if (err) {
+        logger.error(error.fileWriteError(err))
+        mongoose.connection.close()
       }
+    })
+  }
 
-      // write pair.apiKey to apiKey file
-      fs.writeFile(apiKeyFile, JSON.stringify(payload) + '\n', { flag: 'a' }, (err) => {
-        if (err) {
-          logger.error(error.fileWriteError(err))
-          // close MongoDB connection
-          mongoose.connection.close()
-        }
+  return user
+}
+
+async function newCveIdTransform (cveId) {
+  const tmpRequestingCnaUUID = await utils.getOrgUUID(cveId.requested_by.cna)
+  const tmpOwningCnaUUID = await utils.getOrgUUID(cveId.owning_cna)
+  const tmpUserUUID = await utils.getUserUUID(cveId.requested_by.user, tmpRequestingCnaUUID)
+  cveId.requested_by.cna = tmpRequestingCnaUUID
+  cveId.owning_cna = tmpOwningCnaUUID
+  cveId.requested_by.user = tmpUserUUID
+  return cveId
+}
+
+/* populates any collection given the file path for an input JSON,
+ * the data model for the collection, a function that transforms the
+ * data, and a hash that only gets use in the User collection
+ */ 
+function populateCollection (filePath, dataModel, dataTransform = async function (x) {return x}, hash) {
+  const dataName = dataModel.collection.collectionName
+  logger.info(`Populating ${dataName} collection...`)
+  return new Promise(function (resolve, reject) {
+    // let batchData = []
+    let promises = []
+    fs.createReadStream(filePath, {encoding: 'utf8'})
+      .pipe(JSONStream.parse('*'))
+      .on('data', async function (data) {
+        this.pause()
+        data = await dataTransform(data, hash)
+        promises.push(dataModel.insertMany(data))
+        this.resume()
+        promisesShifter(promises)
       })
-    }
-
-    const isLastItem = i === userData.length - 1
-    if (i % 1000 === 0 || isLastItem) {
-      await User.insertMany(batchUser)
-      bar.tick(batchUser.length)
-      batchUser = []
-    }
-  }
-
-  logger.info('User collection populated')
+      .on('close', function () {
+        Promise.all(promises).then(function () {
+          logger.info(`${dataName} populated!`)
+          resolve()
+        })
+      })
+      .on('error', reject)
+  })
 }
 
-// Populating Cve-Id collection
-async function populateCveIdCollection () {
-  const bar = new ProgressBar('Cve-Id collection [:bar] :percent', {
-    complete: '=',
-    incomplete: ' ',
-    width: 40,
-    total: cveIdData.length
-  })
-
-  // replace Org and User values with their UUID equivalents
-  // unlike in the view, we don't care about the original data
-  let batchCveIds = []
-  for (let i = 0; i < cveIdData.length; i++) {
-    const cveid = cveIdData[i]
-    batchCveIds.push(cveid)
-
-    // get our three UUIDs: requesting CNA, owning CNA, requesting User
-    const tmpRequestingCnaUUID = await utils.getOrgUUID(cveid.requested_by.cna)
-    cveid.requested_by.cna = tmpRequestingCnaUUID
-    const tmpOwningCnaUUID = await utils.getOrgUUID(cveid.owning_cna)
-    cveid.owning_cna = tmpOwningCnaUUID
-    const tmpUserUUID = await utils.getUserUUID(cveid.requested_by.user, tmpRequestingCnaUUID)
-    cveid.requested_by.user = tmpUserUUID
-
-    const isLastItem = i === cveIdData.length - 1
-    if (i % 1000 === 0 || isLastItem) {
-      await CveId.insertMany(batchCveIds)
-      bar.tick(batchCveIds.length)
-      batchCveIds = []
+function promisesShifter (promises) {
+  if (promises) {
+    while (!util.inspect(promises[0]).includes('pending')) {
+      promises.shift()
+      if (promises.length == 0) { break }
     }
   }
-
-  // success!
-  logger.info('Cve-Id collection populated')
-}
-
-// Populating Cve collection
-async function populateCveCollection () {
-  const bar = new ProgressBar('Cve collection [:bar] :percent', {
-    complete: '=',
-    incomplete: ' ',
-    width: 40,
-    total: cveData.length
-  })
-
-  let batchCves = []
-  for (let i = 0; i < cveData.length; i++) {
-    const cve = cveData[i]
-    batchCves.push(cve)
-
-    const isLastItem = i === cveData.length - 1
-    if (i % 1000 === 0 || isLastItem) {
-      await Cve.insertMany(batchCves)
-      bar.tick(batchCves.length)
-      batchCves = []
-    }
-  }
-
-  // success!
-  logger.info('Cve collection populated')
 }

--- a/src/scripts/populate.js
+++ b/src/scripts/populate.js
@@ -52,7 +52,7 @@ db.once('open', async () => {
   logger.info('Successfully connected to database!')
 
   // script runner (currently) needs to agree to an action that drops collections
-  const userInput = dataUtils.getUserPopulateInput()
+  const userInput = dataUtils.getUserPopulateInput(Object.keys(populateTheseCollections))
 
   // drops and re-populates collections
   if (userInput.toLowerCase() === 'y') {
@@ -62,7 +62,6 @@ db.once('open', async () => {
       names.push(collection.name)
     })
 
-    
     for (const name in populateTheseCollections) {
       if (names.includes(name)) {
         logger.info(`Dropping ${name} collection !!!`)

--- a/src/scripts/templateScript.js
+++ b/src/scripts/templateScript.js
@@ -6,30 +6,16 @@
  * 3. creating a database snapshot
  * 4. ...
  */
-const config = require('config')
+
 const mongoose = require('mongoose')
 
+const dbUtils = require('../utils/db')
 const errors = require('../utils/error')
 const logger = require('../middleware/logger')
 
 const error = new errors.IDRError()
 
-const appEnv = process.env.NODE_ENV
-let dbUser, dbPassword
-if (process.env.MONGO_USER && process.env.MONGO_PASSWORD) {
-  dbUser = process.env.MONGO_USER
-  dbPassword = process.env.MONGO_PASSWORD
-} else {
-  dbUser = config.has(`${appEnv}.username`) ? config.get(`${appEnv}.username`) : false
-  dbPassword = config.has(`${appEnv}.password`) ? config.get(`${appEnv}.password`) : false
-}
-
-const dbHost = process.env.MONGO_HOST ? process.env.MONGO_HOST : config.get(`${appEnv}.host`)
-const dbPort = process.env.MONGO_PORT ? process.env.MONGO_PORT : config.get(`${appEnv}.port`)
-const dbName = config.get(`${appEnv}.database`)
-const dbLoginPrepend = (dbUser && dbPassword) ? `${dbUser}:${dbPassword}@` : ''
-const dbConnectionStr = `mongodb://${dbLoginPrepend}${dbHost}:${dbPort}/${dbName}`
-
+const dbConnectionStr = dbUtils.getMongoConnectionString()
 mongoose.connect(dbConnectionStr, {
   useNewUrlParser: true,
   useUnifiedTopology: false,

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -1,0 +1,137 @@
+/* This module exports a set of utilities to support new database
+ * population or in-place data migrations utilizing Node.js file streaming
+ * and asynchronous methods to support large data sets.
+ */
+
+const fs = require('fs')
+const util = require('util')
+
+const argon2 = require('argon2')
+const color = require('kleur')
+const cryptoRandomString = require('crypto-random-string')
+const JSONStream = require('JSONStream')
+const mongoose = require('mongoose')
+const uuid = require('uuid')
+
+const CONSTANTS = require('../constants')
+const logger = require('../middleware/logger')
+const utils = require('../utils/utils')
+
+const apiKeyFile = 'user-secret.txt'
+
+async function newOrgTransform (org) {
+  org.UUID = uuid.v4()
+  org.inUse = false
+  return org
+}
+
+async function preprocessUserSecrets () {
+  if (process.env.NODE_ENV === 'development') {
+    const secretKey = process.env.LOCAL_KEY
+    const hash = await argon2.hash(secretKey)
+
+    // provide secret to user in development
+    console.log(color.bold().black().bgWhite(
+      'Use the following API secret for all users:') + ' ' +
+      color.bold().black().italic().bgGreen(secretKey)
+    )
+
+    return hash
+  } else {
+    // delete file for user secrets if one already exists
+    fs.unlink(apiKeyFile, err => {
+      if (err && err.code !== 'ENOENT') {
+        logger.error(error.fileDeleteError(err))
+        mongoose.connection.close()
+      }
+    })
+
+    console.log(
+      color.bold().black().bgWhite('The users\' API secret can be found in:') + ' ' +
+      color.bold().black().italic().bgGreen(apiKeyFile)
+    )
+  }
+}
+
+async function newUserTransform (user, hash) {
+  const tmpOrgUUID = await utils.getOrgUUID(user.cna_short_name)
+  user.org_UUID = tmpOrgUUID
+  user.UUID = uuid.v4()
+  user.authority = { active_roles: [] }
+
+  // shared secret key in development environments
+  if (process.env.NODE_ENV === 'development') {
+    user.secret = hash
+  } else {
+    const randomKey = cryptoRandomString({ length: CONSTANTS.CRYPTO_RANDOM_STRING_LENGTH })
+    user.secret = await argon2.hash(randomKey)
+
+    // write each user's API key to file
+    // necessary when standing up any new shared instance of the system
+    const payload = { username: user.username, secret: randomKey }
+    fs.writeFile(apiKeyFile, JSON.stringify(payload) + '\n', { flag: 'a' }, (err) => {
+      if (err) {
+        logger.error(error.fileWriteError(err))
+        mongoose.connection.close()
+      }
+    })
+  }
+
+  return user
+}
+
+async function newCveIdTransform (cveId) {
+  const tmpRequestingCnaUUID = await utils.getOrgUUID(cveId.requested_by.cna)
+  const tmpOwningCnaUUID = await utils.getOrgUUID(cveId.owning_cna)
+  const tmpUserUUID = await utils.getUserUUID(cveId.requested_by.user, tmpRequestingCnaUUID)
+  cveId.requested_by.cna = tmpRequestingCnaUUID
+  cveId.owning_cna = tmpOwningCnaUUID
+  cveId.requested_by.user = tmpUserUUID
+  return cveId
+}
+
+/* populates any collection given the file path for an input JSON,
+ * the data model for the collection, a function that transforms the
+ * data, and a hash that only gets use in the User collection
+ */ 
+function populateCollection (filePath, dataModel, dataTransform = async function (x) {return x}, hash) {
+  const dataName = dataModel.collection.collectionName
+  logger.info(`Populating ${dataName} collection...`)
+  return new Promise(function (resolve, reject) {
+    // let batchData = []
+    let promises = []
+    fs.createReadStream(filePath, {encoding: 'utf8'})
+      .pipe(JSONStream.parse('*'))
+      .on('data', async function (data) {
+        this.pause()
+        data = await dataTransform(data, hash)
+        promises.push(dataModel.insertMany(data))
+        this.resume()
+        promisesShifter(promises)
+      })
+      .on('close', function () {
+        Promise.all(promises).then(function () {
+          logger.info(`${dataName} populated!`)
+          resolve()
+        })
+      })
+      .on('error', reject)
+  })
+}
+
+function promisesShifter (promises) {
+  if (promises) {
+    while (!util.inspect(promises[0]).includes('pending')) {
+      promises.shift()
+      if (promises.length == 0) { break }
+    }
+  }
+}
+
+module.exports = {
+  newCveIdTransform,
+  newOrgTransform,
+  newUserTransform,
+  populateCollection,
+  preprocessUserSecrets
+}

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -11,6 +11,7 @@ const color = require('kleur')
 const cryptoRandomString = require('crypto-random-string')
 const JSONStream = require('JSONStream')
 const mongoose = require('mongoose')
+const prompt = require('prompt-sync')({ sigint: true })
 const uuid = require('uuid')
 
 const CONSTANTS = require('../constants')
@@ -90,6 +91,21 @@ async function newCveIdTransform (cveId) {
   return cveId
 }
 
+function getUserPopulateInput (appName, dbName) {
+  let userInput = prompt(
+    `Are you sure you wish to pre-populate the database for the ${appName} environment?` +
+    `Doing so will drop the 'Cve' collection in the ${dbName} database. (y/n) `
+  )
+  while (userInput.toLowerCase() !== 'n' && userInput.toLowerCase() !== 'y') {
+    console.log('Unrecognized Input')
+    userInput = prompt(
+      `Do you wish to pre-populate the database for the ${appName} environment?` +
+      `Doing so will drop the 'Cve', collection in the ${dbName} database. (y/n) `
+    )
+  }
+  return userInput
+}
+
 /* populates any collection given the file path for an input JSON,
  * the data model for the collection, a function that transforms the
  * data, and a hash that only gets use in the User collection
@@ -129,6 +145,7 @@ function promisesShifter (promises) {
 }
 
 module.exports = {
+  getUserPopulateInput,
   newCveIdTransform,
   newOrgTransform,
   newUserTransform,

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -8,6 +8,7 @@ const util = require('util')
 
 const argon2 = require('argon2')
 const color = require('kleur')
+const config = require('config')
 const cryptoRandomString = require('crypto-random-string')
 const JSONStream = require('JSONStream')
 const mongoose = require('mongoose')
@@ -91,17 +92,19 @@ async function newCveIdTransform (cveId) {
   return cveId
 }
 
-function getUserPopulateInput (appName, dbName, collectionNames) {
-  let userInput = prompt(
-    `Are you sure you wish to pre-populate the database for the ${appName} environment? ` +
-    `Doing so will drop the 'Cve' collection in the ${dbName} database. (y/n) `
+function getUserPopulateInput (collectionNames) {
+  const appEnv = process.env.NODE_ENV
+  const dbName = config.get(`${appEnv}.database`)
+  const promptString = (
+    `Are you sure you wish to pre-populate the database for the ${appEnv} environment? ` +
+    `Doing so will drop the ${collectionNames.join(', ')} collection(s) ` +
+    `in the ${dbName} database. (y/n) `
   )
+
+  let userInput = prompt(promptString)
   while (userInput.toLowerCase() !== 'n' && userInput.toLowerCase() !== 'y') {
     console.log('Unrecognized Input')
-    userInput = prompt(
-      `Do you wish to pre-populate the database for the ${appName} environment? ` +
-      `Doing so will drop the 'Cve', collection in the ${dbName} database. (y/n) `
-    )
+    userInput = prompt(promptString)
   }
   return userInput
 }

--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -91,15 +91,15 @@ async function newCveIdTransform (cveId) {
   return cveId
 }
 
-function getUserPopulateInput (appName, dbName) {
+function getUserPopulateInput (appName, dbName, collectionNames) {
   let userInput = prompt(
-    `Are you sure you wish to pre-populate the database for the ${appName} environment?` +
+    `Are you sure you wish to pre-populate the database for the ${appName} environment? ` +
     `Doing so will drop the 'Cve' collection in the ${dbName} database. (y/n) `
   )
   while (userInput.toLowerCase() !== 'n' && userInput.toLowerCase() !== 'y') {
     console.log('Unrecognized Input')
     userInput = prompt(
-      `Do you wish to pre-populate the database for the ${appName} environment?` +
+      `Do you wish to pre-populate the database for the ${appName} environment? ` +
       `Doing so will drop the 'Cve', collection in the ${dbName} database. (y/n) `
     )
   }

--- a/src/utils/db.js
+++ b/src/utils/db.js
@@ -1,0 +1,35 @@
+const config = require('config')
+
+const logger = require('../middleware/logger')
+
+/* constructs MongoDB connection string
+ * assumes that host, port, database are always defined in default config, but
+ * that username and password may not be
+ */
+function getMongoConnectionString () {
+  const appEnv = process.env.NODE_ENV
+  let dbUser, dbPassword
+
+  if (process.env.MONGO_USER && process.env.MONGO_PASSWORD) {
+    dbUser = process.env.MONGO_USER
+    dbPassword = process.env.MONGO_PASSWORD
+  } else {
+    dbUser = config.has(`${appEnv}.username`) ? config.get(`${appEnv}.username`) : false
+    dbPassword = config.has(`${appEnv}.password`) ? config.get(`${appEnv}.password`) : false
+  }
+
+  const dbHost = process.env.MONGO_HOST ? process.env.MONGO_HOST : config.get(`${appEnv}.host`)
+  const dbPort = process.env.MONGO_PORT ? process.env.MONGO_PORT : config.get(`${appEnv}.port`)
+  const dbName = config.get(`${appEnv}.database`)
+  const dbLoginPrepend = (dbUser && dbPassword) ? `${dbUser}:${dbPassword}@` : ''
+
+  logger.info(`Using NODE_ENV '${process.env.NODE_ENV}' and app environment '${appEnv}'`)
+  logger.info('Using dbName = ' + config.get(`${appEnv}.database`))
+  logger.info(`Will try to connect to database ${dbName} at ${dbHost}:${dbPort}`)
+
+  return  `mongodb://${dbLoginPrepend}${dbHost}:${dbPort}/${dbName}`
+}
+
+module.exports = {
+  getMongoConnectionString
+}


### PR DESCRIPTION
A recent data migration failed with an error related to the Node.js process running out of memory. That migration used a populate script which loaded a set of static fixtures, similar to those in `cve-services/datadump/pre-population/`, into memory. The particular data set was too large to load as a module and iterate over. This change set uses Node's `fs` streams with `JSONStream` to populate a MongoDb backing service by streaming from a JSON file instead of loading the file into Node as a Javascript `Object`.