### PR TITLE
Updates static fixtures to include fake org admin users

### DIFF
--- a/datadump/pre-population/cve-ids.json
+++ b/datadump/pre-population/cve-ids.json
@@ -1,3452 +1,3452 @@
 [
     {
         "requested_by": {
-            "cna": "whatever_18",
-            "user": "stevenvalentine@whatever_18.com"
+            "cna": "drive_13",
+            "user": "alecmitchell@drive_13.com"
         },
         "time": {
-            "created": "2012-06-01T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2019-09-13T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-1999-0001",
         "cve_year": 1999,
-        "state": "RESERVED",
-        "owning_cna": "whatever_18",
-        "reserved": "2012-06-01T00:00:00.000000Z"
+        "state": "PUBLIC",
+        "owning_cna": "drive_13",
+        "reserved": "2019-09-13T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "from_11",
-            "user": "kimmiller@from_11.com"
+            "cna": "final_7",
+            "user": "joshuaramirez@final_7.com"
         },
         "time": {
-            "created": "2021-01-30T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2019-11-16T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-1999-0002",
         "cve_year": 1999,
-        "state": "RESERVED",
-        "owning_cna": "from_11",
-        "reserved": "2021-01-30T00:00:00.000000Z"
+        "state": "REJECT",
+        "owning_cna": "final_7",
+        "reserved": "2019-11-16T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "technology_4",
-            "user": "jamesvaldez@technology_4.com"
+            "cna": "film_17",
+            "user": "logannewman@film_17.com"
         },
         "time": {
-            "created": "2015-08-10T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2018-04-08T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-1999-0003",
         "cve_year": 1999,
-        "state": "RESERVED",
-        "owning_cna": "technology_4",
-        "reserved": "2015-08-10T00:00:00.000000Z"
+        "state": "PUBLIC",
+        "owning_cna": "film_17",
+        "reserved": "2018-04-08T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "today_2",
-            "user": "franciscoanderson@today_2.com"
+            "cna": "man_8",
+            "user": "ryanschmidt@man_8.com"
         },
         "time": {
-            "created": "2012-06-07T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2015-06-25T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-1999-0004",
         "cve_year": 1999,
         "state": "REJECT",
-        "owning_cna": "today_2",
-        "reserved": "2012-06-07T00:00:00.000000Z"
+        "owning_cna": "man_8",
+        "reserved": "2015-06-25T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "man_5",
-            "user": "jeffreyfigueroa@man_5.com"
+            "cna": "property_15",
+            "user": "julieweaver@property_15.com"
         },
         "time": {
-            "created": "2011-04-22T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:20.000000Z"
+            "created": "2020-04-07T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-1999-0005",
         "cve_year": 1999,
-        "state": "RESERVED",
-        "owning_cna": "man_5",
-        "reserved": "2011-04-22T00:00:00.000000Z"
+        "state": "REJECT",
+        "owning_cna": "property_15",
+        "reserved": "2020-04-07T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "technology_4",
-            "user": "jamesvaldez@technology_4.com"
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
         },
         "time": {
-            "created": "2020-03-31T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2020-05-08T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:15.000000Z"
         },
         "cve_id": "CVE-1999-0006",
         "cve_year": 1999,
         "state": "REJECT",
-        "owning_cna": "technology_4",
-        "reserved": "2020-03-31T00:00:00.000000Z"
+        "owning_cna": "body_2",
+        "reserved": "2020-05-08T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "difference_16",
-            "user": "rebeccahenry@difference_16.com"
+            "cna": "public_20",
+            "user": "richardbradshaw@public_20.com"
         },
         "time": {
-            "created": "2011-09-06T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2018-05-12T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:15.000000Z"
         },
         "cve_id": "CVE-1999-0007",
         "cve_year": 1999,
         "state": "RESERVED",
-        "owning_cna": "difference_16",
-        "reserved": "2011-09-06T00:00:00.000000Z"
+        "owning_cna": "public_20",
+        "reserved": "2018-05-12T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "certain_10",
-            "user": "williammorris@certain_10.com"
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
         },
         "time": {
-            "created": "2018-08-20T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2017-02-01T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:15.000000Z"
         },
         "cve_id": "CVE-1999-0008",
         "cve_year": 1999,
         "state": "RESERVED",
-        "owning_cna": "certain_10",
-        "reserved": "2018-08-20T00:00:00.000000Z"
+        "owning_cna": "body_2",
+        "reserved": "2017-02-01T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "accept_19",
-            "user": "stephenjohnson@accept_19.com"
+            "cna": "film_17",
+            "user": "logannewman@film_17.com"
         },
         "time": {
-            "created": "2013-08-09T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2016-05-22T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-1999-0009",
         "cve_year": 1999,
-        "state": "REJECT",
-        "owning_cna": "accept_19",
-        "reserved": "2013-08-09T00:00:00.000000Z"
+        "state": "RESERVED",
+        "owning_cna": "film_17",
+        "reserved": "2016-05-22T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "from_11",
-            "user": "kimmiller@from_11.com"
+            "cna": "public_20",
+            "user": "richardbradshaw@public_20.com"
         },
         "time": {
-            "created": "2015-09-20T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2011-09-18T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-1999-0010",
         "cve_year": 1999,
-        "state": "PUBLIC",
-        "owning_cna": "from_11",
-        "reserved": "2015-09-20T00:00:00.000000Z"
+        "state": "REJECT",
+        "owning_cna": "public_20",
+        "reserved": "2011-09-18T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "song_3",
-            "user": "sandrabrown@song_3.com"
+            "cna": "final_7",
+            "user": "joshuaramirez@final_7.com"
         },
         "time": {
-            "created": "2013-04-10T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:21.000000Z"
+            "created": "2021-04-21T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2000-0001",
         "cve_year": 2000,
-        "state": "REJECT",
-        "owning_cna": "song_3",
-        "reserved": "2013-04-10T00:00:00.000000Z"
+        "state": "PUBLIC",
+        "owning_cna": "final_7",
+        "reserved": "2021-04-21T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "accept_19",
-            "user": "stephenjohnson@accept_19.com"
+            "cna": "level_16",
+            "user": "andrewgriffith@level_16.com"
         },
         "time": {
-            "created": "2019-11-30T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2015-03-28T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2000-0002",
         "cve_year": 2000,
-        "state": "REJECT",
-        "owning_cna": "accept_19",
-        "reserved": "2019-11-30T00:00:00.000000Z"
+        "state": "RESERVED",
+        "owning_cna": "level_16",
+        "reserved": "2015-03-28T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
+            "cna": "senior_19",
+            "user": "jacobdouglas@senior_19.com"
         },
         "time": {
-            "created": "2017-07-15T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:21.000000Z"
+            "created": "2014-11-28T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2000-0003",
         "cve_year": 2000,
-        "state": "RESERVED",
-        "owning_cna": "magazine_15",
-        "reserved": "2017-07-15T00:00:00.000000Z"
+        "state": "PUBLIC",
+        "owning_cna": "senior_19",
+        "reserved": "2014-11-28T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "difference_16",
-            "user": "rebeccahenry@difference_16.com"
+            "cna": "man_8",
+            "user": "ryanschmidt@man_8.com"
         },
         "time": {
-            "created": "2015-02-16T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2017-09-15T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:16.000000Z"
         },
         "cve_id": "CVE-2000-0004",
         "cve_year": 2000,
-        "state": "RESERVED",
-        "owning_cna": "difference_16",
-        "reserved": "2015-02-16T00:00:00.000000Z"
+        "state": "REJECT",
+        "owning_cna": "man_8",
+        "reserved": "2017-09-15T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "certain_10",
-            "user": "williammorris@certain_10.com"
+            "cna": "agree_1",
+            "user": "rebeccaherring@agree_1.com"
         },
         "time": {
-            "created": "2011-07-10T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2013-01-31T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:16.000000Z"
         },
         "cve_id": "CVE-2000-0005",
         "cve_year": 2000,
-        "state": "PUBLIC",
-        "owning_cna": "certain_10",
-        "reserved": "2011-07-10T00:00:00.000000Z"
+        "state": "REJECT",
+        "owning_cna": "agree_1",
+        "reserved": "2013-01-31T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
+            "cna": "final_7",
+            "user": "joshuaramirez@final_7.com"
         },
         "time": {
-            "created": "2019-10-19T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:22.000000Z"
+            "created": "2017-07-26T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2000-0006",
         "cve_year": 2000,
-        "state": "REJECT",
-        "owning_cna": "only_6",
-        "reserved": "2019-10-19T00:00:00.000000Z"
+        "state": "RESERVED",
+        "owning_cna": "final_7",
+        "reserved": "2017-07-26T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "ok_17",
-            "user": "dominiquefrench@ok_17.com"
+            "cna": "film_17",
+            "user": "logannewman@film_17.com"
         },
         "time": {
-            "created": "2016-02-22T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2011-06-29T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2000-0007",
         "cve_year": 2000,
-        "state": "PUBLIC",
-        "owning_cna": "ok_17",
-        "reserved": "2016-02-22T00:00:00.000000Z"
+        "state": "RESERVED",
+        "owning_cna": "film_17",
+        "reserved": "2011-06-29T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "ok_17",
-            "user": "dominiquefrench@ok_17.com"
+            "cna": "bad_10",
+            "user": "cynthiabrooks@bad_10.com"
         },
         "time": {
-            "created": "2017-01-09T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2014-07-23T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2000-0008",
         "cve_year": 2000,
-        "state": "RESERVED",
-        "owning_cna": "ok_17",
-        "reserved": "2017-01-09T00:00:00.000000Z"
+        "state": "REJECT",
+        "owning_cna": "bad_10",
+        "reserved": "2014-07-23T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "whatever_18",
-            "user": "stevenvalentine@whatever_18.com"
+            "cna": "theory_9",
+            "user": "christophercook@theory_9.com"
         },
         "time": {
-            "created": "2012-01-13T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:22.000000Z"
+            "created": "2018-11-08T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2000-0009",
         "cve_year": 2000,
         "state": "PUBLIC",
-        "owning_cna": "whatever_18",
-        "reserved": "2012-01-13T00:00:00.000000Z"
+        "owning_cna": "theory_9",
+        "reserved": "2018-11-08T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
+            "cna": "single_6",
+            "user": "lindavaughn@single_6.com"
         },
         "time": {
-            "created": "2014-06-02T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:22.000000Z"
+            "created": "2020-08-21T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2000-0010",
         "cve_year": 2000,
-        "state": "PUBLIC",
-        "owning_cna": "only_6",
-        "reserved": "2014-06-02T00:00:00.000000Z"
+        "state": "RESERVED",
+        "owning_cna": "single_6",
+        "reserved": "2020-08-21T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "technology_4",
-            "user": "jamesvaldez@technology_4.com"
+            "cna": "public_20",
+            "user": "richardbradshaw@public_20.com"
         },
         "time": {
-            "created": "2011-08-26T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2012-02-04T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:17.000000Z"
         },
         "cve_id": "CVE-2001-0001",
         "cve_year": 2001,
         "state": "PUBLIC",
-        "owning_cna": "technology_4",
-        "reserved": "2011-08-26T00:00:00.000000Z"
+        "owning_cna": "public_20",
+        "reserved": "2012-02-04T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "technology_4",
-            "user": "jamesvaldez@technology_4.com"
+            "cna": "eight_3",
+            "user": "louisrose@eight_3.com"
         },
         "time": {
-            "created": "2015-09-06T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2012-07-02T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2001-0002",
         "cve_year": 2001,
-        "state": "RESERVED",
-        "owning_cna": "technology_4",
-        "reserved": "2015-09-06T00:00:00.000000Z"
+        "state": "PUBLIC",
+        "owning_cna": "eight_3",
+        "reserved": "2012-07-02T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "accept_19",
-            "user": "stephenjohnson@accept_19.com"
+            "cna": "theory_9",
+            "user": "christophercook@theory_9.com"
         },
         "time": {
-            "created": "2011-12-13T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:23.000000Z"
+            "created": "2018-08-06T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2001-0003",
         "cve_year": 2001,
-        "state": "REJECT",
-        "owning_cna": "accept_19",
-        "reserved": "2011-12-13T00:00:00.000000Z"
+        "state": "PUBLIC",
+        "owning_cna": "theory_9",
+        "reserved": "2018-08-06T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "man_5",
-            "user": "jeffreyfigueroa@man_5.com"
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
         },
         "time": {
-            "created": "2016-08-10T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2019-07-26T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2001-0004",
         "cve_year": 2001,
         "state": "RESERVED",
-        "owning_cna": "man_5",
-        "reserved": "2016-08-10T00:00:00.000000Z"
+        "owning_cna": "student_18",
+        "reserved": "2019-07-26T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "song_3",
-            "user": "sandrabrown@song_3.com"
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
         },
         "time": {
-            "created": "2016-07-29T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2017-08-18T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2001-0005",
         "cve_year": 2001,
-        "state": "RESERVED",
-        "owning_cna": "song_3",
-        "reserved": "2016-07-29T00:00:00.000000Z"
+        "state": "PUBLIC",
+        "owning_cna": "body_2",
+        "reserved": "2017-08-18T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "opportunity_13",
-            "user": "colleentorres@opportunity_13.com"
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
         },
         "time": {
-            "created": "2019-11-03T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2017-12-20T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2001-0006",
         "cve_year": 2001,
-        "state": "RESERVED",
-        "owning_cna": "opportunity_13",
-        "reserved": "2019-11-03T00:00:00.000000Z"
+        "state": "REJECT",
+        "owning_cna": "student_18",
+        "reserved": "2017-12-20T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "quickly_7",
-            "user": "ashleyanderson@quickly_7.com"
+            "cna": "eight_3",
+            "user": "louisrose@eight_3.com"
         },
         "time": {
-            "created": "2016-10-07T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2021-03-21T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2001-0007",
         "cve_year": 2001,
         "state": "RESERVED",
-        "owning_cna": "quickly_7",
-        "reserved": "2016-10-07T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "mitre",
-            "user": "christianromero@mitre.com"
-        },
-        "time": {
-            "created": "2016-05-20T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:24.000000Z"
-        },
-        "cve_id": "CVE-2001-0008",
-        "cve_year": 2001,
-        "state": "RESERVED",
-        "owning_cna": "mitre",
-        "reserved": "2016-05-20T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "cost_12",
-            "user": "codymurphy@cost_12.com"
-        },
-        "time": {
-            "created": "2011-10-22T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2001-0009",
-        "cve_year": 2001,
-        "state": "RESERVED",
-        "owning_cna": "cost_12",
-        "reserved": "2011-10-22T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "opportunity_13",
-            "user": "colleentorres@opportunity_13.com"
-        },
-        "time": {
-            "created": "2014-09-02T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2001-0010",
-        "cve_year": 2001,
-        "state": "REJECT",
-        "owning_cna": "opportunity_13",
-        "reserved": "2014-09-02T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "difference_16",
-            "user": "rebeccahenry@difference_16.com"
-        },
-        "time": {
-            "created": "2018-09-23T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2002-0001",
-        "cve_year": 2002,
-        "state": "RESERVED",
-        "owning_cna": "difference_16",
-        "reserved": "2018-09-23T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
-        },
-        "time": {
-            "created": "2016-02-10T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:25.000000Z"
-        },
-        "cve_id": "CVE-2002-0002",
-        "cve_year": 2002,
-        "state": "RESERVED",
-        "owning_cna": "magazine_15",
-        "reserved": "2016-02-10T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "concern_8",
-            "user": "jasongray@concern_8.com"
-        },
-        "time": {
-            "created": "2021-03-21T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2002-0003",
-        "cve_year": 2002,
-        "state": "PUBLIC",
-        "owning_cna": "concern_8",
+        "owning_cna": "eight_3",
         "reserved": "2021-03-21T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "accept_19",
-            "user": "stephenjohnson@accept_19.com"
+            "cna": "drive_13",
+            "user": "alecmitchell@drive_13.com"
         },
         "time": {
-            "created": "2019-12-05T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2019-11-15T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2002-0004",
-        "cve_year": 2002,
-        "state": "REJECT",
-        "owning_cna": "accept_19",
-        "reserved": "2019-12-05T00:00:00.000000Z"
+        "cve_id": "CVE-2001-0008",
+        "cve_year": 2001,
+        "state": "RESERVED",
+        "owning_cna": "drive_13",
+        "reserved": "2019-11-15T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "difference_16",
-            "user": "rebeccahenry@difference_16.com"
+            "cna": "senior_19",
+            "user": "jacobdouglas@senior_19.com"
         },
         "time": {
-            "created": "2018-12-05T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2016-03-16T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2001-0009",
+        "cve_year": 2001,
+        "state": "PUBLIC",
+        "owning_cna": "senior_19",
+        "reserved": "2016-03-16T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "final_7",
+            "user": "joshuaramirez@final_7.com"
+        },
+        "time": {
+            "created": "2016-11-02T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2001-0010",
+        "cve_year": 2001,
+        "state": "RESERVED",
+        "owning_cna": "final_7",
+        "reserved": "2016-11-02T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "property_15",
+            "user": "julieweaver@property_15.com"
+        },
+        "time": {
+            "created": "2011-12-19T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2002-0001",
+        "cve_year": 2002,
+        "state": "PUBLIC",
+        "owning_cna": "property_15",
+        "reserved": "2011-12-19T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "film_17",
+            "user": "logannewman@film_17.com"
+        },
+        "time": {
+            "created": "2020-02-28T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2002-0002",
+        "cve_year": 2002,
+        "state": "PUBLIC",
+        "owning_cna": "film_17",
+        "reserved": "2020-02-28T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "film_17",
+            "user": "logannewman@film_17.com"
+        },
+        "time": {
+            "created": "2019-08-07T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2002-0003",
+        "cve_year": 2002,
+        "state": "REJECT",
+        "owning_cna": "film_17",
+        "reserved": "2019-08-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "senior_19",
+            "user": "jacobdouglas@senior_19.com"
+        },
+        "time": {
+            "created": "2019-01-26T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:20.000000Z"
+        },
+        "cve_id": "CVE-2002-0004",
+        "cve_year": 2002,
+        "state": "RESERVED",
+        "owning_cna": "senior_19",
+        "reserved": "2019-01-26T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "agree_1",
+            "user": "rebeccaherring@agree_1.com"
+        },
+        "time": {
+            "created": "2014-03-23T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2002-0005",
         "cve_year": 2002,
         "state": "RESERVED",
-        "owning_cna": "difference_16",
-        "reserved": "2018-12-05T00:00:00.000000Z"
+        "owning_cna": "agree_1",
+        "reserved": "2014-03-23T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "raise_9",
-            "user": "ashleybradley@raise_9.com"
+            "cna": "now_11",
+            "user": "amybass@now_11.com"
         },
         "time": {
-            "created": "2014-07-18T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2020-04-18T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2002-0006",
         "cve_year": 2002,
-        "state": "RESERVED",
-        "owning_cna": "raise_9",
-        "reserved": "2014-07-18T00:00:00.000000Z"
+        "state": "PUBLIC",
+        "owning_cna": "now_11",
+        "reserved": "2020-04-18T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "difference_16",
-            "user": "rebeccahenry@difference_16.com"
+            "cna": "agree_1",
+            "user": "rebeccaherring@agree_1.com"
         },
         "time": {
-            "created": "2020-01-09T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2020-06-19T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2002-0007",
         "cve_year": 2002,
-        "state": "PUBLIC",
-        "owning_cna": "difference_16",
-        "reserved": "2020-01-09T00:00:00.000000Z"
+        "state": "RESERVED",
+        "owning_cna": "agree_1",
+        "reserved": "2020-06-19T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "today_2",
-            "user": "franciscoanderson@today_2.com"
+            "cna": "final_7",
+            "user": "joshuaramirez@final_7.com"
         },
         "time": {
-            "created": "2013-07-01T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2012-01-14T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2002-0008",
         "cve_year": 2002,
         "state": "RESERVED",
-        "owning_cna": "today_2",
-        "reserved": "2013-07-01T00:00:00.000000Z"
+        "owning_cna": "final_7",
+        "reserved": "2012-01-14T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "quickly_7",
-            "user": "ashleyanderson@quickly_7.com"
-        },
-        "time": {
-            "created": "2014-05-03T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2002-0009",
-        "cve_year": 2002,
-        "state": "REJECT",
-        "owning_cna": "quickly_7",
-        "reserved": "2014-05-03T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "man_5",
-            "user": "jeffreyfigueroa@man_5.com"
-        },
-        "time": {
-            "created": "2016-02-08T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2002-0010",
-        "cve_year": 2002,
-        "state": "REJECT",
-        "owning_cna": "man_5",
-        "reserved": "2016-02-08T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
-        },
-        "time": {
-            "created": "2013-06-15T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2003-0001",
-        "cve_year": 2003,
-        "state": "RESERVED",
-        "owning_cna": "magazine_15",
-        "reserved": "2013-06-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "technology_4",
-            "user": "jamesvaldez@technology_4.com"
-        },
-        "time": {
-            "created": "2011-06-23T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:26.000000Z"
-        },
-        "cve_id": "CVE-2003-0002",
-        "cve_year": 2003,
-        "state": "RESERVED",
-        "owning_cna": "technology_4",
-        "reserved": "2011-06-23T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "difference_16",
-            "user": "rebeccahenry@difference_16.com"
-        },
-        "time": {
-            "created": "2014-03-04T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2003-0003",
-        "cve_year": 2003,
-        "state": "PUBLIC",
-        "owning_cna": "difference_16",
-        "reserved": "2014-03-04T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "quickly_7",
-            "user": "ashleyanderson@quickly_7.com"
-        },
-        "time": {
-            "created": "2021-03-29T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2003-0004",
-        "cve_year": 2003,
-        "state": "RESERVED",
-        "owning_cna": "quickly_7",
-        "reserved": "2021-03-29T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
-        },
-        "time": {
-            "created": "2018-03-31T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:27.000000Z"
-        },
-        "cve_id": "CVE-2003-0005",
-        "cve_year": 2003,
-        "state": "RESERVED",
-        "owning_cna": "only_6",
-        "reserved": "2018-03-31T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "song_3",
-            "user": "sandrabrown@song_3.com"
-        },
-        "time": {
-            "created": "2021-03-12T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2003-0006",
-        "cve_year": 2003,
-        "state": "REJECT",
-        "owning_cna": "song_3",
-        "reserved": "2021-03-12T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "mitre",
-            "user": "christianromero@mitre.com"
-        },
-        "time": {
-            "created": "2017-08-09T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2003-0007",
-        "cve_year": 2003,
-        "state": "PUBLIC",
-        "owning_cna": "mitre",
-        "reserved": "2017-08-09T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "opportunity_13",
-            "user": "colleentorres@opportunity_13.com"
-        },
-        "time": {
-            "created": "2013-10-27T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:27.000000Z"
-        },
-        "cve_id": "CVE-2003-0008",
-        "cve_year": 2003,
-        "state": "PUBLIC",
-        "owning_cna": "opportunity_13",
-        "reserved": "2013-10-27T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "certain_10",
-            "user": "williammorris@certain_10.com"
-        },
-        "time": {
-            "created": "2012-09-04T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2003-0009",
-        "cve_year": 2003,
-        "state": "REJECT",
-        "owning_cna": "certain_10",
-        "reserved": "2012-09-04T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
-        },
-        "time": {
-            "created": "2018-11-17T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:28.000000Z"
-        },
-        "cve_id": "CVE-2003-0010",
-        "cve_year": 2003,
-        "state": "REJECT",
-        "owning_cna": "only_6",
-        "reserved": "2018-11-17T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "raise_9",
-            "user": "ashleybradley@raise_9.com"
-        },
-        "time": {
-            "created": "2016-10-10T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:28.000000Z"
-        },
-        "cve_id": "CVE-2004-0001",
-        "cve_year": 2004,
-        "state": "RESERVED",
-        "owning_cna": "raise_9",
-        "reserved": "2016-10-10T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "cost_12",
-            "user": "codymurphy@cost_12.com"
-        },
-        "time": {
-            "created": "2012-04-02T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2004-0002",
-        "cve_year": 2004,
-        "state": "RESERVED",
-        "owning_cna": "cost_12",
-        "reserved": "2012-04-02T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "from_11",
-            "user": "kimmiller@from_11.com"
-        },
-        "time": {
-            "created": "2015-01-23T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2004-0003",
-        "cve_year": 2004,
-        "state": "RESERVED",
-        "owning_cna": "from_11",
-        "reserved": "2015-01-23T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
-        },
-        "time": {
-            "created": "2018-03-04T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2004-0004",
-        "cve_year": 2004,
-        "state": "RESERVED",
-        "owning_cna": "magazine_15",
-        "reserved": "2018-03-04T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "quickly_7",
-            "user": "ashleyanderson@quickly_7.com"
-        },
-        "time": {
-            "created": "2016-12-23T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2004-0005",
-        "cve_year": 2004,
-        "state": "REJECT",
-        "owning_cna": "quickly_7",
-        "reserved": "2016-12-23T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
-        },
-        "time": {
-            "created": "2018-06-02T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2004-0006",
-        "cve_year": 2004,
-        "state": "REJECT",
-        "owning_cna": "only_6",
-        "reserved": "2018-06-02T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
-        },
-        "time": {
-            "created": "2017-10-07T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2004-0007",
-        "cve_year": 2004,
-        "state": "REJECT",
-        "owning_cna": "only_6",
-        "reserved": "2017-10-07T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "from_11",
-            "user": "kimmiller@from_11.com"
-        },
-        "time": {
-            "created": "2015-08-12T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2004-0008",
-        "cve_year": 2004,
-        "state": "RESERVED",
-        "owning_cna": "from_11",
-        "reserved": "2015-08-12T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "difference_16",
-            "user": "rebeccahenry@difference_16.com"
-        },
-        "time": {
-            "created": "2014-12-06T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2004-0009",
-        "cve_year": 2004,
-        "state": "RESERVED",
-        "owning_cna": "difference_16",
-        "reserved": "2014-12-06T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "cost_12",
-            "user": "codymurphy@cost_12.com"
-        },
-        "time": {
-            "created": "2019-07-28T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2004-0010",
-        "cve_year": 2004,
-        "state": "PUBLIC",
-        "owning_cna": "cost_12",
-        "reserved": "2019-07-28T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whether_20",
-            "user": "nicolecallahan@whether_20.com"
-        },
-        "time": {
-            "created": "2017-05-07T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:29.000000Z"
-        },
-        "cve_id": "CVE-2005-0001",
-        "cve_year": 2005,
-        "state": "RESERVED",
-        "owning_cna": "whether_20",
-        "reserved": "2017-05-07T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "song_3",
-            "user": "sandrabrown@song_3.com"
-        },
-        "time": {
-            "created": "2012-05-22T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2005-0002",
-        "cve_year": 2005,
-        "state": "RESERVED",
-        "owning_cna": "song_3",
-        "reserved": "2012-05-22T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "raise_9",
-            "user": "ashleybradley@raise_9.com"
-        },
-        "time": {
-            "created": "2015-01-22T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:30.000000Z"
-        },
-        "cve_id": "CVE-2005-0003",
-        "cve_year": 2005,
-        "state": "PUBLIC",
-        "owning_cna": "raise_9",
-        "reserved": "2015-01-22T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
-        },
-        "time": {
-            "created": "2013-04-22T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:30.000000Z"
-        },
-        "cve_id": "CVE-2005-0004",
-        "cve_year": 2005,
-        "state": "RESERVED",
-        "owning_cna": "magazine_15",
-        "reserved": "2013-04-22T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "certain_10",
-            "user": "williammorris@certain_10.com"
-        },
-        "time": {
-            "created": "2016-10-04T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2005-0005",
-        "cve_year": 2005,
-        "state": "PUBLIC",
-        "owning_cna": "certain_10",
-        "reserved": "2016-10-04T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "song_3",
-            "user": "sandrabrown@song_3.com"
-        },
-        "time": {
-            "created": "2018-08-14T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:30.000000Z"
-        },
-        "cve_id": "CVE-2005-0006",
-        "cve_year": 2005,
-        "state": "PUBLIC",
-        "owning_cna": "song_3",
-        "reserved": "2018-08-14T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "ok_17",
-            "user": "dominiquefrench@ok_17.com"
-        },
-        "time": {
-            "created": "2012-10-12T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2005-0007",
-        "cve_year": 2005,
-        "state": "RESERVED",
-        "owning_cna": "ok_17",
-        "reserved": "2012-10-12T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "ok_17",
-            "user": "dominiquefrench@ok_17.com"
-        },
-        "time": {
-            "created": "2017-01-11T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2005-0008",
-        "cve_year": 2005,
-        "state": "PUBLIC",
-        "owning_cna": "ok_17",
-        "reserved": "2017-01-11T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "here_1",
-            "user": "jamesfreeman@here_1.com"
-        },
-        "time": {
-            "created": "2019-12-31T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:31.000000Z"
-        },
-        "cve_id": "CVE-2005-0009",
-        "cve_year": 2005,
-        "state": "REJECT",
-        "owning_cna": "here_1",
-        "reserved": "2019-12-31T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "raise_9",
-            "user": "ashleybradley@raise_9.com"
-        },
-        "time": {
-            "created": "2013-09-18T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:31.000000Z"
-        },
-        "cve_id": "CVE-2005-0010",
-        "cve_year": 2005,
-        "state": "RESERVED",
-        "owning_cna": "raise_9",
-        "reserved": "2013-09-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "song_3",
-            "user": "sandrabrown@song_3.com"
-        },
-        "time": {
-            "created": "2012-11-18T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2006-0001",
-        "cve_year": 2006,
-        "state": "PUBLIC",
-        "owning_cna": "song_3",
-        "reserved": "2012-11-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "certain_10",
-            "user": "williammorris@certain_10.com"
-        },
-        "time": {
-            "created": "2016-07-21T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2006-0002",
-        "cve_year": 2006,
-        "state": "RESERVED",
-        "owning_cna": "certain_10",
-        "reserved": "2016-07-21T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "concern_8",
-            "user": "jasongray@concern_8.com"
-        },
-        "time": {
-            "created": "2019-01-19T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:32.000000Z"
-        },
-        "cve_id": "CVE-2006-0003",
-        "cve_year": 2006,
-        "state": "RESERVED",
-        "owning_cna": "concern_8",
-        "reserved": "2019-01-19T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "value_14",
-            "user": "janetdean@value_14.com"
-        },
-        "time": {
-            "created": "2019-01-23T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2006-0004",
-        "cve_year": 2006,
-        "state": "REJECT",
-        "owning_cna": "value_14",
-        "reserved": "2019-01-23T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "difference_16",
-            "user": "rebeccahenry@difference_16.com"
-        },
-        "time": {
-            "created": "2017-09-07T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2006-0005",
-        "cve_year": 2006,
-        "state": "PUBLIC",
-        "owning_cna": "difference_16",
-        "reserved": "2017-09-07T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "today_2",
-            "user": "franciscoanderson@today_2.com"
-        },
-        "time": {
-            "created": "2015-01-22T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2006-0006",
-        "cve_year": 2006,
-        "state": "REJECT",
-        "owning_cna": "today_2",
-        "reserved": "2015-01-22T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "man_5",
-            "user": "jeffreyfigueroa@man_5.com"
-        },
-        "time": {
-            "created": "2020-02-26T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2006-0007",
-        "cve_year": 2006,
-        "state": "PUBLIC",
-        "owning_cna": "man_5",
-        "reserved": "2020-02-26T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "technology_4",
-            "user": "jamesvaldez@technology_4.com"
-        },
-        "time": {
-            "created": "2018-02-25T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2006-0008",
-        "cve_year": 2006,
-        "state": "RESERVED",
-        "owning_cna": "technology_4",
-        "reserved": "2018-02-25T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "mitre",
-            "user": "christianromero@mitre.com"
-        },
-        "time": {
-            "created": "2011-06-05T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2006-0009",
-        "cve_year": 2006,
-        "state": "RESERVED",
-        "owning_cna": "mitre",
-        "reserved": "2011-06-05T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "here_1",
-            "user": "jamesfreeman@here_1.com"
-        },
-        "time": {
-            "created": "2021-01-03T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2006-0010",
-        "cve_year": 2006,
-        "state": "RESERVED",
-        "owning_cna": "here_1",
-        "reserved": "2021-01-03T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "mitre",
-            "user": "christianromero@mitre.com"
-        },
-        "time": {
-            "created": "2020-05-20T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2007-0001",
-        "cve_year": 2007,
-        "state": "RESERVED",
-        "owning_cna": "mitre",
-        "reserved": "2020-05-20T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "opportunity_13",
-            "user": "colleentorres@opportunity_13.com"
-        },
-        "time": {
-            "created": "2016-12-18T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:33.000000Z"
-        },
-        "cve_id": "CVE-2007-0002",
-        "cve_year": 2007,
-        "state": "REJECT",
-        "owning_cna": "opportunity_13",
-        "reserved": "2016-12-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
-        },
-        "time": {
-            "created": "2019-12-21T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2007-0003",
-        "cve_year": 2007,
-        "state": "RESERVED",
-        "owning_cna": "magazine_15",
-        "reserved": "2019-12-21T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "accept_19",
-            "user": "stephenjohnson@accept_19.com"
-        },
-        "time": {
-            "created": "2012-02-13T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2007-0004",
-        "cve_year": 2007,
-        "state": "PUBLIC",
-        "owning_cna": "accept_19",
-        "reserved": "2012-02-13T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "value_14",
-            "user": "janetdean@value_14.com"
+            "cna": "drive_13",
+            "user": "alecmitchell@drive_13.com"
         },
         "time": {
             "created": "2019-03-03T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2007-0005",
-        "cve_year": 2007,
-        "state": "RESERVED",
-        "owning_cna": "value_14",
+        "cve_id": "CVE-2002-0009",
+        "cve_year": 2002,
+        "state": "PUBLIC",
+        "owning_cna": "drive_13",
         "reserved": "2019-03-03T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "cost_12",
-            "user": "codymurphy@cost_12.com"
+            "cna": "senior_19",
+            "user": "jacobdouglas@senior_19.com"
         },
         "time": {
-            "created": "2019-01-15T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2019-01-24T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:21.000000Z"
         },
-        "cve_id": "CVE-2007-0006",
-        "cve_year": 2007,
-        "state": "RESERVED",
-        "owning_cna": "cost_12",
-        "reserved": "2019-01-15T00:00:00.000000Z"
+        "cve_id": "CVE-2002-0010",
+        "cve_year": 2002,
+        "state": "PUBLIC",
+        "owning_cna": "senior_19",
+        "reserved": "2019-01-24T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "concern_8",
-            "user": "jasongray@concern_8.com"
+            "cna": "senior_19",
+            "user": "jacobdouglas@senior_19.com"
         },
         "time": {
-            "created": "2016-06-30T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2017-01-12T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2007-0007",
-        "cve_year": 2007,
+        "cve_id": "CVE-2003-0001",
+        "cve_year": 2003,
         "state": "RESERVED",
-        "owning_cna": "concern_8",
-        "reserved": "2016-06-30T00:00:00.000000Z"
+        "owning_cna": "senior_19",
+        "reserved": "2017-01-12T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "today_2",
-            "user": "franciscoanderson@today_2.com"
+            "cna": "threat_12",
+            "user": "bethanybryant@threat_12.com"
         },
         "time": {
-            "created": "2016-07-30T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2020-10-12T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2007-0008",
-        "cve_year": 2007,
+        "cve_id": "CVE-2003-0002",
+        "cve_year": 2003,
+        "state": "RESERVED",
+        "owning_cna": "threat_12",
+        "reserved": "2020-10-12T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
+        },
+        "time": {
+            "created": "2020-01-28T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2003-0003",
+        "cve_year": 2003,
+        "state": "RESERVED",
+        "owning_cna": "body_2",
+        "reserved": "2020-01-28T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "bad_10",
+            "user": "cynthiabrooks@bad_10.com"
+        },
+        "time": {
+            "created": "2012-07-11T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2003-0004",
+        "cve_year": 2003,
         "state": "REJECT",
-        "owning_cna": "today_2",
-        "reserved": "2016-07-30T00:00:00.000000Z"
+        "owning_cna": "bad_10",
+        "reserved": "2012-07-11T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "whether_20",
-            "user": "nicolecallahan@whether_20.com"
+            "cna": "drive_13",
+            "user": "alecmitchell@drive_13.com"
         },
         "time": {
-            "created": "2013-12-16T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2011-07-17T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2007-0009",
-        "cve_year": 2007,
-        "state": "RESERVED",
-        "owning_cna": "whether_20",
-        "reserved": "2013-12-16T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whether_20",
-            "user": "nicolecallahan@whether_20.com"
-        },
-        "time": {
-            "created": "2019-03-15T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2007-0010",
-        "cve_year": 2007,
-        "state": "PUBLIC",
-        "owning_cna": "whether_20",
-        "reserved": "2019-03-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "quickly_7",
-            "user": "ashleyanderson@quickly_7.com"
-        },
-        "time": {
-            "created": "2016-02-14T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2008-0001",
-        "cve_year": 2008,
-        "state": "RESERVED",
-        "owning_cna": "quickly_7",
-        "reserved": "2016-02-14T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "opportunity_13",
-            "user": "colleentorres@opportunity_13.com"
-        },
-        "time": {
-            "created": "2020-07-10T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2008-0002",
-        "cve_year": 2008,
-        "state": "RESERVED",
-        "owning_cna": "opportunity_13",
-        "reserved": "2020-07-10T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "man_5",
-            "user": "jeffreyfigueroa@man_5.com"
-        },
-        "time": {
-            "created": "2015-10-28T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2008-0003",
-        "cve_year": 2008,
-        "state": "PUBLIC",
-        "owning_cna": "man_5",
-        "reserved": "2015-10-28T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "cost_12",
-            "user": "codymurphy@cost_12.com"
-        },
-        "time": {
-            "created": "2017-10-26T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2008-0004",
-        "cve_year": 2008,
-        "state": "RESERVED",
-        "owning_cna": "cost_12",
-        "reserved": "2017-10-26T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "difference_16",
-            "user": "rebeccahenry@difference_16.com"
-        },
-        "time": {
-            "created": "2019-07-13T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:35.000000Z"
-        },
-        "cve_id": "CVE-2008-0005",
-        "cve_year": 2008,
+        "cve_id": "CVE-2003-0005",
+        "cve_year": 2003,
         "state": "REJECT",
-        "owning_cna": "difference_16",
-        "reserved": "2019-07-13T00:00:00.000000Z"
+        "owning_cna": "drive_13",
+        "reserved": "2011-07-17T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "whether_20",
-            "user": "nicolecallahan@whether_20.com"
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
         },
         "time": {
-            "created": "2020-01-26T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2020-01-28T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:22.000000Z"
         },
-        "cve_id": "CVE-2008-0006",
-        "cve_year": 2008,
-        "state": "PUBLIC",
-        "owning_cna": "whether_20",
-        "reserved": "2020-01-26T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "value_14",
-            "user": "janetdean@value_14.com"
-        },
-        "time": {
-            "created": "2012-02-29T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2008-0007",
-        "cve_year": 2008,
-        "state": "RESERVED",
-        "owning_cna": "value_14",
-        "reserved": "2012-02-29T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "mitre",
-            "user": "christianromero@mitre.com"
-        },
-        "time": {
-            "created": "2014-05-06T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2008-0008",
-        "cve_year": 2008,
-        "state": "RESERVED",
-        "owning_cna": "mitre",
-        "reserved": "2014-05-06T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "today_2",
-            "user": "franciscoanderson@today_2.com"
-        },
-        "time": {
-            "created": "2012-08-15T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2008-0009",
-        "cve_year": 2008,
-        "state": "RESERVED",
-        "owning_cna": "today_2",
-        "reserved": "2012-08-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "cost_12",
-            "user": "codymurphy@cost_12.com"
-        },
-        "time": {
-            "created": "2011-11-17T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2008-0010",
-        "cve_year": 2008,
+        "cve_id": "CVE-2003-0006",
+        "cve_year": 2003,
         "state": "REJECT",
-        "owning_cna": "cost_12",
-        "reserved": "2011-11-17T00:00:00.000000Z"
+        "owning_cna": "body_2",
+        "reserved": "2020-01-28T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "today_2",
-            "user": "franciscoanderson@today_2.com"
+            "cna": "final_7",
+            "user": "joshuaramirez@final_7.com"
         },
         "time": {
-            "created": "2014-04-04T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2019-12-05T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2009-0001",
-        "cve_year": 2009,
+        "cve_id": "CVE-2003-0007",
+        "cve_year": 2003,
+        "state": "PUBLIC",
+        "owning_cna": "final_7",
+        "reserved": "2019-12-05T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "man_8",
+            "user": "ryanschmidt@man_8.com"
+        },
+        "time": {
+            "created": "2016-01-29T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2003-0008",
+        "cve_year": 2003,
+        "state": "RESERVED",
+        "owning_cna": "man_8",
+        "reserved": "2016-01-29T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2013-08-06T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2003-0009",
+        "cve_year": 2003,
+        "state": "PUBLIC",
+        "owning_cna": "student_18",
+        "reserved": "2013-08-06T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "suddenly_4",
+            "user": "christinediaz@suddenly_4.com"
+        },
+        "time": {
+            "created": "2014-05-27T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2003-0010",
+        "cve_year": 2003,
         "state": "REJECT",
-        "owning_cna": "today_2",
-        "reserved": "2014-04-04T00:00:00.000000Z"
+        "owning_cna": "suddenly_4",
+        "reserved": "2014-05-27T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "today_2",
-            "user": "franciscoanderson@today_2.com"
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
         },
         "time": {
-            "created": "2015-08-19T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2013-04-26T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2009-0002",
-        "cve_year": 2009,
+        "cve_id": "CVE-2004-0001",
+        "cve_year": 2004,
         "state": "RESERVED",
-        "owning_cna": "today_2",
-        "reserved": "2015-08-19T00:00:00.000000Z"
+        "owning_cna": "student_18",
+        "reserved": "2013-04-26T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "song_3",
-            "user": "sandrabrown@song_3.com"
+            "cna": "bad_10",
+            "user": "cynthiabrooks@bad_10.com"
         },
         "time": {
-            "created": "2012-09-13T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:37.000000Z"
+            "created": "2020-04-21T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2009-0003",
-        "cve_year": 2009,
-        "state": "PUBLIC",
-        "owning_cna": "song_3",
-        "reserved": "2012-09-13T00:00:00.000000Z"
+        "cve_id": "CVE-2004-0002",
+        "cve_year": 2004,
+        "state": "RESERVED",
+        "owning_cna": "bad_10",
+        "reserved": "2020-04-21T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "opportunity_13",
-            "user": "colleentorres@opportunity_13.com"
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
         },
         "time": {
-            "created": "2014-03-17T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2011-10-19T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:23.000000Z"
         },
-        "cve_id": "CVE-2009-0004",
-        "cve_year": 2009,
-        "state": "PUBLIC",
-        "owning_cna": "opportunity_13",
-        "reserved": "2014-03-17T00:00:00.000000Z"
+        "cve_id": "CVE-2004-0003",
+        "cve_year": 2004,
+        "state": "RESERVED",
+        "owning_cna": "body_2",
+        "reserved": "2011-10-19T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "accept_19",
-            "user": "stephenjohnson@accept_19.com"
+            "cna": "theory_9",
+            "user": "christophercook@theory_9.com"
         },
         "time": {
-            "created": "2019-04-24T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:37.000000Z"
+            "created": "2012-07-31T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2009-0005",
-        "cve_year": 2009,
-        "state": "PUBLIC",
-        "owning_cna": "accept_19",
-        "reserved": "2019-04-24T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whatever_18",
-            "user": "stevenvalentine@whatever_18.com"
-        },
-        "time": {
-            "created": "2012-06-27T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2009-0006",
-        "cve_year": 2009,
+        "cve_id": "CVE-2004-0004",
+        "cve_year": 2004,
         "state": "REJECT",
-        "owning_cna": "whatever_18",
-        "reserved": "2012-06-27T00:00:00.000000Z"
+        "owning_cna": "theory_9",
+        "reserved": "2012-07-31T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "accept_19",
-            "user": "stephenjohnson@accept_19.com"
+            "cna": "threat_12",
+            "user": "bethanybryant@threat_12.com"
         },
         "time": {
-            "created": "2016-02-03T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2016-06-12T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2009-0007",
-        "cve_year": 2009,
+        "cve_id": "CVE-2004-0005",
+        "cve_year": 2004,
         "state": "RESERVED",
-        "owning_cna": "accept_19",
-        "reserved": "2016-02-03T00:00:00.000000Z"
+        "owning_cna": "threat_12",
+        "reserved": "2016-06-12T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "technology_4",
-            "user": "jamesvaldez@technology_4.com"
+            "cna": "property_15",
+            "user": "julieweaver@property_15.com"
         },
         "time": {
-            "created": "2014-11-21T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:37.000000Z"
+            "created": "2016-03-12T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:24.000000Z"
         },
-        "cve_id": "CVE-2009-0008",
-        "cve_year": 2009,
+        "cve_id": "CVE-2004-0006",
+        "cve_year": 2004,
         "state": "RESERVED",
-        "owning_cna": "technology_4",
-        "reserved": "2014-11-21T00:00:00.000000Z"
+        "owning_cna": "property_15",
+        "reserved": "2016-03-12T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "whatever_18",
-            "user": "stevenvalentine@whatever_18.com"
+            "cna": "public_20",
+            "user": "richardbradshaw@public_20.com"
         },
         "time": {
-            "created": "2018-04-01T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2017-01-09T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:24.000000Z"
         },
-        "cve_id": "CVE-2009-0009",
-        "cve_year": 2009,
-        "state": "RESERVED",
-        "owning_cna": "whatever_18",
-        "reserved": "2018-04-01T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "song_3",
-            "user": "sandrabrown@song_3.com"
-        },
-        "time": {
-            "created": "2014-08-20T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2009-0010",
-        "cve_year": 2009,
-        "state": "RESERVED",
-        "owning_cna": "song_3",
-        "reserved": "2014-08-20T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "value_14",
-            "user": "janetdean@value_14.com"
-        },
-        "time": {
-            "created": "2020-06-04T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:38.000000Z"
-        },
-        "cve_id": "CVE-2010-0001",
-        "cve_year": 2010,
-        "state": "RESERVED",
-        "owning_cna": "value_14",
-        "reserved": "2020-06-04T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "technology_4",
-            "user": "jamesvaldez@technology_4.com"
-        },
-        "time": {
-            "created": "2012-10-06T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:38.000000Z"
-        },
-        "cve_id": "CVE-2010-0002",
-        "cve_year": 2010,
+        "cve_id": "CVE-2004-0007",
+        "cve_year": 2004,
         "state": "PUBLIC",
-        "owning_cna": "technology_4",
-        "reserved": "2012-10-06T00:00:00.000000Z"
+        "owning_cna": "public_20",
+        "reserved": "2017-01-09T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
         },
         "time": {
-            "created": "2014-12-11T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2021-02-09T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2010-0003",
-        "cve_year": 2010,
+        "cve_id": "CVE-2004-0008",
+        "cve_year": 2004,
         "state": "RESERVED",
-        "owning_cna": "magazine_15",
-        "reserved": "2014-12-11T00:00:00.000000Z"
+        "owning_cna": "body_2",
+        "reserved": "2021-02-09T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "cost_12",
-            "user": "codymurphy@cost_12.com"
+            "cna": "agree_1",
+            "user": "rebeccaherring@agree_1.com"
         },
         "time": {
-            "created": "2016-04-28T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:38.000000Z"
+            "created": "2019-10-06T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2010-0004",
-        "cve_year": 2010,
-        "state": "RESERVED",
-        "owning_cna": "cost_12",
-        "reserved": "2016-04-28T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whatever_18",
-            "user": "stevenvalentine@whatever_18.com"
-        },
-        "time": {
-            "created": "2014-03-08T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2010-0005",
-        "cve_year": 2010,
+        "cve_id": "CVE-2004-0009",
+        "cve_year": 2004,
         "state": "PUBLIC",
-        "owning_cna": "whatever_18",
-        "reserved": "2014-03-08T00:00:00.000000Z"
+        "owning_cna": "agree_1",
+        "reserved": "2019-10-06T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "whether_20",
-            "user": "nicolecallahan@whether_20.com"
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
         },
         "time": {
-            "created": "2011-10-24T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:39.000000Z"
+            "created": "2018-02-20T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:24.000000Z"
         },
-        "cve_id": "CVE-2010-0006",
-        "cve_year": 2010,
+        "cve_id": "CVE-2004-0010",
+        "cve_year": 2004,
+        "state": "RESERVED",
+        "owning_cna": "body_2",
+        "reserved": "2018-02-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2016-06-06T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:25.000000Z"
+        },
+        "cve_id": "CVE-2005-0001",
+        "cve_year": 2005,
         "state": "REJECT",
-        "owning_cna": "whether_20",
-        "reserved": "2011-10-24T00:00:00.000000Z"
+        "owning_cna": "student_18",
+        "reserved": "2016-06-06T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "man_5",
-            "user": "jeffreyfigueroa@man_5.com"
+            "cna": "level_16",
+            "user": "andrewgriffith@level_16.com"
         },
         "time": {
-            "created": "2019-06-26T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2017-09-11T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2010-0007",
-        "cve_year": 2010,
-        "state": "REJECT",
-        "owning_cna": "man_5",
-        "reserved": "2019-06-26T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "today_2",
-            "user": "franciscoanderson@today_2.com"
-        },
-        "time": {
-            "created": "2014-10-07T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2010-0008",
-        "cve_year": 2010,
+        "cve_id": "CVE-2005-0002",
+        "cve_year": 2005,
         "state": "RESERVED",
-        "owning_cna": "today_2",
-        "reserved": "2014-10-07T00:00:00.000000Z"
+        "owning_cna": "level_16",
+        "reserved": "2017-09-11T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "difference_16",
-            "user": "rebeccahenry@difference_16.com"
+            "cna": "property_15",
+            "user": "julieweaver@property_15.com"
         },
         "time": {
-            "created": "2017-02-19T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2012-04-10T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2010-0009",
-        "cve_year": 2010,
+        "cve_id": "CVE-2005-0003",
+        "cve_year": 2005,
         "state": "REJECT",
-        "owning_cna": "difference_16",
-        "reserved": "2017-02-19T00:00:00.000000Z"
+        "owning_cna": "property_15",
+        "reserved": "2012-04-10T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "today_2",
-            "user": "franciscoanderson@today_2.com"
+            "cna": "suddenly_4",
+            "user": "christinediaz@suddenly_4.com"
         },
         "time": {
-            "created": "2015-09-04T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2020-05-18T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2010-0010",
-        "cve_year": 2010,
+        "cve_id": "CVE-2005-0004",
+        "cve_year": 2005,
         "state": "PUBLIC",
-        "owning_cna": "today_2",
-        "reserved": "2015-09-04T00:00:00.000000Z"
+        "owning_cna": "suddenly_4",
+        "reserved": "2020-05-18T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "whatever_18",
-            "user": "stevenvalentine@whatever_18.com"
+            "cna": "level_16",
+            "user": "andrewgriffith@level_16.com"
         },
         "time": {
-            "created": "2013-12-20T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2015-06-27T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2011-0001",
-        "cve_year": 2011,
-        "state": "PUBLIC",
-        "owning_cna": "whatever_18",
-        "reserved": "2013-12-20T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "certain_10",
-            "user": "williammorris@certain_10.com"
-        },
-        "time": {
-            "created": "2012-06-27T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2011-0002",
-        "cve_year": 2011,
+        "cve_id": "CVE-2005-0005",
+        "cve_year": 2005,
         "state": "RESERVED",
-        "owning_cna": "certain_10",
-        "reserved": "2012-06-27T00:00:00.000000Z"
+        "owning_cna": "level_16",
+        "reserved": "2015-06-27T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "technology_4",
-            "user": "jamesvaldez@technology_4.com"
+            "cna": "theory_9",
+            "user": "christophercook@theory_9.com"
         },
         "time": {
-            "created": "2014-10-10T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:40.000000Z"
+            "created": "2019-10-09T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2011-0003",
-        "cve_year": 2011,
-        "state": "PUBLIC",
-        "owning_cna": "technology_4",
-        "reserved": "2014-10-10T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
-        },
-        "time": {
-            "created": "2019-08-13T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2011-0004",
-        "cve_year": 2011,
-        "state": "PUBLIC",
-        "owning_cna": "only_6",
-        "reserved": "2019-08-13T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "certain_10",
-            "user": "williammorris@certain_10.com"
-        },
-        "time": {
-            "created": "2020-08-14T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2011-0005",
-        "cve_year": 2011,
-        "state": "REJECT",
-        "owning_cna": "certain_10",
-        "reserved": "2020-08-14T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "quickly_7",
-            "user": "ashleyanderson@quickly_7.com"
-        },
-        "time": {
-            "created": "2012-02-08T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:41.000000Z"
-        },
-        "cve_id": "CVE-2011-0006",
-        "cve_year": 2011,
+        "cve_id": "CVE-2005-0006",
+        "cve_year": 2005,
         "state": "RESERVED",
-        "owning_cna": "quickly_7",
-        "reserved": "2012-02-08T00:00:00.000000Z"
+        "owning_cna": "theory_9",
+        "reserved": "2019-10-09T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "whether_20",
-            "user": "nicolecallahan@whether_20.com"
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
         },
         "time": {
-            "created": "2019-05-28T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2018-07-08T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2011-0007",
-        "cve_year": 2011,
-        "state": "RESERVED",
-        "owning_cna": "whether_20",
-        "reserved": "2019-05-28T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
-        },
-        "time": {
-            "created": "2016-01-18T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2011-0008",
-        "cve_year": 2011,
-        "state": "REJECT",
-        "owning_cna": "magazine_15",
-        "reserved": "2016-01-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "opportunity_13",
-            "user": "colleentorres@opportunity_13.com"
-        },
-        "time": {
-            "created": "2017-03-22T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:41.000000Z"
-        },
-        "cve_id": "CVE-2011-0009",
-        "cve_year": 2011,
-        "state": "REJECT",
-        "owning_cna": "opportunity_13",
-        "reserved": "2017-03-22T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "from_11",
-            "user": "kimmiller@from_11.com"
-        },
-        "time": {
-            "created": "2016-08-02T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2011-0010",
-        "cve_year": 2011,
-        "state": "RESERVED",
-        "owning_cna": "from_11",
-        "reserved": "2016-08-02T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "mitre",
-            "user": "christianromero@mitre.com"
-        },
-        "time": {
-            "created": "2015-05-03T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2012-0001",
-        "cve_year": 2012,
+        "cve_id": "CVE-2005-0007",
+        "cve_year": 2005,
         "state": "PUBLIC",
-        "owning_cna": "mitre",
-        "reserved": "2015-05-03T00:00:00.000000Z"
+        "owning_cna": "student_18",
+        "reserved": "2018-07-08T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "accept_19",
-            "user": "stephenjohnson@accept_19.com"
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
         },
         "time": {
             "created": "2020-06-03T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2012-0002",
-        "cve_year": 2012,
+        "cve_id": "CVE-2005-0008",
+        "cve_year": 2005,
         "state": "RESERVED",
-        "owning_cna": "accept_19",
+        "owning_cna": "student_18",
         "reserved": "2020-06-03T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "difference_16",
-            "user": "rebeccahenry@difference_16.com"
+            "cna": "level_16",
+            "user": "andrewgriffith@level_16.com"
         },
         "time": {
-            "created": "2016-09-27T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2017-03-04T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2012-0003",
-        "cve_year": 2012,
-        "state": "RESERVED",
-        "owning_cna": "difference_16",
-        "reserved": "2016-09-27T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "quickly_7",
-            "user": "ashleyanderson@quickly_7.com"
-        },
-        "time": {
-            "created": "2019-07-18T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2012-0004",
-        "cve_year": 2012,
-        "state": "RESERVED",
-        "owning_cna": "quickly_7",
-        "reserved": "2019-07-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "today_2",
-            "user": "franciscoanderson@today_2.com"
-        },
-        "time": {
-            "created": "2015-01-06T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2012-0005",
-        "cve_year": 2012,
-        "state": "RESERVED",
-        "owning_cna": "today_2",
-        "reserved": "2015-01-06T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "technology_4",
-            "user": "jamesvaldez@technology_4.com"
-        },
-        "time": {
-            "created": "2018-02-23T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2012-0006",
-        "cve_year": 2012,
-        "state": "RESERVED",
-        "owning_cna": "technology_4",
-        "reserved": "2018-02-23T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "opportunity_13",
-            "user": "colleentorres@opportunity_13.com"
-        },
-        "time": {
-            "created": "2012-08-11T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:43.000000Z"
-        },
-        "cve_id": "CVE-2012-0007",
-        "cve_year": 2012,
-        "state": "RESERVED",
-        "owning_cna": "opportunity_13",
-        "reserved": "2012-08-11T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "concern_8",
-            "user": "jasongray@concern_8.com"
-        },
-        "time": {
-            "created": "2017-05-15T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:43.000000Z"
-        },
-        "cve_id": "CVE-2012-0008",
-        "cve_year": 2012,
+        "cve_id": "CVE-2005-0009",
+        "cve_year": 2005,
         "state": "REJECT",
-        "owning_cna": "concern_8",
-        "reserved": "2017-05-15T00:00:00.000000Z"
+        "owning_cna": "level_16",
+        "reserved": "2017-03-04T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "ok_17",
-            "user": "dominiquefrench@ok_17.com"
+            "cna": "film_17",
+            "user": "logannewman@film_17.com"
         },
         "time": {
-            "created": "2015-09-09T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2014-05-14T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2012-0009",
-        "cve_year": 2012,
-        "state": "RESERVED",
-        "owning_cna": "ok_17",
-        "reserved": "2015-09-09T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "song_3",
-            "user": "sandrabrown@song_3.com"
-        },
-        "time": {
-            "created": "2017-09-23T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2012-0010",
-        "cve_year": 2012,
-        "state": "RESERVED",
-        "owning_cna": "song_3",
-        "reserved": "2017-09-23T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "technology_4",
-            "user": "jamesvaldez@technology_4.com"
-        },
-        "time": {
-            "created": "2012-04-26T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:43.000000Z"
-        },
-        "cve_id": "CVE-2013-0001",
-        "cve_year": 2013,
-        "state": "RESERVED",
-        "owning_cna": "technology_4",
-        "reserved": "2012-04-26T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "here_1",
-            "user": "jamesfreeman@here_1.com"
-        },
-        "time": {
-            "created": "2017-10-02T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2013-0002",
-        "cve_year": 2013,
-        "state": "RESERVED",
-        "owning_cna": "here_1",
-        "reserved": "2017-10-02T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "value_14",
-            "user": "janetdean@value_14.com"
-        },
-        "time": {
-            "created": "2014-10-11T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2013-0003",
-        "cve_year": 2013,
-        "state": "RESERVED",
-        "owning_cna": "value_14",
-        "reserved": "2014-10-11T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "cost_12",
-            "user": "codymurphy@cost_12.com"
-        },
-        "time": {
-            "created": "2014-11-03T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:44.000000Z"
-        },
-        "cve_id": "CVE-2013-0004",
-        "cve_year": 2013,
-        "state": "RESERVED",
-        "owning_cna": "cost_12",
-        "reserved": "2014-11-03T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
-        },
-        "time": {
-            "created": "2016-10-07T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2013-0005",
-        "cve_year": 2013,
+        "cve_id": "CVE-2005-0010",
+        "cve_year": 2005,
         "state": "REJECT",
-        "owning_cna": "magazine_15",
-        "reserved": "2016-10-07T00:00:00.000000Z"
+        "owning_cna": "film_17",
+        "reserved": "2014-05-14T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "ok_17",
-            "user": "dominiquefrench@ok_17.com"
+            "cna": "film_5",
+            "user": "benjaminnavarro@film_5.com"
         },
         "time": {
-            "created": "2011-05-18T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2015-10-23T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2013-0006",
-        "cve_year": 2013,
+        "cve_id": "CVE-2006-0001",
+        "cve_year": 2006,
         "state": "RESERVED",
-        "owning_cna": "ok_17",
-        "reserved": "2011-05-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "raise_9",
-            "user": "ashleybradley@raise_9.com"
-        },
-        "time": {
-            "created": "2018-05-15T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2013-0007",
-        "cve_year": 2013,
-        "state": "REJECT",
-        "owning_cna": "raise_9",
-        "reserved": "2018-05-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whatever_18",
-            "user": "stevenvalentine@whatever_18.com"
-        },
-        "time": {
-            "created": "2018-09-28T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:44.000000Z"
-        },
-        "cve_id": "CVE-2013-0008",
-        "cve_year": 2013,
-        "state": "REJECT",
-        "owning_cna": "whatever_18",
-        "reserved": "2018-09-28T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "man_5",
-            "user": "jeffreyfigueroa@man_5.com"
-        },
-        "time": {
-            "created": "2012-07-16T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2013-0009",
-        "cve_year": 2013,
-        "state": "REJECT",
-        "owning_cna": "man_5",
-        "reserved": "2012-07-16T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
-        },
-        "time": {
-            "created": "2016-12-12T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2013-0010",
-        "cve_year": 2013,
-        "state": "REJECT",
-        "owning_cna": "only_6",
-        "reserved": "2016-12-12T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whatever_18",
-            "user": "stevenvalentine@whatever_18.com"
-        },
-        "time": {
-            "created": "2020-10-24T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2014-0001",
-        "cve_year": 2014,
-        "state": "PUBLIC",
-        "owning_cna": "whatever_18",
-        "reserved": "2020-10-24T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
-        },
-        "time": {
-            "created": "2016-01-19T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2014-0002",
-        "cve_year": 2014,
-        "state": "RESERVED",
-        "owning_cna": "magazine_15",
-        "reserved": "2016-01-19T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "value_14",
-            "user": "janetdean@value_14.com"
-        },
-        "time": {
-            "created": "2016-08-25T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2014-0003",
-        "cve_year": 2014,
-        "state": "REJECT",
-        "owning_cna": "value_14",
-        "reserved": "2016-08-25T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "today_2",
-            "user": "franciscoanderson@today_2.com"
-        },
-        "time": {
-            "created": "2016-05-24T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:45.000000Z"
-        },
-        "cve_id": "CVE-2014-0004",
-        "cve_year": 2014,
-        "state": "PUBLIC",
-        "owning_cna": "today_2",
-        "reserved": "2016-05-24T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
-        },
-        "time": {
-            "created": "2019-03-05T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:46.000000Z"
-        },
-        "cve_id": "CVE-2014-0005",
-        "cve_year": 2014,
-        "state": "PUBLIC",
-        "owning_cna": "magazine_15",
-        "reserved": "2019-03-05T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "certain_10",
-            "user": "williammorris@certain_10.com"
-        },
-        "time": {
-            "created": "2016-02-05T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:46.000000Z"
-        },
-        "cve_id": "CVE-2014-0006",
-        "cve_year": 2014,
-        "state": "PUBLIC",
-        "owning_cna": "certain_10",
-        "reserved": "2016-02-05T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "song_3",
-            "user": "sandrabrown@song_3.com"
-        },
-        "time": {
-            "created": "2020-08-09T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2014-0007",
-        "cve_year": 2014,
-        "state": "RESERVED",
-        "owning_cna": "song_3",
-        "reserved": "2020-08-09T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "ok_17",
-            "user": "dominiquefrench@ok_17.com"
-        },
-        "time": {
-            "created": "2019-01-31T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:46.000000Z"
-        },
-        "cve_id": "CVE-2014-0008",
-        "cve_year": 2014,
-        "state": "REJECT",
-        "owning_cna": "ok_17",
-        "reserved": "2019-01-31T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whatever_18",
-            "user": "stevenvalentine@whatever_18.com"
-        },
-        "time": {
-            "created": "2019-05-20T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:46.000000Z"
-        },
-        "cve_id": "CVE-2014-0009",
-        "cve_year": 2014,
-        "state": "PUBLIC",
-        "owning_cna": "whatever_18",
-        "reserved": "2019-05-20T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "ok_17",
-            "user": "dominiquefrench@ok_17.com"
-        },
-        "time": {
-            "created": "2016-02-29T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:46.000000Z"
-        },
-        "cve_id": "CVE-2014-0010",
-        "cve_year": 2014,
-        "state": "RESERVED",
-        "owning_cna": "ok_17",
-        "reserved": "2016-02-29T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whether_20",
-            "user": "nicolecallahan@whether_20.com"
-        },
-        "time": {
-            "created": "2012-11-23T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2015-0001",
-        "cve_year": 2015,
-        "state": "RESERVED",
-        "owning_cna": "whether_20",
-        "reserved": "2012-11-23T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
-        },
-        "time": {
-            "created": "2012-08-10T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:47.000000Z"
-        },
-        "cve_id": "CVE-2015-0002",
-        "cve_year": 2015,
-        "state": "REJECT",
-        "owning_cna": "only_6",
-        "reserved": "2012-08-10T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "quickly_7",
-            "user": "ashleyanderson@quickly_7.com"
-        },
-        "time": {
-            "created": "2020-06-04T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2015-0003",
-        "cve_year": 2015,
-        "state": "RESERVED",
-        "owning_cna": "quickly_7",
-        "reserved": "2020-06-04T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "opportunity_13",
-            "user": "colleentorres@opportunity_13.com"
-        },
-        "time": {
-            "created": "2015-06-23T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:47.000000Z"
-        },
-        "cve_id": "CVE-2015-0004",
-        "cve_year": 2015,
-        "state": "REJECT",
-        "owning_cna": "opportunity_13",
-        "reserved": "2015-06-23T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "concern_8",
-            "user": "jasongray@concern_8.com"
-        },
-        "time": {
-            "created": "2012-08-09T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2015-0005",
-        "cve_year": 2015,
-        "state": "RESERVED",
-        "owning_cna": "concern_8",
-        "reserved": "2012-08-09T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "value_14",
-            "user": "janetdean@value_14.com"
-        },
-        "time": {
-            "created": "2020-10-10T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2015-0006",
-        "cve_year": 2015,
-        "state": "RESERVED",
-        "owning_cna": "value_14",
-        "reserved": "2020-10-10T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "opportunity_13",
-            "user": "colleentorres@opportunity_13.com"
-        },
-        "time": {
-            "created": "2013-07-27T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2015-0007",
-        "cve_year": 2015,
-        "state": "RESERVED",
-        "owning_cna": "opportunity_13",
-        "reserved": "2013-07-27T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "quickly_7",
-            "user": "ashleyanderson@quickly_7.com"
-        },
-        "time": {
-            "created": "2013-03-20T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2015-0008",
-        "cve_year": 2015,
-        "state": "REJECT",
-        "owning_cna": "quickly_7",
-        "reserved": "2013-03-20T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "from_11",
-            "user": "kimmiller@from_11.com"
-        },
-        "time": {
-            "created": "2011-05-29T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2015-0009",
-        "cve_year": 2015,
-        "state": "RESERVED",
-        "owning_cna": "from_11",
-        "reserved": "2011-05-29T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whatever_18",
-            "user": "stevenvalentine@whatever_18.com"
-        },
-        "time": {
-            "created": "2020-11-13T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2015-0010",
-        "cve_year": 2015,
-        "state": "RESERVED",
-        "owning_cna": "whatever_18",
-        "reserved": "2020-11-13T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whatever_18",
-            "user": "stevenvalentine@whatever_18.com"
-        },
-        "time": {
-            "created": "2013-09-19T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2016-0001",
-        "cve_year": 2016,
-        "state": "PUBLIC",
-        "owning_cna": "whatever_18",
-        "reserved": "2013-09-19T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "certain_10",
-            "user": "williammorris@certain_10.com"
-        },
-        "time": {
-            "created": "2012-05-31T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2016-0002",
-        "cve_year": 2016,
-        "state": "RESERVED",
-        "owning_cna": "certain_10",
-        "reserved": "2012-05-31T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
-        },
-        "time": {
-            "created": "2019-04-06T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2016-0003",
-        "cve_year": 2016,
-        "state": "PUBLIC",
-        "owning_cna": "magazine_15",
-        "reserved": "2019-04-06T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whether_20",
-            "user": "nicolecallahan@whether_20.com"
-        },
-        "time": {
-            "created": "2016-12-21T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:49.000000Z"
-        },
-        "cve_id": "CVE-2016-0004",
-        "cve_year": 2016,
-        "state": "RESERVED",
-        "owning_cna": "whether_20",
-        "reserved": "2016-12-21T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "man_5",
-            "user": "jeffreyfigueroa@man_5.com"
-        },
-        "time": {
-            "created": "2015-12-09T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2016-0005",
-        "cve_year": 2016,
-        "state": "REJECT",
-        "owning_cna": "man_5",
-        "reserved": "2015-12-09T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
-        },
-        "time": {
-            "created": "2015-06-24T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:49.000000Z"
-        },
-        "cve_id": "CVE-2016-0006",
-        "cve_year": 2016,
-        "state": "REJECT",
-        "owning_cna": "only_6",
-        "reserved": "2015-06-24T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "from_11",
-            "user": "kimmiller@from_11.com"
-        },
-        "time": {
-            "created": "2020-02-07T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:49.000000Z"
-        },
-        "cve_id": "CVE-2016-0007",
-        "cve_year": 2016,
-        "state": "PUBLIC",
-        "owning_cna": "from_11",
-        "reserved": "2020-02-07T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "concern_8",
-            "user": "jasongray@concern_8.com"
-        },
-        "time": {
-            "created": "2011-05-25T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2016-0008",
-        "cve_year": 2016,
-        "state": "PUBLIC",
-        "owning_cna": "concern_8",
-        "reserved": "2011-05-25T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "song_3",
-            "user": "sandrabrown@song_3.com"
-        },
-        "time": {
-            "created": "2020-01-18T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:50.000000Z"
-        },
-        "cve_id": "CVE-2016-0009",
-        "cve_year": 2016,
-        "state": "REJECT",
-        "owning_cna": "song_3",
-        "reserved": "2020-01-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "value_14",
-            "user": "janetdean@value_14.com"
-        },
-        "time": {
-            "created": "2018-09-01T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:50.000000Z"
-        },
-        "cve_id": "CVE-2016-0010",
-        "cve_year": 2016,
-        "state": "PUBLIC",
-        "owning_cna": "value_14",
-        "reserved": "2018-09-01T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
-        },
-        "time": {
-            "created": "2018-06-03T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2017-0001",
-        "cve_year": 2017,
-        "state": "REJECT",
-        "owning_cna": "only_6",
-        "reserved": "2018-06-03T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "concern_8",
-            "user": "jasongray@concern_8.com"
-        },
-        "time": {
-            "created": "2016-01-14T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2017-0002",
-        "cve_year": 2017,
-        "state": "PUBLIC",
-        "owning_cna": "concern_8",
-        "reserved": "2016-01-14T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "here_1",
-            "user": "jamesfreeman@here_1.com"
-        },
-        "time": {
-            "created": "2016-11-25T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:51.000000Z"
-        },
-        "cve_id": "CVE-2017-0003",
-        "cve_year": 2017,
-        "state": "RESERVED",
-        "owning_cna": "here_1",
-        "reserved": "2016-11-25T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "cost_12",
-            "user": "codymurphy@cost_12.com"
-        },
-        "time": {
-            "created": "2020-03-08T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2017-0004",
-        "cve_year": 2017,
-        "state": "PUBLIC",
-        "owning_cna": "cost_12",
-        "reserved": "2020-03-08T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whether_20",
-            "user": "nicolecallahan@whether_20.com"
-        },
-        "time": {
-            "created": "2019-02-17T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:51.000000Z"
-        },
-        "cve_id": "CVE-2017-0005",
-        "cve_year": 2017,
-        "state": "REJECT",
-        "owning_cna": "whether_20",
-        "reserved": "2019-02-17T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whatever_18",
-            "user": "stevenvalentine@whatever_18.com"
-        },
-        "time": {
-            "created": "2018-02-08T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:51.000000Z"
-        },
-        "cve_id": "CVE-2017-0006",
-        "cve_year": 2017,
-        "state": "REJECT",
-        "owning_cna": "whatever_18",
-        "reserved": "2018-02-08T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
-        },
-        "time": {
-            "created": "2011-08-09T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2017-0007",
-        "cve_year": 2017,
-        "state": "PUBLIC",
-        "owning_cna": "magazine_15",
-        "reserved": "2011-08-09T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "accept_19",
-            "user": "stephenjohnson@accept_19.com"
-        },
-        "time": {
-            "created": "2011-07-24T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2017-0008",
-        "cve_year": 2017,
-        "state": "REJECT",
-        "owning_cna": "accept_19",
-        "reserved": "2011-07-24T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "raise_9",
-            "user": "ashleybradley@raise_9.com"
-        },
-        "time": {
-            "created": "2012-03-06T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2017-0009",
-        "cve_year": 2017,
-        "state": "RESERVED",
-        "owning_cna": "raise_9",
-        "reserved": "2012-03-06T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "ok_17",
-            "user": "dominiquefrench@ok_17.com"
-        },
-        "time": {
-            "created": "2015-03-03T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2017-0010",
-        "cve_year": 2017,
-        "state": "PUBLIC",
-        "owning_cna": "ok_17",
-        "reserved": "2015-03-03T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "quickly_7",
-            "user": "ashleyanderson@quickly_7.com"
-        },
-        "time": {
-            "created": "2020-04-10T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2018-0001",
-        "cve_year": 2018,
-        "state": "RESERVED",
-        "owning_cna": "quickly_7",
-        "reserved": "2020-04-10T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "concern_8",
-            "user": "jasongray@concern_8.com"
-        },
-        "time": {
-            "created": "2017-04-25T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2018-0002",
-        "cve_year": 2018,
-        "state": "RESERVED",
-        "owning_cna": "concern_8",
-        "reserved": "2017-04-25T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
-        },
-        "time": {
-            "created": "2013-04-06T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:52.000000Z"
-        },
-        "cve_id": "CVE-2018-0003",
-        "cve_year": 2018,
-        "state": "RESERVED",
-        "owning_cna": "only_6",
-        "reserved": "2013-04-06T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "concern_8",
-            "user": "jasongray@concern_8.com"
-        },
-        "time": {
-            "created": "2021-01-29T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2018-0004",
-        "cve_year": 2018,
-        "state": "PUBLIC",
-        "owning_cna": "concern_8",
-        "reserved": "2021-01-29T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
-        },
-        "time": {
-            "created": "2012-11-18T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2018-0005",
-        "cve_year": 2018,
-        "state": "RESERVED",
-        "owning_cna": "only_6",
-        "reserved": "2012-11-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
-        },
-        "time": {
-            "created": "2020-02-16T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2018-0006",
-        "cve_year": 2018,
-        "state": "PUBLIC",
-        "owning_cna": "magazine_15",
-        "reserved": "2020-02-16T00:00:00.000000Z"
+        "owning_cna": "film_5",
+        "reserved": "2015-10-23T00:00:00.000000Z"
     },
     {
         "requested_by": {
             "cna": "mitre",
-            "user": "christianromero@mitre.com"
+            "user": "michellemartin@mitre.com"
         },
         "time": {
-            "created": "2020-08-18T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2012-08-08T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
-        "cve_id": "CVE-2018-0007",
-        "cve_year": 2018,
-        "state": "RESERVED",
+        "cve_id": "CVE-2006-0002",
+        "cve_year": 2006,
+        "state": "REJECT",
         "owning_cna": "mitre",
-        "reserved": "2020-08-18T00:00:00.000000Z"
+        "reserved": "2012-08-08T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "whether_20",
-            "user": "nicolecallahan@whether_20.com"
+            "cna": "single_6",
+            "user": "lindavaughn@single_6.com"
+        },
+        "time": {
+            "created": "2017-02-16T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2006-0003",
+        "cve_year": 2006,
+        "state": "RESERVED",
+        "owning_cna": "single_6",
+        "reserved": "2017-02-16T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "senior_19",
+            "user": "jacobdouglas@senior_19.com"
+        },
+        "time": {
+            "created": "2016-01-07T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2006-0004",
+        "cve_year": 2006,
+        "state": "RESERVED",
+        "owning_cna": "senior_19",
+        "reserved": "2016-01-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "several_14",
+            "user": "calvinthompson@several_14.com"
+        },
+        "time": {
+            "created": "2020-10-07T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:27.000000Z"
+        },
+        "cve_id": "CVE-2006-0005",
+        "cve_year": 2006,
+        "state": "PUBLIC",
+        "owning_cna": "several_14",
+        "reserved": "2020-10-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2020-06-22T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:27.000000Z"
+        },
+        "cve_id": "CVE-2006-0006",
+        "cve_year": 2006,
+        "state": "PUBLIC",
+        "owning_cna": "student_18",
+        "reserved": "2020-06-22T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "michellemartin@mitre.com"
+        },
+        "time": {
+            "created": "2011-10-15T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:28.000000Z"
+        },
+        "cve_id": "CVE-2006-0007",
+        "cve_year": 2006,
+        "state": "RESERVED",
+        "owning_cna": "mitre",
+        "reserved": "2011-10-15T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "senior_19",
+            "user": "jacobdouglas@senior_19.com"
+        },
+        "time": {
+            "created": "2017-09-08T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2006-0008",
+        "cve_year": 2006,
+        "state": "PUBLIC",
+        "owning_cna": "senior_19",
+        "reserved": "2017-09-08T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "bad_10",
+            "user": "cynthiabrooks@bad_10.com"
+        },
+        "time": {
+            "created": "2019-02-08T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2006-0009",
+        "cve_year": 2006,
+        "state": "RESERVED",
+        "owning_cna": "bad_10",
+        "reserved": "2019-02-08T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "man_8",
+            "user": "ryanschmidt@man_8.com"
+        },
+        "time": {
+            "created": "2011-06-10T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2006-0010",
+        "cve_year": 2006,
+        "state": "PUBLIC",
+        "owning_cna": "man_8",
+        "reserved": "2011-06-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
+        },
+        "time": {
+            "created": "2021-03-20T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:28.000000Z"
+        },
+        "cve_id": "CVE-2007-0001",
+        "cve_year": 2007,
+        "state": "REJECT",
+        "owning_cna": "body_2",
+        "reserved": "2021-03-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2012-02-26T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2007-0002",
+        "cve_year": 2007,
+        "state": "PUBLIC",
+        "owning_cna": "student_18",
+        "reserved": "2012-02-26T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "agree_1",
+            "user": "rebeccaherring@agree_1.com"
+        },
+        "time": {
+            "created": "2013-08-04T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2007-0003",
+        "cve_year": 2007,
+        "state": "RESERVED",
+        "owning_cna": "agree_1",
+        "reserved": "2013-08-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "michellemartin@mitre.com"
+        },
+        "time": {
+            "created": "2021-03-21T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2007-0004",
+        "cve_year": 2007,
+        "state": "RESERVED",
+        "owning_cna": "mitre",
+        "reserved": "2021-03-21T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "threat_12",
+            "user": "bethanybryant@threat_12.com"
+        },
+        "time": {
+            "created": "2019-04-27T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2007-0005",
+        "cve_year": 2007,
+        "state": "REJECT",
+        "owning_cna": "threat_12",
+        "reserved": "2019-04-27T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "public_20",
+            "user": "richardbradshaw@public_20.com"
+        },
+        "time": {
+            "created": "2018-05-04T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:29.000000Z"
+        },
+        "cve_id": "CVE-2007-0006",
+        "cve_year": 2007,
+        "state": "RESERVED",
+        "owning_cna": "public_20",
+        "reserved": "2018-05-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "level_16",
+            "user": "andrewgriffith@level_16.com"
+        },
+        "time": {
+            "created": "2012-05-13T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2007-0007",
+        "cve_year": 2007,
+        "state": "RESERVED",
+        "owning_cna": "level_16",
+        "reserved": "2012-05-13T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "eight_3",
+            "user": "louisrose@eight_3.com"
+        },
+        "time": {
+            "created": "2020-04-07T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2007-0008",
+        "cve_year": 2007,
+        "state": "REJECT",
+        "owning_cna": "eight_3",
+        "reserved": "2020-04-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "eight_3",
+            "user": "louisrose@eight_3.com"
+        },
+        "time": {
+            "created": "2020-08-26T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2007-0009",
+        "cve_year": 2007,
+        "state": "RESERVED",
+        "owning_cna": "eight_3",
+        "reserved": "2020-08-26T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "level_16",
+            "user": "andrewgriffith@level_16.com"
+        },
+        "time": {
+            "created": "2014-10-01T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2007-0010",
+        "cve_year": 2007,
+        "state": "PUBLIC",
+        "owning_cna": "level_16",
+        "reserved": "2014-10-01T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "now_11",
+            "user": "amybass@now_11.com"
+        },
+        "time": {
+            "created": "2012-01-15T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:30.000000Z"
+        },
+        "cve_id": "CVE-2008-0001",
+        "cve_year": 2008,
+        "state": "PUBLIC",
+        "owning_cna": "now_11",
+        "reserved": "2012-01-15T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "film_17",
+            "user": "logannewman@film_17.com"
+        },
+        "time": {
+            "created": "2018-06-20T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:30.000000Z"
+        },
+        "cve_id": "CVE-2008-0002",
+        "cve_year": 2008,
+        "state": "RESERVED",
+        "owning_cna": "film_17",
+        "reserved": "2018-06-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "man_8",
+            "user": "ryanschmidt@man_8.com"
+        },
+        "time": {
+            "created": "2012-06-23T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2008-0003",
+        "cve_year": 2008,
+        "state": "RESERVED",
+        "owning_cna": "man_8",
+        "reserved": "2012-06-23T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
+        },
+        "time": {
+            "created": "2018-06-17T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2008-0004",
+        "cve_year": 2008,
+        "state": "PUBLIC",
+        "owning_cna": "body_2",
+        "reserved": "2018-06-17T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "level_16",
+            "user": "andrewgriffith@level_16.com"
+        },
+        "time": {
+            "created": "2013-02-24T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2008-0005",
+        "cve_year": 2008,
+        "state": "PUBLIC",
+        "owning_cna": "level_16",
+        "reserved": "2013-02-24T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "theory_9",
+            "user": "christophercook@theory_9.com"
+        },
+        "time": {
+            "created": "2017-02-01T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2008-0006",
+        "cve_year": 2008,
+        "state": "RESERVED",
+        "owning_cna": "theory_9",
+        "reserved": "2017-02-01T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "public_20",
+            "user": "richardbradshaw@public_20.com"
+        },
+        "time": {
+            "created": "2013-03-25T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2008-0007",
+        "cve_year": 2008,
+        "state": "REJECT",
+        "owning_cna": "public_20",
+        "reserved": "2013-03-25T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "man_8",
+            "user": "ryanschmidt@man_8.com"
+        },
+        "time": {
+            "created": "2013-06-22T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:31.000000Z"
+        },
+        "cve_id": "CVE-2008-0008",
+        "cve_year": 2008,
+        "state": "PUBLIC",
+        "owning_cna": "man_8",
+        "reserved": "2013-06-22T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "michellemartin@mitre.com"
+        },
+        "time": {
+            "created": "2016-06-03T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:31.000000Z"
+        },
+        "cve_id": "CVE-2008-0009",
+        "cve_year": 2008,
+        "state": "RESERVED",
+        "owning_cna": "mitre",
+        "reserved": "2016-06-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "property_15",
+            "user": "julieweaver@property_15.com"
+        },
+        "time": {
+            "created": "2019-07-04T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2008-0010",
+        "cve_year": 2008,
+        "state": "REJECT",
+        "owning_cna": "property_15",
+        "reserved": "2019-07-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "michellemartin@mitre.com"
+        },
+        "time": {
+            "created": "2019-11-24T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2009-0001",
+        "cve_year": 2009,
+        "state": "PUBLIC",
+        "owning_cna": "mitre",
+        "reserved": "2019-11-24T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "level_16",
+            "user": "andrewgriffith@level_16.com"
+        },
+        "time": {
+            "created": "2014-07-17T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2009-0002",
+        "cve_year": 2009,
+        "state": "REJECT",
+        "owning_cna": "level_16",
+        "reserved": "2014-07-17T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "single_6",
+            "user": "lindavaughn@single_6.com"
+        },
+        "time": {
+            "created": "2020-01-26T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2009-0003",
+        "cve_year": 2009,
+        "state": "REJECT",
+        "owning_cna": "single_6",
+        "reserved": "2020-01-26T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "theory_9",
+            "user": "christophercook@theory_9.com"
+        },
+        "time": {
+            "created": "2012-06-04T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2009-0004",
+        "cve_year": 2009,
+        "state": "RESERVED",
+        "owning_cna": "theory_9",
+        "reserved": "2012-06-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "now_11",
+            "user": "amybass@now_11.com"
+        },
+        "time": {
+            "created": "2018-01-10T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2009-0005",
+        "cve_year": 2009,
+        "state": "RESERVED",
+        "owning_cna": "now_11",
+        "reserved": "2018-01-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "bad_10",
+            "user": "cynthiabrooks@bad_10.com"
+        },
+        "time": {
+            "created": "2018-08-07T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2009-0006",
+        "cve_year": 2009,
+        "state": "REJECT",
+        "owning_cna": "bad_10",
+        "reserved": "2018-08-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "property_15",
+            "user": "julieweaver@property_15.com"
+        },
+        "time": {
+            "created": "2018-09-22T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:33.000000Z"
+        },
+        "cve_id": "CVE-2009-0007",
+        "cve_year": 2009,
+        "state": "RESERVED",
+        "owning_cna": "property_15",
+        "reserved": "2018-09-22T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2017-04-13T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2009-0008",
+        "cve_year": 2009,
+        "state": "REJECT",
+        "owning_cna": "student_18",
+        "reserved": "2017-04-13T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "level_16",
+            "user": "andrewgriffith@level_16.com"
+        },
+        "time": {
+            "created": "2011-06-13T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:33.000000Z"
+        },
+        "cve_id": "CVE-2009-0009",
+        "cve_year": 2009,
+        "state": "RESERVED",
+        "owning_cna": "level_16",
+        "reserved": "2011-06-13T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "drive_13",
+            "user": "alecmitchell@drive_13.com"
+        },
+        "time": {
+            "created": "2017-01-07T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2009-0010",
+        "cve_year": 2009,
+        "state": "RESERVED",
+        "owning_cna": "drive_13",
+        "reserved": "2017-01-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "michellemartin@mitre.com"
+        },
+        "time": {
+            "created": "2016-12-18T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:33.000000Z"
+        },
+        "cve_id": "CVE-2010-0001",
+        "cve_year": 2010,
+        "state": "PUBLIC",
+        "owning_cna": "mitre",
+        "reserved": "2016-12-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "property_15",
+            "user": "julieweaver@property_15.com"
+        },
+        "time": {
+            "created": "2016-04-14T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2010-0002",
+        "cve_year": 2010,
+        "state": "PUBLIC",
+        "owning_cna": "property_15",
+        "reserved": "2016-04-14T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "suddenly_4",
+            "user": "christinediaz@suddenly_4.com"
+        },
+        "time": {
+            "created": "2012-05-10T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2010-0003",
+        "cve_year": 2010,
+        "state": "REJECT",
+        "owning_cna": "suddenly_4",
+        "reserved": "2012-05-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "bad_10",
+            "user": "cynthiabrooks@bad_10.com"
+        },
+        "time": {
+            "created": "2019-06-01T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2010-0004",
+        "cve_year": 2010,
+        "state": "RESERVED",
+        "owning_cna": "bad_10",
+        "reserved": "2019-06-01T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "single_6",
+            "user": "lindavaughn@single_6.com"
+        },
+        "time": {
+            "created": "2021-05-04T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2010-0005",
+        "cve_year": 2010,
+        "state": "RESERVED",
+        "owning_cna": "single_6",
+        "reserved": "2021-05-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "single_6",
+            "user": "lindavaughn@single_6.com"
+        },
+        "time": {
+            "created": "2013-10-20T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2010-0006",
+        "cve_year": 2010,
+        "state": "RESERVED",
+        "owning_cna": "single_6",
+        "reserved": "2013-10-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "bad_10",
+            "user": "cynthiabrooks@bad_10.com"
+        },
+        "time": {
+            "created": "2014-11-05T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:35.000000Z"
+        },
+        "cve_id": "CVE-2010-0007",
+        "cve_year": 2010,
+        "state": "RESERVED",
+        "owning_cna": "bad_10",
+        "reserved": "2014-11-05T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "single_6",
+            "user": "lindavaughn@single_6.com"
+        },
+        "time": {
+            "created": "2018-01-10T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:35.000000Z"
+        },
+        "cve_id": "CVE-2010-0008",
+        "cve_year": 2010,
+        "state": "PUBLIC",
+        "owning_cna": "single_6",
+        "reserved": "2018-01-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "now_11",
+            "user": "amybass@now_11.com"
+        },
+        "time": {
+            "created": "2013-03-09T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2010-0009",
+        "cve_year": 2010,
+        "state": "PUBLIC",
+        "owning_cna": "now_11",
+        "reserved": "2013-03-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "agree_1",
+            "user": "rebeccaherring@agree_1.com"
+        },
+        "time": {
+            "created": "2020-07-27T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:35.000000Z"
+        },
+        "cve_id": "CVE-2010-0010",
+        "cve_year": 2010,
+        "state": "PUBLIC",
+        "owning_cna": "agree_1",
+        "reserved": "2020-07-27T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "drive_13",
+            "user": "alecmitchell@drive_13.com"
+        },
+        "time": {
+            "created": "2016-07-29T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2011-0001",
+        "cve_year": 2011,
+        "state": "RESERVED",
+        "owning_cna": "drive_13",
+        "reserved": "2016-07-29T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2018-07-29T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:36.000000Z"
+        },
+        "cve_id": "CVE-2011-0002",
+        "cve_year": 2011,
+        "state": "REJECT",
+        "owning_cna": "student_18",
+        "reserved": "2018-07-29T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "threat_12",
+            "user": "bethanybryant@threat_12.com"
+        },
+        "time": {
+            "created": "2017-05-22T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:36.000000Z"
+        },
+        "cve_id": "CVE-2011-0003",
+        "cve_year": 2011,
+        "state": "RESERVED",
+        "owning_cna": "threat_12",
+        "reserved": "2017-05-22T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "final_7",
+            "user": "joshuaramirez@final_7.com"
+        },
+        "time": {
+            "created": "2016-10-31T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2011-0004",
+        "cve_year": 2011,
+        "state": "REJECT",
+        "owning_cna": "final_7",
+        "reserved": "2016-10-31T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "drive_13",
+            "user": "alecmitchell@drive_13.com"
+        },
+        "time": {
+            "created": "2011-08-03T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2011-0005",
+        "cve_year": 2011,
+        "state": "RESERVED",
+        "owning_cna": "drive_13",
+        "reserved": "2011-08-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "bad_10",
+            "user": "cynthiabrooks@bad_10.com"
+        },
+        "time": {
+            "created": "2015-09-01T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2011-0006",
+        "cve_year": 2011,
+        "state": "PUBLIC",
+        "owning_cna": "bad_10",
+        "reserved": "2015-09-01T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "single_6",
+            "user": "lindavaughn@single_6.com"
+        },
+        "time": {
+            "created": "2012-06-10T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2011-0007",
+        "cve_year": 2011,
+        "state": "PUBLIC",
+        "owning_cna": "single_6",
+        "reserved": "2012-06-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "bad_10",
+            "user": "cynthiabrooks@bad_10.com"
+        },
+        "time": {
+            "created": "2018-05-09T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2011-0008",
+        "cve_year": 2011,
+        "state": "RESERVED",
+        "owning_cna": "bad_10",
+        "reserved": "2018-05-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "single_6",
+            "user": "lindavaughn@single_6.com"
+        },
+        "time": {
+            "created": "2016-07-10T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:37.000000Z"
+        },
+        "cve_id": "CVE-2011-0009",
+        "cve_year": 2011,
+        "state": "RESERVED",
+        "owning_cna": "single_6",
+        "reserved": "2016-07-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "senior_19",
+            "user": "jacobdouglas@senior_19.com"
+        },
+        "time": {
+            "created": "2014-05-25T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2011-0010",
+        "cve_year": 2011,
+        "state": "RESERVED",
+        "owning_cna": "senior_19",
+        "reserved": "2014-05-25T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "now_11",
+            "user": "amybass@now_11.com"
+        },
+        "time": {
+            "created": "2020-08-09T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2012-0001",
+        "cve_year": 2012,
+        "state": "RESERVED",
+        "owning_cna": "now_11",
+        "reserved": "2020-08-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
+        },
+        "time": {
+            "created": "2016-06-21T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:37.000000Z"
+        },
+        "cve_id": "CVE-2012-0002",
+        "cve_year": 2012,
+        "state": "RESERVED",
+        "owning_cna": "body_2",
+        "reserved": "2016-06-21T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "several_14",
+            "user": "calvinthompson@several_14.com"
+        },
+        "time": {
+            "created": "2017-11-22T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:38.000000Z"
+        },
+        "cve_id": "CVE-2012-0003",
+        "cve_year": 2012,
+        "state": "RESERVED",
+        "owning_cna": "several_14",
+        "reserved": "2017-11-22T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "film_5",
+            "user": "benjaminnavarro@film_5.com"
+        },
+        "time": {
+            "created": "2014-02-12T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:38.000000Z"
+        },
+        "cve_id": "CVE-2012-0004",
+        "cve_year": 2012,
+        "state": "REJECT",
+        "owning_cna": "film_5",
+        "reserved": "2014-02-12T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "suddenly_4",
+            "user": "christinediaz@suddenly_4.com"
+        },
+        "time": {
+            "created": "2017-03-24T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:38.000000Z"
+        },
+        "cve_id": "CVE-2012-0005",
+        "cve_year": 2012,
+        "state": "REJECT",
+        "owning_cna": "suddenly_4",
+        "reserved": "2017-03-24T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "drive_13",
+            "user": "alecmitchell@drive_13.com"
+        },
+        "time": {
+            "created": "2019-12-04T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2012-0006",
+        "cve_year": 2012,
+        "state": "PUBLIC",
+        "owning_cna": "drive_13",
+        "reserved": "2019-12-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "man_8",
+            "user": "ryanschmidt@man_8.com"
+        },
+        "time": {
+            "created": "2012-02-20T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2012-0007",
+        "cve_year": 2012,
+        "state": "RESERVED",
+        "owning_cna": "man_8",
+        "reserved": "2012-02-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "senior_19",
+            "user": "jacobdouglas@senior_19.com"
+        },
+        "time": {
+            "created": "2012-12-24T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2012-0008",
+        "cve_year": 2012,
+        "state": "RESERVED",
+        "owning_cna": "senior_19",
+        "reserved": "2012-12-24T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "level_16",
+            "user": "andrewgriffith@level_16.com"
+        },
+        "time": {
+            "created": "2014-09-24T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2012-0009",
+        "cve_year": 2012,
+        "state": "PUBLIC",
+        "owning_cna": "level_16",
+        "reserved": "2014-09-24T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "agree_1",
+            "user": "rebeccaherring@agree_1.com"
+        },
+        "time": {
+            "created": "2011-12-09T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2012-0010",
+        "cve_year": 2012,
+        "state": "REJECT",
+        "owning_cna": "agree_1",
+        "reserved": "2011-12-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "eight_3",
+            "user": "louisrose@eight_3.com"
+        },
+        "time": {
+            "created": "2012-08-20T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2013-0001",
+        "cve_year": 2013,
+        "state": "PUBLIC",
+        "owning_cna": "eight_3",
+        "reserved": "2012-08-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "single_6",
+            "user": "lindavaughn@single_6.com"
+        },
+        "time": {
+            "created": "2013-02-09T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2013-0002",
+        "cve_year": 2013,
+        "state": "RESERVED",
+        "owning_cna": "single_6",
+        "reserved": "2013-02-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "threat_12",
+            "user": "bethanybryant@threat_12.com"
+        },
+        "time": {
+            "created": "2013-01-18T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2013-0003",
+        "cve_year": 2013,
+        "state": "RESERVED",
+        "owning_cna": "threat_12",
+        "reserved": "2013-01-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "final_7",
+            "user": "joshuaramirez@final_7.com"
+        },
+        "time": {
+            "created": "2016-05-17T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2013-0004",
+        "cve_year": 2013,
+        "state": "RESERVED",
+        "owning_cna": "final_7",
+        "reserved": "2016-05-17T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "eight_3",
+            "user": "louisrose@eight_3.com"
+        },
+        "time": {
+            "created": "2015-07-07T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2013-0005",
+        "cve_year": 2013,
+        "state": "PUBLIC",
+        "owning_cna": "eight_3",
+        "reserved": "2015-07-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "final_7",
+            "user": "joshuaramirez@final_7.com"
+        },
+        "time": {
+            "created": "2011-06-27T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2013-0006",
+        "cve_year": 2013,
+        "state": "RESERVED",
+        "owning_cna": "final_7",
+        "reserved": "2011-06-27T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "public_20",
+            "user": "richardbradshaw@public_20.com"
+        },
+        "time": {
+            "created": "2019-08-01T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2013-0007",
+        "cve_year": 2013,
+        "state": "REJECT",
+        "owning_cna": "public_20",
+        "reserved": "2019-08-01T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "eight_3",
+            "user": "louisrose@eight_3.com"
+        },
+        "time": {
+            "created": "2014-05-20T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2013-0008",
+        "cve_year": 2013,
+        "state": "RESERVED",
+        "owning_cna": "eight_3",
+        "reserved": "2014-05-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
+        },
+        "time": {
+            "created": "2013-04-28T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2013-0009",
+        "cve_year": 2013,
+        "state": "REJECT",
+        "owning_cna": "body_2",
+        "reserved": "2013-04-28T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "threat_12",
+            "user": "bethanybryant@threat_12.com"
+        },
+        "time": {
+            "created": "2018-07-11T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2013-0010",
+        "cve_year": 2013,
+        "state": "REJECT",
+        "owning_cna": "threat_12",
+        "reserved": "2018-07-11T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "drive_13",
+            "user": "alecmitchell@drive_13.com"
+        },
+        "time": {
+            "created": "2016-10-15T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2014-0001",
+        "cve_year": 2014,
+        "state": "RESERVED",
+        "owning_cna": "drive_13",
+        "reserved": "2016-10-15T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
+        },
+        "time": {
+            "created": "2015-10-26T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2014-0002",
+        "cve_year": 2014,
+        "state": "RESERVED",
+        "owning_cna": "body_2",
+        "reserved": "2015-10-26T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "michellemartin@mitre.com"
+        },
+        "time": {
+            "created": "2020-02-09T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2014-0003",
+        "cve_year": 2014,
+        "state": "PUBLIC",
+        "owning_cna": "mitre",
+        "reserved": "2020-02-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "theory_9",
+            "user": "christophercook@theory_9.com"
+        },
+        "time": {
+            "created": "2017-05-20T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2014-0004",
+        "cve_year": 2014,
+        "state": "RESERVED",
+        "owning_cna": "theory_9",
+        "reserved": "2017-05-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "michellemartin@mitre.com"
+        },
+        "time": {
+            "created": "2012-11-11T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2014-0005",
+        "cve_year": 2014,
+        "state": "RESERVED",
+        "owning_cna": "mitre",
+        "reserved": "2012-11-11T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "film_5",
+            "user": "benjaminnavarro@film_5.com"
+        },
+        "time": {
+            "created": "2020-11-20T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2014-0006",
+        "cve_year": 2014,
+        "state": "REJECT",
+        "owning_cna": "film_5",
+        "reserved": "2020-11-20T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
+        },
+        "time": {
+            "created": "2015-11-03T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2014-0007",
+        "cve_year": 2014,
+        "state": "PUBLIC",
+        "owning_cna": "body_2",
+        "reserved": "2015-11-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "suddenly_4",
+            "user": "christinediaz@suddenly_4.com"
+        },
+        "time": {
+            "created": "2019-11-17T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2014-0008",
+        "cve_year": 2014,
+        "state": "RESERVED",
+        "owning_cna": "suddenly_4",
+        "reserved": "2019-11-17T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "theory_9",
+            "user": "christophercook@theory_9.com"
+        },
+        "time": {
+            "created": "2011-11-01T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2014-0009",
+        "cve_year": 2014,
+        "state": "PUBLIC",
+        "owning_cna": "theory_9",
+        "reserved": "2011-11-01T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "michellemartin@mitre.com"
+        },
+        "time": {
+            "created": "2013-12-10T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2014-0010",
+        "cve_year": 2014,
+        "state": "PUBLIC",
+        "owning_cna": "mitre",
+        "reserved": "2013-12-10T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "now_11",
+            "user": "amybass@now_11.com"
         },
         "time": {
             "created": "2013-12-24T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "modified": "2021-05-11T02:56:42.000000Z"
         },
-        "cve_id": "CVE-2018-0008",
-        "cve_year": 2018,
+        "cve_id": "CVE-2015-0001",
+        "cve_year": 2015,
         "state": "RESERVED",
-        "owning_cna": "whether_20",
+        "owning_cna": "now_11",
         "reserved": "2013-12-24T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
+            "cna": "film_5",
+            "user": "benjaminnavarro@film_5.com"
         },
         "time": {
-            "created": "2018-08-03T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:53.000000Z"
+            "created": "2018-02-15T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:43.000000Z"
+        },
+        "cve_id": "CVE-2015-0002",
+        "cve_year": 2015,
+        "state": "REJECT",
+        "owning_cna": "film_5",
+        "reserved": "2018-02-15T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "theory_9",
+            "user": "christophercook@theory_9.com"
+        },
+        "time": {
+            "created": "2013-06-17T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:43.000000Z"
+        },
+        "cve_id": "CVE-2015-0003",
+        "cve_year": 2015,
+        "state": "RESERVED",
+        "owning_cna": "theory_9",
+        "reserved": "2013-06-17T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2014-04-19T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2015-0004",
+        "cve_year": 2015,
+        "state": "RESERVED",
+        "owning_cna": "student_18",
+        "reserved": "2014-04-19T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "threat_12",
+            "user": "bethanybryant@threat_12.com"
+        },
+        "time": {
+            "created": "2017-04-13T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2015-0005",
+        "cve_year": 2015,
+        "state": "RESERVED",
+        "owning_cna": "threat_12",
+        "reserved": "2017-04-13T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "eight_3",
+            "user": "louisrose@eight_3.com"
+        },
+        "time": {
+            "created": "2015-11-19T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:43.000000Z"
+        },
+        "cve_id": "CVE-2015-0006",
+        "cve_year": 2015,
+        "state": "PUBLIC",
+        "owning_cna": "eight_3",
+        "reserved": "2015-11-19T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "suddenly_4",
+            "user": "christinediaz@suddenly_4.com"
+        },
+        "time": {
+            "created": "2013-07-07T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:43.000000Z"
+        },
+        "cve_id": "CVE-2015-0007",
+        "cve_year": 2015,
+        "state": "REJECT",
+        "owning_cna": "suddenly_4",
+        "reserved": "2013-07-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2013-12-01T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2015-0008",
+        "cve_year": 2015,
+        "state": "RESERVED",
+        "owning_cna": "student_18",
+        "reserved": "2013-12-01T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "threat_12",
+            "user": "bethanybryant@threat_12.com"
+        },
+        "time": {
+            "created": "2016-08-12T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:44.000000Z"
+        },
+        "cve_id": "CVE-2015-0009",
+        "cve_year": 2015,
+        "state": "PUBLIC",
+        "owning_cna": "threat_12",
+        "reserved": "2016-08-12T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "threat_12",
+            "user": "bethanybryant@threat_12.com"
+        },
+        "time": {
+            "created": "2011-10-30T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2015-0010",
+        "cve_year": 2015,
+        "state": "RESERVED",
+        "owning_cna": "threat_12",
+        "reserved": "2011-10-30T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "man_8",
+            "user": "ryanschmidt@man_8.com"
+        },
+        "time": {
+            "created": "2013-03-18T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:44.000000Z"
+        },
+        "cve_id": "CVE-2016-0001",
+        "cve_year": 2016,
+        "state": "PUBLIC",
+        "owning_cna": "man_8",
+        "reserved": "2013-03-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "film_5",
+            "user": "benjaminnavarro@film_5.com"
+        },
+        "time": {
+            "created": "2016-01-11T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2016-0002",
+        "cve_year": 2016,
+        "state": "RESERVED",
+        "owning_cna": "film_5",
+        "reserved": "2016-01-11T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
+        },
+        "time": {
+            "created": "2020-12-09T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2016-0003",
+        "cve_year": 2016,
+        "state": "REJECT",
+        "owning_cna": "body_2",
+        "reserved": "2020-12-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "public_20",
+            "user": "richardbradshaw@public_20.com"
+        },
+        "time": {
+            "created": "2012-07-04T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2016-0004",
+        "cve_year": 2016,
+        "state": "PUBLIC",
+        "owning_cna": "public_20",
+        "reserved": "2012-07-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "senior_19",
+            "user": "jacobdouglas@senior_19.com"
+        },
+        "time": {
+            "created": "2014-11-03T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2016-0005",
+        "cve_year": 2016,
+        "state": "PUBLIC",
+        "owning_cna": "senior_19",
+        "reserved": "2014-11-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "single_6",
+            "user": "lindavaughn@single_6.com"
+        },
+        "time": {
+            "created": "2021-04-15T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2016-0006",
+        "cve_year": 2016,
+        "state": "RESERVED",
+        "owning_cna": "single_6",
+        "reserved": "2021-04-15T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2018-10-08T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2016-0007",
+        "cve_year": 2016,
+        "state": "RESERVED",
+        "owning_cna": "student_18",
+        "reserved": "2018-10-08T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "several_14",
+            "user": "calvinthompson@several_14.com"
+        },
+        "time": {
+            "created": "2020-11-16T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2016-0008",
+        "cve_year": 2016,
+        "state": "PUBLIC",
+        "owning_cna": "several_14",
+        "reserved": "2020-11-16T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "eight_3",
+            "user": "louisrose@eight_3.com"
+        },
+        "time": {
+            "created": "2016-05-08T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2016-0009",
+        "cve_year": 2016,
+        "state": "RESERVED",
+        "owning_cna": "eight_3",
+        "reserved": "2016-05-08T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "film_5",
+            "user": "benjaminnavarro@film_5.com"
+        },
+        "time": {
+            "created": "2019-04-07T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:46.000000Z"
+        },
+        "cve_id": "CVE-2016-0010",
+        "cve_year": 2016,
+        "state": "RESERVED",
+        "owning_cna": "film_5",
+        "reserved": "2019-04-07T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "property_15",
+            "user": "julieweaver@property_15.com"
+        },
+        "time": {
+            "created": "2020-12-03T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2017-0001",
+        "cve_year": 2017,
+        "state": "PUBLIC",
+        "owning_cna": "property_15",
+        "reserved": "2020-12-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "several_14",
+            "user": "calvinthompson@several_14.com"
+        },
+        "time": {
+            "created": "2017-09-24T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2017-0002",
+        "cve_year": 2017,
+        "state": "RESERVED",
+        "owning_cna": "several_14",
+        "reserved": "2017-09-24T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "drive_13",
+            "user": "alecmitchell@drive_13.com"
+        },
+        "time": {
+            "created": "2012-12-15T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2017-0003",
+        "cve_year": 2017,
+        "state": "RESERVED",
+        "owning_cna": "drive_13",
+        "reserved": "2012-12-15T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "film_17",
+            "user": "logannewman@film_17.com"
+        },
+        "time": {
+            "created": "2013-08-12T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:46.000000Z"
+        },
+        "cve_id": "CVE-2017-0004",
+        "cve_year": 2017,
+        "state": "PUBLIC",
+        "owning_cna": "film_17",
+        "reserved": "2013-08-12T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "film_5",
+            "user": "benjaminnavarro@film_5.com"
+        },
+        "time": {
+            "created": "2020-02-12T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:46.000000Z"
+        },
+        "cve_id": "CVE-2017-0005",
+        "cve_year": 2017,
+        "state": "REJECT",
+        "owning_cna": "film_5",
+        "reserved": "2020-02-12T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "theory_9",
+            "user": "christophercook@theory_9.com"
+        },
+        "time": {
+            "created": "2014-11-01T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2017-0006",
+        "cve_year": 2017,
+        "state": "RESERVED",
+        "owning_cna": "theory_9",
+        "reserved": "2014-11-01T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "drive_13",
+            "user": "alecmitchell@drive_13.com"
+        },
+        "time": {
+            "created": "2020-08-17T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2017-0007",
+        "cve_year": 2017,
+        "state": "RESERVED",
+        "owning_cna": "drive_13",
+        "reserved": "2020-08-17T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "final_7",
+            "user": "joshuaramirez@final_7.com"
+        },
+        "time": {
+            "created": "2012-06-15T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2017-0008",
+        "cve_year": 2017,
+        "state": "RESERVED",
+        "owning_cna": "final_7",
+        "reserved": "2012-06-15T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2019-08-09T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2017-0009",
+        "cve_year": 2017,
+        "state": "RESERVED",
+        "owning_cna": "student_18",
+        "reserved": "2019-08-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
+        },
+        "time": {
+            "created": "2017-02-02T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2017-0010",
+        "cve_year": 2017,
+        "state": "RESERVED",
+        "owning_cna": "body_2",
+        "reserved": "2017-02-02T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2017-04-11T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2018-0001",
+        "cve_year": 2018,
+        "state": "PUBLIC",
+        "owning_cna": "student_18",
+        "reserved": "2017-04-11T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "several_14",
+            "user": "calvinthompson@several_14.com"
+        },
+        "time": {
+            "created": "2012-07-09T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:47.000000Z"
+        },
+        "cve_id": "CVE-2018-0002",
+        "cve_year": 2018,
+        "state": "PUBLIC",
+        "owning_cna": "several_14",
+        "reserved": "2012-07-09T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "body_2",
+            "user": "debrasmith@body_2.com"
+        },
+        "time": {
+            "created": "2018-01-16T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2018-0003",
+        "cve_year": 2018,
+        "state": "REJECT",
+        "owning_cna": "body_2",
+        "reserved": "2018-01-16T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "threat_12",
+            "user": "bethanybryant@threat_12.com"
+        },
+        "time": {
+            "created": "2012-06-18T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2018-0004",
+        "cve_year": 2018,
+        "state": "RESERVED",
+        "owning_cna": "threat_12",
+        "reserved": "2012-06-18T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2012-01-30T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2018-0005",
+        "cve_year": 2018,
+        "state": "PUBLIC",
+        "owning_cna": "student_18",
+        "reserved": "2012-01-30T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "now_11",
+            "user": "amybass@now_11.com"
+        },
+        "time": {
+            "created": "2020-05-29T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2018-0006",
+        "cve_year": 2018,
+        "state": "RESERVED",
+        "owning_cna": "now_11",
+        "reserved": "2020-05-29T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "public_20",
+            "user": "richardbradshaw@public_20.com"
+        },
+        "time": {
+            "created": "2013-05-27T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2018-0007",
+        "cve_year": 2018,
+        "state": "PUBLIC",
+        "owning_cna": "public_20",
+        "reserved": "2013-05-27T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "eight_3",
+            "user": "louisrose@eight_3.com"
+        },
+        "time": {
+            "created": "2013-06-01T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2018-0008",
+        "cve_year": 2018,
+        "state": "REJECT",
+        "owning_cna": "eight_3",
+        "reserved": "2013-06-01T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "property_15",
+            "user": "julieweaver@property_15.com"
+        },
+        "time": {
+            "created": "2015-12-27T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:48.000000Z"
         },
         "cve_id": "CVE-2018-0009",
         "cve_year": 2018,
-        "state": "RESERVED",
-        "owning_cna": "magazine_15",
-        "reserved": "2018-08-03T00:00:00.000000Z"
+        "state": "REJECT",
+        "owning_cna": "property_15",
+        "reserved": "2015-12-27T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "raise_9",
-            "user": "ashleybradley@raise_9.com"
+            "cna": "film_17",
+            "user": "logannewman@film_17.com"
         },
         "time": {
-            "created": "2012-12-16T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2013-12-16T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:49.000000Z"
         },
         "cve_id": "CVE-2018-0010",
         "cve_year": 2018,
-        "state": "REJECT",
-        "owning_cna": "raise_9",
-        "reserved": "2012-12-16T00:00:00.000000Z"
+        "state": "RESERVED",
+        "owning_cna": "film_17",
+        "reserved": "2013-12-16T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "cost_12",
-            "user": "codymurphy@cost_12.com"
+            "cna": "property_15",
+            "user": "julieweaver@property_15.com"
         },
         "time": {
-            "created": "2018-01-08T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2019-10-09T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2019-0001",
         "cve_year": 2019,
         "state": "REJECT",
-        "owning_cna": "cost_12",
-        "reserved": "2018-01-08T00:00:00.000000Z"
+        "owning_cna": "property_15",
+        "reserved": "2019-10-09T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
-        },
-        "time": {
-            "created": "2011-09-01T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2019-0002",
-        "cve_year": 2019,
-        "state": "PUBLIC",
-        "owning_cna": "magazine_15",
-        "reserved": "2011-09-01T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "quickly_7",
-            "user": "ashleyanderson@quickly_7.com"
-        },
-        "time": {
-            "created": "2019-09-21T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2019-0003",
-        "cve_year": 2019,
-        "state": "REJECT",
-        "owning_cna": "quickly_7",
-        "reserved": "2019-09-21T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "song_3",
-            "user": "sandrabrown@song_3.com"
-        },
-        "time": {
-            "created": "2017-07-21T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2019-0004",
-        "cve_year": 2019,
-        "state": "RESERVED",
-        "owning_cna": "song_3",
-        "reserved": "2017-07-21T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "raise_9",
-            "user": "ashleybradley@raise_9.com"
-        },
-        "time": {
-            "created": "2013-01-20T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2019-0005",
-        "cve_year": 2019,
-        "state": "RESERVED",
-        "owning_cna": "raise_9",
-        "reserved": "2013-01-20T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "cost_12",
-            "user": "codymurphy@cost_12.com"
-        },
-        "time": {
-            "created": "2013-02-18T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:54.000000Z"
-        },
-        "cve_id": "CVE-2019-0006",
-        "cve_year": 2019,
-        "state": "RESERVED",
-        "owning_cna": "cost_12",
-        "reserved": "2013-02-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "from_11",
-            "user": "kimmiller@from_11.com"
-        },
-        "time": {
-            "created": "2019-08-13T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2019-0007",
-        "cve_year": 2019,
-        "state": "RESERVED",
-        "owning_cna": "from_11",
-        "reserved": "2019-08-13T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "opportunity_13",
-            "user": "colleentorres@opportunity_13.com"
-        },
-        "time": {
-            "created": "2019-06-18T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2019-0008",
-        "cve_year": 2019,
-        "state": "RESERVED",
-        "owning_cna": "opportunity_13",
-        "reserved": "2019-06-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "concern_8",
-            "user": "jasongray@concern_8.com"
-        },
-        "time": {
-            "created": "2021-01-09T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:54.000000Z"
-        },
-        "cve_id": "CVE-2019-0009",
-        "cve_year": 2019,
-        "state": "RESERVED",
-        "owning_cna": "concern_8",
-        "reserved": "2021-01-09T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "man_5",
-            "user": "jeffreyfigueroa@man_5.com"
-        },
-        "time": {
-            "created": "2017-04-06T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2019-0010",
-        "cve_year": 2019,
-        "state": "REJECT",
-        "owning_cna": "man_5",
-        "reserved": "2017-04-06T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "difference_16",
-            "user": "rebeccahenry@difference_16.com"
-        },
-        "time": {
-            "created": "2015-09-09T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2020-0001",
-        "cve_year": 2020,
-        "state": "PUBLIC",
-        "owning_cna": "difference_16",
-        "reserved": "2015-09-09T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
-        },
-        "time": {
-            "created": "2014-06-29T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2020-0002",
-        "cve_year": 2020,
-        "state": "REJECT",
-        "owning_cna": "only_6",
-        "reserved": "2014-06-29T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "difference_16",
-            "user": "rebeccahenry@difference_16.com"
-        },
-        "time": {
-            "created": "2015-07-18T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:55.000000Z"
-        },
-        "cve_id": "CVE-2020-0003",
-        "cve_year": 2020,
-        "state": "RESERVED",
-        "owning_cna": "difference_16",
-        "reserved": "2015-07-18T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "raise_9",
-            "user": "ashleybradley@raise_9.com"
-        },
-        "time": {
-            "created": "2021-03-15T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2020-0004",
-        "cve_year": 2020,
-        "state": "REJECT",
-        "owning_cna": "raise_9",
-        "reserved": "2021-03-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "value_14",
-            "user": "janetdean@value_14.com"
-        },
-        "time": {
-            "created": "2020-03-10T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2020-0005",
-        "cve_year": 2020,
-        "state": "PUBLIC",
-        "owning_cna": "value_14",
-        "reserved": "2020-03-10T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "ok_17",
-            "user": "dominiquefrench@ok_17.com"
-        },
-        "time": {
-            "created": "2017-03-27T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2020-0006",
-        "cve_year": 2020,
-        "state": "PUBLIC",
-        "owning_cna": "ok_17",
-        "reserved": "2017-03-27T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "only_6",
-            "user": "davidmcguire@only_6.com"
-        },
-        "time": {
-            "created": "2018-08-26T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2020-0007",
-        "cve_year": 2020,
-        "state": "RESERVED",
-        "owning_cna": "only_6",
-        "reserved": "2018-08-26T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "from_11",
-            "user": "kimmiller@from_11.com"
-        },
-        "time": {
-            "created": "2014-11-13T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2020-0008",
-        "cve_year": 2020,
-        "state": "RESERVED",
-        "owning_cna": "from_11",
-        "reserved": "2014-11-13T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "quickly_7",
-            "user": "ashleyanderson@quickly_7.com"
-        },
-        "time": {
-            "created": "2015-09-09T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2020-0009",
-        "cve_year": 2020,
-        "state": "RESERVED",
-        "owning_cna": "quickly_7",
-        "reserved": "2015-09-09T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "raise_9",
-            "user": "ashleybradley@raise_9.com"
-        },
-        "time": {
-            "created": "2021-02-07T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2020-0010",
-        "cve_year": 2020,
-        "state": "REJECT",
-        "owning_cna": "raise_9",
-        "reserved": "2021-02-07T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "song_3",
-            "user": "sandrabrown@song_3.com"
-        },
-        "time": {
-            "created": "2011-05-20T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2021-0001",
-        "cve_year": 2021,
-        "state": "RESERVED",
-        "owning_cna": "song_3",
-        "reserved": "2011-05-20T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whatever_18",
-            "user": "stevenvalentine@whatever_18.com"
-        },
-        "time": {
-            "created": "2013-09-01T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2021-0002",
-        "cve_year": 2021,
-        "state": "RESERVED",
-        "owning_cna": "whatever_18",
-        "reserved": "2013-09-01T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "raise_9",
-            "user": "ashleybradley@raise_9.com"
-        },
-        "time": {
-            "created": "2013-11-04T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2021-0003",
-        "cve_year": 2021,
-        "state": "REJECT",
-        "owning_cna": "raise_9",
-        "reserved": "2013-11-04T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "today_2",
-            "user": "franciscoanderson@today_2.com"
-        },
-        "time": {
-            "created": "2020-08-02T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:57.000000Z"
-        },
-        "cve_id": "CVE-2021-0004",
-        "cve_year": 2021,
-        "state": "PUBLIC",
-        "owning_cna": "today_2",
-        "reserved": "2020-08-02T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "man_5",
-            "user": "jeffreyfigueroa@man_5.com"
-        },
-        "time": {
-            "created": "2018-02-01T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2021-0005",
-        "cve_year": 2021,
-        "state": "RESERVED",
-        "owning_cna": "man_5",
-        "reserved": "2018-02-01T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "magazine_15",
-            "user": "jameshansen@magazine_15.com"
-        },
-        "time": {
-            "created": "2013-12-15T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
-        },
-        "cve_id": "CVE-2021-0006",
-        "cve_year": 2021,
-        "state": "RESERVED",
-        "owning_cna": "magazine_15",
-        "reserved": "2013-12-15T00:00:00.000000Z"
-    },
-    {
-        "requested_by": {
-            "cna": "whether_20",
-            "user": "nicolecallahan@whether_20.com"
+            "cna": "threat_12",
+            "user": "bethanybryant@threat_12.com"
         },
         "time": {
             "created": "2015-01-06T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:57.000000Z"
+            "modified": "2021-05-11T02:56:49.000000Z"
         },
-        "cve_id": "CVE-2021-0007",
-        "cve_year": 2021,
-        "state": "RESERVED",
-        "owning_cna": "whether_20",
+        "cve_id": "CVE-2019-0002",
+        "cve_year": 2019,
+        "state": "REJECT",
+        "owning_cna": "threat_12",
         "reserved": "2015-01-06T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "here_1",
-            "user": "jamesfreeman@here_1.com"
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
         },
         "time": {
-            "created": "2018-07-31T00:00:00.000000Z",
-            "modified": "2021-04-21T02:08:58.000000Z"
+            "created": "2016-01-29T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2019-0003",
+        "cve_year": 2019,
+        "state": "REJECT",
+        "owning_cna": "student_18",
+        "reserved": "2016-01-29T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "drive_13",
+            "user": "alecmitchell@drive_13.com"
+        },
+        "time": {
+            "created": "2020-06-14T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:49.000000Z"
+        },
+        "cve_id": "CVE-2019-0004",
+        "cve_year": 2019,
+        "state": "REJECT",
+        "owning_cna": "drive_13",
+        "reserved": "2020-06-14T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "bad_10",
+            "user": "cynthiabrooks@bad_10.com"
+        },
+        "time": {
+            "created": "2019-10-02T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:49.000000Z"
+        },
+        "cve_id": "CVE-2019-0005",
+        "cve_year": 2019,
+        "state": "PUBLIC",
+        "owning_cna": "bad_10",
+        "reserved": "2019-10-02T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "single_6",
+            "user": "lindavaughn@single_6.com"
+        },
+        "time": {
+            "created": "2013-12-28T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2019-0006",
+        "cve_year": 2019,
+        "state": "RESERVED",
+        "owning_cna": "single_6",
+        "reserved": "2013-12-28T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2012-02-21T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:50.000000Z"
+        },
+        "cve_id": "CVE-2019-0007",
+        "cve_year": 2019,
+        "state": "REJECT",
+        "owning_cna": "student_18",
+        "reserved": "2012-02-21T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2021-02-27T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:50.000000Z"
+        },
+        "cve_id": "CVE-2019-0008",
+        "cve_year": 2019,
+        "state": "REJECT",
+        "owning_cna": "student_18",
+        "reserved": "2021-02-27T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "theory_9",
+            "user": "christophercook@theory_9.com"
+        },
+        "time": {
+            "created": "2013-04-16T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:50.000000Z"
+        },
+        "cve_id": "CVE-2019-0009",
+        "cve_year": 2019,
+        "state": "RESERVED",
+        "owning_cna": "theory_9",
+        "reserved": "2013-04-16T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "drive_13",
+            "user": "alecmitchell@drive_13.com"
+        },
+        "time": {
+            "created": "2020-01-16T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2019-0010",
+        "cve_year": 2019,
+        "state": "RESERVED",
+        "owning_cna": "drive_13",
+        "reserved": "2020-01-16T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "michellemartin@mitre.com"
+        },
+        "time": {
+            "created": "2017-04-05T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2020-0001",
+        "cve_year": 2020,
+        "state": "REJECT",
+        "owning_cna": "mitre",
+        "reserved": "2017-04-05T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "public_20",
+            "user": "richardbradshaw@public_20.com"
+        },
+        "time": {
+            "created": "2021-04-06T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2020-0002",
+        "cve_year": 2020,
+        "state": "REJECT",
+        "owning_cna": "public_20",
+        "reserved": "2021-04-06T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "mitre",
+            "user": "michellemartin@mitre.com"
+        },
+        "time": {
+            "created": "2016-05-04T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:51.000000Z"
+        },
+        "cve_id": "CVE-2020-0003",
+        "cve_year": 2020,
+        "state": "RESERVED",
+        "owning_cna": "mitre",
+        "reserved": "2016-05-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "public_20",
+            "user": "richardbradshaw@public_20.com"
+        },
+        "time": {
+            "created": "2015-10-01T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2020-0004",
+        "cve_year": 2020,
+        "state": "RESERVED",
+        "owning_cna": "public_20",
+        "reserved": "2015-10-01T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "property_15",
+            "user": "julieweaver@property_15.com"
+        },
+        "time": {
+            "created": "2020-07-02T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:51.000000Z"
+        },
+        "cve_id": "CVE-2020-0005",
+        "cve_year": 2020,
+        "state": "RESERVED",
+        "owning_cna": "property_15",
+        "reserved": "2020-07-02T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "final_7",
+            "user": "joshuaramirez@final_7.com"
+        },
+        "time": {
+            "created": "2017-02-25T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:51.000000Z"
+        },
+        "cve_id": "CVE-2020-0006",
+        "cve_year": 2020,
+        "state": "RESERVED",
+        "owning_cna": "final_7",
+        "reserved": "2017-02-25T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "film_17",
+            "user": "logannewman@film_17.com"
+        },
+        "time": {
+            "created": "2020-04-13T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2020-0007",
+        "cve_year": 2020,
+        "state": "REJECT",
+        "owning_cna": "film_17",
+        "reserved": "2020-04-13T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "final_7",
+            "user": "joshuaramirez@final_7.com"
+        },
+        "time": {
+            "created": "2013-09-30T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2020-0008",
+        "cve_year": 2020,
+        "state": "RESERVED",
+        "owning_cna": "final_7",
+        "reserved": "2013-09-30T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "now_11",
+            "user": "amybass@now_11.com"
+        },
+        "time": {
+            "created": "2019-04-21T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2020-0009",
+        "cve_year": 2020,
+        "state": "RESERVED",
+        "owning_cna": "now_11",
+        "reserved": "2019-04-21T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "level_16",
+            "user": "andrewgriffith@level_16.com"
+        },
+        "time": {
+            "created": "2012-05-22T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:52.000000Z"
+        },
+        "cve_id": "CVE-2020-0010",
+        "cve_year": 2020,
+        "state": "REJECT",
+        "owning_cna": "level_16",
+        "reserved": "2012-05-22T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "student_18",
+            "user": "annecherry@student_18.com"
+        },
+        "time": {
+            "created": "2015-11-15T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:52.000000Z"
+        },
+        "cve_id": "CVE-2021-0001",
+        "cve_year": 2021,
+        "state": "PUBLIC",
+        "owning_cna": "student_18",
+        "reserved": "2015-11-15T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "theory_9",
+            "user": "christophercook@theory_9.com"
+        },
+        "time": {
+            "created": "2017-02-04T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2021-0002",
+        "cve_year": 2021,
+        "state": "RESERVED",
+        "owning_cna": "theory_9",
+        "reserved": "2017-02-04T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "senior_19",
+            "user": "jacobdouglas@senior_19.com"
+        },
+        "time": {
+            "created": "2019-02-03T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2021-0003",
+        "cve_year": 2021,
+        "state": "RESERVED",
+        "owning_cna": "senior_19",
+        "reserved": "2019-02-03T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "senior_19",
+            "user": "jacobdouglas@senior_19.com"
+        },
+        "time": {
+            "created": "2014-01-13T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:53.000000Z"
+        },
+        "cve_id": "CVE-2021-0004",
+        "cve_year": 2021,
+        "state": "RESERVED",
+        "owning_cna": "senior_19",
+        "reserved": "2014-01-13T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "property_15",
+            "user": "julieweaver@property_15.com"
+        },
+        "time": {
+            "created": "2018-01-23T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:53.000000Z"
+        },
+        "cve_id": "CVE-2021-0005",
+        "cve_year": 2021,
+        "state": "RESERVED",
+        "owning_cna": "property_15",
+        "reserved": "2018-01-23T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "film_17",
+            "user": "logannewman@film_17.com"
+        },
+        "time": {
+            "created": "2013-02-26T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2021-0006",
+        "cve_year": 2021,
+        "state": "PUBLIC",
+        "owning_cna": "film_17",
+        "reserved": "2013-02-26T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "agree_1",
+            "user": "rebeccaherring@agree_1.com"
+        },
+        "time": {
+            "created": "2012-08-23T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
+        },
+        "cve_id": "CVE-2021-0007",
+        "cve_year": 2021,
+        "state": "RESERVED",
+        "owning_cna": "agree_1",
+        "reserved": "2012-08-23T00:00:00.000000Z"
+    },
+    {
+        "requested_by": {
+            "cna": "film_17",
+            "user": "logannewman@film_17.com"
+        },
+        "time": {
+            "created": "2013-05-13T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:53.000000Z"
         },
         "cve_id": "CVE-2021-0008",
         "cve_year": 2021,
         "state": "REJECT",
-        "owning_cna": "here_1",
-        "reserved": "2018-07-31T00:00:00.000000Z"
+        "owning_cna": "film_17",
+        "reserved": "2013-05-13T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "concern_8",
-            "user": "jasongray@concern_8.com"
+            "cna": "now_11",
+            "user": "amybass@now_11.com"
         },
         "time": {
-            "created": "2017-11-01T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2018-04-29T00:00:00.000000Z",
+            "modified": "2021-05-11T02:56:53.000000Z"
         },
         "cve_id": "CVE-2021-0009",
         "cve_year": 2021,
-        "state": "PUBLIC",
-        "owning_cna": "concern_8",
-        "reserved": "2017-11-01T00:00:00.000000Z"
+        "state": "REJECT",
+        "owning_cna": "now_11",
+        "reserved": "2018-04-29T00:00:00.000000Z"
     },
     {
         "requested_by": {
-            "cna": "whatever_18",
-            "user": "stevenvalentine@whatever_18.com"
+            "cna": "agree_1",
+            "user": "rebeccaherring@agree_1.com"
         },
         "time": {
-            "created": "2020-05-09T00:00:00.000000Z",
-            "modified": "2021-04-21T02:09:05.156373Z"
+            "created": "2017-01-26T00:00:00.000000Z",
+            "modified": "2021-05-11T02:57:00.618085Z"
         },
         "cve_id": "CVE-2021-0010",
         "cve_year": 2021,
         "state": "RESERVED",
-        "owning_cna": "whatever_18",
-        "reserved": "2020-05-09T00:00:00.000000Z"
+        "owning_cna": "agree_1",
+        "reserved": "2017-01-26T00:00:00.000000Z"
     }
 ]

--- a/datadump/pre-population/cves.json
+++ b/datadump/pre-population/cves.json
@@ -1,7 +1,222 @@
 [
     {
         "time": {
-            "created": "2012-06-07T00:00:00.000000Z",
+            "created": "2019-09-13T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-1999-0001",
+                "ASSIGNER": "alecmitchell@drive_13.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Cruz Ltd",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "actually",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "clearly, go, top, nearly, area"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Diverse executive concept"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Loretta Navarro",
+                        "url": "https://www.harris.org/wp-content/list/wp-content/about.html"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Dwayne Gomez",
+                        "url": "http://wilson-jimenez.com/"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Jennifer Morales",
+                        "url": "https://sutton-melton.com/category/category/category/register.asp"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Brian Jones",
+                        "url": "http://www.rios-wells.com/"
+                    },
+                    {
+                        "refsource": "HIM",
+                        "name": "Kristine Farrell",
+                        "url": "https://wilson.biz/app/search/main.php"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Heart spend action save official. While take our skill consider beautiful."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-11-16T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-1999-0002",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Another bring life nice. Fast beat low color. Television weight compare upon go around."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2018-04-08T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-1999-0003",
+                "ASSIGNER": "logannewman@film_17.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Nguyen Group",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "ground",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "Democrat, on, coach, heavy"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Diverse executive concept"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Wyatt Patrick",
+                        "url": "http://www.mitchell.com/wp-content/tags/tags/about/"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Brenda Medina",
+                        "url": "http://wang-collins.info/faq.html"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Christian Murray",
+                        "url": "https://www.smith.com/faq/"
+                    },
+                    {
+                        "refsource": "SPEECH",
+                        "name": "Evan Gallagher",
+                        "url": "http://davis-edwards.net/search/main/list/post/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Larry Hicks",
+                        "url": "https://www.baker-garcia.org/terms/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Kayla Jackson",
+                        "url": "http://www.rivera.com/wp-content/category/category/register.html"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Tina Blevins",
+                        "url": "https://www.carney-hernandez.biz/category/explore/index.php"
+                    },
+                    {
+                        "refsource": "HIM",
+                        "name": "Kristine Farrell",
+                        "url": "https://wilson.biz/app/search/main.php"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "In both soldier many focus mother. Star try year wrong issue show fast."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2015-06-25T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -17,7 +232,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Organization speak concern buy available fish."
+                        "value": "Admit fish outside pull future much. Such everything drug plant research foreign sit. Door remain wind under performance."
                     }
                 ]
             }
@@ -25,8 +240,32 @@
     },
     {
         "time": {
-            "created": "2020-03-31T00:00:00.000000Z",
+            "created": "2020-04-07T00:00:00.000000Z",
             "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-1999-0005",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Bag bring finally important. Argue new traditional indicate."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-05-08T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:15.116028+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -41,7 +280,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Car national short including cut. Wait government discussion option knowledge already. State hotel option yourself nature test point."
+                        "value": "Team soon painting. Else son world environmental big computer."
                     }
                 ]
             }
@@ -49,31 +288,7 @@
     },
     {
         "time": {
-            "created": "2013-08-09T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-1999-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Lead drop another use. Trial talk each discussion gun I million. Figure character history."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-09-20T00:00:00.000000Z",
+            "created": "2011-09-18T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -82,68 +297,14 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-1999-0010",
-                "ASSIGNER": "kimmiller@from_11.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Graves PLC",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "either",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "small, center, board, stand, visit, attack"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Open-source 6thgeneration standardization"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "DARK",
-                        "name": "Marcia Johnson",
-                        "url": "https://smith-perkins.net/tags/terms.jsp"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://www.morales.com/tags/main/home.asp",
-                        "url": "https://www.morales.com/tags/main/home.asp"
-                    },
-                    {
-                        "refsource": "HAPPY",
-                        "name": "Mr. Matthew Nguyen MD",
-                        "url": "https://www.decker.com/explore/blog/faq.jsp"
-                    }
-                ]
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Stand away record however administration. Ball particular remember chance effort."
+                        "value": "Wrong assume spend per analysis question part. Energy big kind similar consider."
                     }
                 ]
             }
@@ -151,8 +312,8 @@
     },
     {
         "time": {
-            "created": "2013-04-10T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:21.211813+00:00"
+            "created": "2021-04-21T00:00:00.000000Z",
+            "modified": null
         },
         "cve": {
             "data_type": "CVE",
@@ -160,14 +321,63 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2000-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
+                "ASSIGNER": "joshuaramirez@final_7.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Hernandez-Charles",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "cold",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "let, clear, modern, size, will"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Streamlined background software"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "TYPE",
+                        "name": "Kristi Wiggins",
+                        "url": "https://patterson.com/search/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.collins.org/search/main/privacy.html",
+                        "url": "https://www.collins.org/search/main/privacy.html"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Social hotel letter cover pull less you might. Pretty several hand magazine decide appear activity beat. Save true again end memory yard growth. Hard push least."
+                        "value": "Speech region nearly unit real. Learn attorney kitchen through challenge relate. With clearly decade third describe."
                     }
                 ]
             }
@@ -175,7 +385,7 @@
     },
     {
         "time": {
-            "created": "2019-11-30T00:00:00.000000Z",
+            "created": "2014-11-28T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -183,15 +393,84 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2000-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
+                "ID": "CVE-2000-0003",
+                "ASSIGNER": "jacobdouglas@senior_19.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Scott-Gonzalez",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "likely",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "yeah"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Integrated radical array"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "FAR",
+                        "name": "Dwayne Gomez",
+                        "url": "http://wilson-jimenez.com/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Rebecca Johnson",
+                        "url": "https://james.com/wp-content/blog/main.jsp"
+                    },
+                    {
+                        "refsource": "SEA",
+                        "name": "Deborah Odonnell",
+                        "url": "http://morrison.org/category/explore/main/author/"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Keith Yates",
+                        "url": "https://massey.com/app/search/homepage.asp"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "http://www.rasmussen-davis.net/",
+                        "url": "http://www.rasmussen-davis.net/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Joseph Sanford",
+                        "url": "https://le.biz/"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Whether subject increase field few. Determine bar across cause. Husband item our case card director. Figure floor camera style region site low."
+                        "value": "Car send officer office once quite. Lay against relationship smile owner provide. Use huge play specific Congress over beautiful."
                     }
                 ]
             }
@@ -199,8 +478,32 @@
     },
     {
         "time": {
-            "created": "2011-07-10T00:00:00.000000Z",
-            "modified": null
+            "created": "2017-09-15T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:16.469734+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2000-0004",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "After system possible likely yourself without heavy. When national television. Special thing consumer use art. Trade others leg human."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2013-01-31T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:16.696503+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -208,94 +511,6 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2000-0005",
-                "ASSIGNER": "williammorris@certain_10.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Noble Group",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "green",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "determine"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Cross-platform logistical artificial intelligence"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "http://www.thompson-gibson.info/post.htm",
-                        "url": "http://www.thompson-gibson.info/post.htm"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "Sara Erickson",
-                        "url": "http://www.williams.com/"
-                    },
-                    {
-                        "refsource": "BILL",
-                        "name": "Matthew Gonzales",
-                        "url": "https://www.ross-jackson.com/privacy/"
-                    },
-                    {
-                        "refsource": "BILL",
-                        "name": "Mary Morales",
-                        "url": "http://www.adams-ramirez.com/search/"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Jeffrey Davis",
-                        "url": "https://miller.info/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Build system class cost clear shoulder year. Order radio money story office card."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-10-19T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:22.007071+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2000-0006",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -303,7 +518,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Century magazine up glass land even analysis. Language would piece level bank interest. Long sell small everyone single possible."
+                        "value": "Subject accept tend should whose staff relationship. Staff between arm push either church."
                     }
                 ]
             }
@@ -311,7 +526,7 @@
     },
     {
         "time": {
-            "created": "2016-02-22T00:00:00.000000Z",
+            "created": "2014-07-23T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -319,94 +534,15 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2000-0007",
-                "ASSIGNER": "dominiquefrench@ok_17.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Cox Group",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "stop",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "pay, success, police, difficult, but"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "HAPPY",
-                        "name": "Christopher Lewis",
-                        "url": "https://www.saunders-wright.com/"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "April Silva",
-                        "url": "http://henry.biz/category/register/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Catherine Adams",
-                        "url": "https://www.sanchez.com/posts/posts/app/author/"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Jared Reyes",
-                        "url": "https://www.holloway.biz/"
-                    },
-                    {
-                        "refsource": "HAPPY",
-                        "name": "Joshua Walls",
-                        "url": "https://www.arroyo.biz/post/"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "Karen Ray",
-                        "url": "https://www.ruiz.org/"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "Katherine Richard",
-                        "url": "https://www.holland.biz/tag/app/about/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
-                    }
-                ]
+                "ID": "CVE-2000-0008",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Above take building behavior. Land into themselves especially toward brother risk."
+                        "value": "Early drop response. Make all form seven shoulder laugh something."
                     }
                 ]
             }
@@ -414,8 +550,8 @@
     },
     {
         "time": {
-            "created": "2012-01-13T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:22.454789+00:00"
+            "created": "2018-11-08T00:00:00.000000Z",
+            "modified": null
         },
         "cve": {
             "data_type": "CVE",
@@ -423,105 +559,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2000-0009",
-                "ASSIGNER": "stevenvalentine@whatever_18.com",
+                "ASSIGNER": "christophercook@theory_9.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Roberts-Martin",
+                            "vendor_name": "Hill, Watson and Lambert",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "soon",
+                                        "product_name": "anything",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "almost, clear, whom, character, through, interesting"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "De-engineered uniform open system"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "http://www.thompson-gibson.info/post.htm",
-                        "url": "http://www.thompson-gibson.info/post.htm"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "April Silva",
-                        "url": "http://henry.biz/category/register/"
-                    },
-                    {
-                        "refsource": "THESE",
-                        "name": "Jeffrey Davis",
-                        "url": "http://www.wright-lamb.com/index.html"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Catherine Adams",
-                        "url": "https://www.sanchez.com/posts/posts/app/author/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Student clear effect radio man day writer city. True why article source fire wide."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-06-02T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:22.634323+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2000-0010",
-                "ASSIGNER": "davidmcguire@only_6.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Kelly-Singh",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "theory",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "friend, rich, conference, performance, lawyer, central"
+                                                    "version_value": "fall"
                                                 }
                                             ]
                                         }
@@ -547,29 +600,24 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "DARK",
-                        "name": "Emily Gutierrez",
-                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
-                    },
-                    {
-                        "refsource": "BECAUSE",
-                        "name": "Angelica Delgado",
-                        "url": "https://perry.com/register.html"
-                    },
-                    {
                         "refsource": "MISC",
-                        "name": "http://escobar.com/homepage.php",
-                        "url": "http://escobar.com/homepage.php"
+                        "name": "https://www.hernandez.com/list/wp-content/posts/post.php",
+                        "url": "https://www.hernandez.com/list/wp-content/posts/post.php"
                     },
                     {
-                        "refsource": "GENERATION",
-                        "name": "Jared Reyes",
-                        "url": "https://www.holloway.biz/"
+                        "refsource": "UNIT",
+                        "name": "Larry Hicks",
+                        "url": "https://www.baker-garcia.org/terms/"
                     },
                     {
-                        "refsource": "THOUGH",
-                        "name": "Allison Jensen",
-                        "url": "https://www.miller.com/terms.htm"
+                        "refsource": "TREATMENT",
+                        "name": "Joseph Weber",
+                        "url": "https://campbell-murphy.com/app/app/author/"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Heather Lopez",
+                        "url": "http://moore-jackson.info/search/home.htm"
                     }
                 ]
             },
@@ -577,7 +625,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Capital behind without discuss city by owner clearly. Author various stay trade stand people run."
+                        "value": "Month force from from policy happen Congress. Defense successful deal human sell wife there."
                     }
                 ]
             }
@@ -585,8 +633,8 @@
     },
     {
         "time": {
-            "created": "2011-08-26T00:00:00.000000Z",
-            "modified": null
+            "created": "2012-02-04T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:17.746527+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -594,22 +642,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2001-0001",
-                "ASSIGNER": "jamesvaldez@technology_4.com",
+                "ASSIGNER": "richardbradshaw@public_20.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Ballard Inc",
+                            "vendor_name": "Hudson, Johnson and Phillips",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "reveal",
+                                        "product_name": "probably",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "figure, answer"
+                                                    "version_value": "difference, tough, entire, indeed, its"
                                                 }
                                             ]
                                         }
@@ -626,7 +674,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Total systemic portal"
+                                "value": "Streamlined background software"
                             }
                         ]
                     }
@@ -635,49 +683,19 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "GENERATION",
-                        "name": "Angela Anderson",
-                        "url": "http://drake.net/search.jsp"
+                        "refsource": "ISSUE",
+                        "name": "Amy Graves",
+                        "url": "https://taylor.net/privacy/"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Karen Rogers",
-                        "url": "https://www.willis.biz/list/tags/main/"
+                        "refsource": "EIGHT",
+                        "name": "Christian Murray",
+                        "url": "https://www.smith.com/faq/"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Brett Krause",
-                        "url": "http://curtis-campbell.com/"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Kayla Hill",
-                        "url": "http://smith.net/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Marcia Johnson",
-                        "url": "https://smith-perkins.net/tags/terms.jsp"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Jeffrey Garcia",
-                        "url": "http://www.vega-fuentes.com/search/list/about/"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://www.morales.com/tags/main/home.asp",
-                        "url": "https://www.morales.com/tags/main/home.asp"
-                    },
-                    {
-                        "refsource": "BECAUSE",
-                        "name": "Samantha Heath MD",
-                        "url": "http://knapp.com/blog/blog/category.php"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "John Sullivan",
-                        "url": "http://www.palmer.com/author/"
+                        "refsource": "ISSUE",
+                        "name": "Charles Mcclure",
+                        "url": "http://sanchez-long.org/"
                     }
                 ]
             },
@@ -685,7 +703,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "School already true share attention of well. Also responsibility down forward piece voice mission. Ability morning seem deal."
+                        "value": "Lead minute enjoy early. Likely appear animal there able specific. Personal especially hold."
                     }
                 ]
             }
@@ -693,31 +711,7 @@
     },
     {
         "time": {
-            "created": "2011-12-13T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:23.282017+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2001-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Raise arm crime product safe husband American. Defense from market red him not local. Son outside opportunity war plan best."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-09-02T00:00:00.000000Z",
+            "created": "2012-07-02T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -725,15 +719,79 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2001-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
+                "ID": "CVE-2001-0002",
+                "ASSIGNER": "louisrose@eight_3.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Davis Group",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "understand",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "position"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Diverse executive concept"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "UNIT",
+                        "name": "Kristen Davis",
+                        "url": "https://www.harrison-miller.org/"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Michael Smith",
+                        "url": "http://medina.com/app/categories/category/category/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Jeffrey Johnson",
+                        "url": "https://smith.com/terms.jsp"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Brandon Johnson",
+                        "url": "http://johnson-bryant.info/category/"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Charles Mcclure",
+                        "url": "http://sanchez-long.org/"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Protect risk whose every skill. Drug leave he everybody."
+                        "value": "Find manage bank trip. Sing college any six deep."
                     }
                 ]
             }
@@ -741,7 +799,471 @@
     },
     {
         "time": {
-            "created": "2021-03-21T00:00:00.000000Z",
+            "created": "2018-08-06T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2001-0003",
+                "ASSIGNER": "christophercook@theory_9.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Schroeder-Daugherty",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "effect",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "trade, soldier, away, describe, away, nearly, address, especially"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Diverse executive concept"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Christian Murray",
+                        "url": "https://www.smith.com/faq/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Elizabeth Bradley",
+                        "url": "https://www.williams.com/"
+                    },
+                    {
+                        "refsource": "SEA",
+                        "name": "William Kelley",
+                        "url": "http://www.jones-medina.info/category.php"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Drew Ford",
+                        "url": "https://www.reynolds.com/"
+                    },
+                    {
+                        "refsource": "PHYSICAL",
+                        "name": "Lisa Fuller",
+                        "url": "https://www.gordon.com/app/register.asp"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Heart treat energy later time later. Themselves treat word. Rise tax drive rich six school."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2017-08-18T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2001-0005",
+                "ASSIGNER": "debrasmith@body_2.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Tucker LLC",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "establish",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "dark, unit, table"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Streamlined background software"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.collins.org/search/main/privacy.html",
+                        "url": "https://www.collins.org/search/main/privacy.html"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Land spring door direction rate."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2017-12-20T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2001-0006",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "No market four against. Join never politics capital. Environment appear reality us federal lay."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2016-03-16T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2001-0009",
+                "ASSIGNER": "jacobdouglas@senior_19.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Peters-Jackson",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "bar",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "girl, analysis, reveal, remember, best, service, develop, similar, people"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "n/a"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "UNIT",
+                        "name": "Larry Hicks",
+                        "url": "https://www.baker-garcia.org/terms/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Occur around such back direction discuss level. Total conference plan each determine maybe director federal. Oil hospital evidence Congress."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2011-12-19T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2002-0001",
+                "ASSIGNER": "julieweaver@property_15.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Maldonado LLC",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "civil",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "turn, summer, particular, education, about"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Down-sized executive hierarchy"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Rebecca Walker",
+                        "url": "https://johnson.com/main.htm"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://jacobson.net/category/tags/list/register.htm",
+                        "url": "https://jacobson.net/category/tags/list/register.htm"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Keith Yates",
+                        "url": "https://massey.com/app/search/homepage.asp"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Heather Lopez",
+                        "url": "http://moore-jackson.info/search/home.htm"
+                    },
+                    {
+                        "refsource": "PHYSICAL",
+                        "name": "Stacy Salazar",
+                        "url": "https://mckenzie.com/main/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Drew Ford",
+                        "url": "https://www.reynolds.com/"
+                    },
+                    {
+                        "refsource": "PHYSICAL",
+                        "name": "Lisa Fuller",
+                        "url": "https://www.gordon.com/app/register.asp"
+                    },
+                    {
+                        "refsource": "HIM",
+                        "name": "Kristine Farrell",
+                        "url": "https://wilson.biz/app/search/main.php"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Child natural record daughter with. Always use officer community. Again cold sound music season."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-02-28T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2002-0002",
+                "ASSIGNER": "logannewman@film_17.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Owen and Sons",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "animal",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "happy, third, deep, fill, much, wife, generation"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Integrated radical array"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "FAR",
+                        "name": "Dwayne Gomez",
+                        "url": "http://wilson-jimenez.com/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Rebecca Johnson",
+                        "url": "https://james.com/wp-content/blog/main.jsp"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://www.hall.biz/",
+                        "url": "http://www.hall.biz/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Elizabeth Bradley",
+                        "url": "https://www.williams.com/"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Michael Smith",
+                        "url": "http://medina.com/app/categories/category/category/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Jeffrey Johnson",
+                        "url": "https://smith.com/terms.jsp"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.mendez.com/app/category.asp",
+                        "url": "https://www.mendez.com/app/category.asp"
+                    },
+                    {
+                        "refsource": "SEA",
+                        "name": "William Kelley",
+                        "url": "http://www.jones-medina.info/category.php"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Brandon Johnson",
+                        "url": "http://johnson-bryant.info/category/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.hood.com/explore/post/",
+                        "url": "https://www.hood.com/explore/post/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Here receive over whatever. Parent system or body there theory."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-08-07T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -750,22 +1272,222 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2002-0003",
-                "ASSIGNER": "jasongray@concern_8.com",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Reflect against suffer. Deal think past policy teach baby movie. Sister entire interest appear ball show put concern."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-04-18T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2002-0006",
+                "ASSIGNER": "amybass@now_11.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Smith-Cooper",
+                            "vendor_name": "Medina-Hall",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "nature",
+                                        "product_name": "risk",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "sound, bar, word, change, usually, new, result, their, anything"
+                                                    "version_value": "bring, century, head"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Diverse executive concept"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Brenda Medina",
+                        "url": "http://wang-collins.info/faq.html"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Born style which message run. Simply really defense already language. Rather down only similar."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-03-03T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2002-0009",
+                "ASSIGNER": "alecmitchell@drive_13.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Smith, Holloway and Pruitt",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "provide",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "system, tonight, commercial, blood, general, issue, perform, gun, college"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Customer-focused asymmetric database"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Loretta Navarro",
+                        "url": "https://www.harris.org/wp-content/list/wp-content/about.html"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Brenda Medina",
+                        "url": "http://wang-collins.info/faq.html"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Amy Graves",
+                        "url": "https://taylor.net/privacy/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Kristen Davis",
+                        "url": "https://www.harrison-miller.org/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://www.hernandez.com/list/wp-content/posts/post.php",
+                        "url": "https://www.hernandez.com/list/wp-content/posts/post.php"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Kristi Wiggins",
+                        "url": "https://patterson.com/search/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Joseph Bryant",
+                        "url": "https://barrett.net/"
+                    },
+                    {
+                        "refsource": "HIM",
+                        "name": "Kristine Farrell",
+                        "url": "https://wilson.biz/app/search/main.php"
+                    },
+                    {
+                        "refsource": "SEA",
+                        "name": "Chad Villegas",
+                        "url": "http://hill-evans.com/list/tags/blog/author/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Listen them least serve member career free. Really party type majority. Natural discuss research wish laugh sit end."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-01-24T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:21.263238+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2002-0010",
+                "ASSIGNER": "jacobdouglas@senior_19.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Cook, Roy and Williams",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "speech",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "computer, option, watch, film, consumer, century, production"
                                                 }
                                             ]
                                         }
@@ -791,9 +1513,34 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "BECAUSE",
-                        "name": "Kristina Carter",
-                        "url": "http://www.pennington.com/explore/index/"
+                        "refsource": "ISSUE",
+                        "name": "Wyatt Patrick",
+                        "url": "http://www.mitchell.com/wp-content/tags/tags/about/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://velazquez.com/privacy/",
+                        "url": "https://velazquez.com/privacy/"
+                    },
+                    {
+                        "refsource": "SEA",
+                        "name": "Deborah Odonnell",
+                        "url": "http://morrison.org/category/explore/main/author/"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Christian Murray",
+                        "url": "https://www.smith.com/faq/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://jacobson.net/category/tags/list/register.htm",
+                        "url": "https://jacobson.net/category/tags/list/register.htm"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Charles Mcclure",
+                        "url": "http://sanchez-long.org/"
                     }
                 ]
             },
@@ -801,7 +1548,79 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Discuss control information. Guess guy begin recognize situation. Institution experience southern."
+                        "value": "Gun wide need arrive. Size author according Congress lawyer. By baby education small marriage chance defense."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2012-07-11T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2003-0004",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Sport five media. Pressure sport nearly born but. Relate daughter reality state kitchen hotel evidence."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2011-07-17T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2003-0005",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Exactly official dark our apply improve life. Adult black leader term word themselves."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-01-28T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:22.454324+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2003-0006",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Son just movie throw wait. Type best sea soldier very national two both. Charge choose collection participant Mr hot city."
                     }
                 ]
             }
@@ -817,383 +1636,23 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2002-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Rich goal team federal instead exist. Billion another onto beat partner life hear."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-01-09T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2002-0007",
-                "ASSIGNER": "rebeccahenry@difference_16.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Chapman, Gonzalez and Wade",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "begin",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "third, him"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Open-source 6thgeneration standardization"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "MISC",
-                        "name": "http://escobar.com/homepage.php",
-                        "url": "http://escobar.com/homepage.php"
-                    },
-                    {
-                        "refsource": "HAPPY",
-                        "name": "Mr. Matthew Nguyen MD",
-                        "url": "https://www.decker.com/explore/blog/faq.jsp"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Until likely tell very again child. Assume firm then close place. Beat coach past available Mr along."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-05-03T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2002-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Discussion line whether themselves. Firm her apply forget course discuss establish. Population show court every crime."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-02-08T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2002-0010",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Single car attention. Soon college fight key. Need cause billion school money director."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-03-04T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2003-0003",
-                "ASSIGNER": "rebeccahenry@difference_16.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Williams PLC",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "city",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "end, evening, style"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Cross-platform logistical artificial intelligence"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Troy Gutierrez",
-                        "url": "http://richards.com/post/"
-                    },
-                    {
-                        "refsource": "BECAUSE",
-                        "name": "Angelica Delgado",
-                        "url": "https://perry.com/register.html"
-                    },
-                    {
-                        "refsource": "HAPPY",
-                        "name": "Mr. Matthew Nguyen MD",
-                        "url": "https://www.decker.com/explore/blog/faq.jsp"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "Karen Ray",
-                        "url": "https://www.ruiz.org/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Bar spring support town old act where. Laugh issue situation have suddenly."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2021-03-12T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2003-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "With general art institution southern miss. Argue maybe expect those those support. Painting car compare this believe such collection."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-08-09T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
                 "ID": "CVE-2003-0007",
-                "ASSIGNER": "christianromero@mitre.com",
+                "ASSIGNER": "joshuaramirez@final_7.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
+                            "vendor_name": "Perez-Carter",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "n/a",
+                                        "product_name": "also",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "n/a"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            },
-                            "vendor_name": "n/a"
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "THESE",
-                        "name": "Michael Carroll",
-                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://clark.biz/",
-                        "url": "https://clark.biz/"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Eric Thompson",
-                        "url": "https://nunez.com/blog/homepage.html"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "Sara Erickson",
-                        "url": "http://www.williams.com/"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "April Silva",
-                        "url": "http://henry.biz/category/register/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.mcgee.biz/index/",
-                        "url": "http://www.mcgee.biz/index/"
-                    },
-                    {
-                        "refsource": "BILL",
-                        "name": "Erin Taylor",
-                        "url": "http://www.miller.com/search/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Scott Wise",
-                        "url": "http://www.gardner.com/main/post/"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "Karen Ray",
-                        "url": "https://www.ruiz.org/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Opportunity cost today save indicate modern rise. Program pretty sister teacher bed."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-10-27T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:27.820280+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2003-0008",
-                "ASSIGNER": "colleentorres@opportunity_13.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Hayden-Griffin",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "share",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "month, soldier, card, usually, parent, until, gun, yes"
+                                                    "version_value": "break, bar, environment, eight, away"
                                                 }
                                             ]
                                         }
@@ -1210,7 +1669,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Digitized eco-centric frame"
+                                "value": "Down-sized executive hierarchy"
                             }
                         ]
                     }
@@ -1219,34 +1678,44 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "THESE",
-                        "name": "Michael Carroll",
-                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
+                        "refsource": "FAR",
+                        "name": "Rebecca Johnson",
+                        "url": "https://james.com/wp-content/blog/main.jsp"
                     },
                     {
-                        "refsource": "GENERATION",
-                        "name": "Patrick Ross",
-                        "url": "http://www.aguilar.com/"
+                        "refsource": "EIGHT",
+                        "name": "Christian Murray",
+                        "url": "https://www.smith.com/faq/"
                     },
                     {
-                        "refsource": "BECAUSE",
-                        "name": "Angelica Delgado",
-                        "url": "https://perry.com/register.html"
+                        "refsource": "ISSUE",
+                        "name": "Jennifer Morales",
+                        "url": "https://sutton-melton.com/category/category/category/register.asp"
                     },
                     {
-                        "refsource": "MISC",
-                        "name": "http://escobar.com/homepage.php",
-                        "url": "http://escobar.com/homepage.php"
+                        "refsource": "SPEECH",
+                        "name": "Evan Gallagher",
+                        "url": "http://davis-edwards.net/search/main/list/post/"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Scott Wise",
-                        "url": "http://www.gardner.com/main/post/"
+                        "refsource": "FAR",
+                        "name": "Brian Jones",
+                        "url": "http://www.rios-wells.com/"
                     },
                     {
-                        "refsource": "BALL",
-                        "name": "Katherine Richard",
-                        "url": "https://www.holland.biz/tag/app/about/"
+                        "refsource": "ISSUE",
+                        "name": "Charles Mcclure",
+                        "url": "http://sanchez-long.org/"
+                    },
+                    {
+                        "refsource": "HIM",
+                        "name": "Kristine Farrell",
+                        "url": "https://wilson.biz/app/search/main.php"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Joseph Sanford",
+                        "url": "https://le.biz/"
                     }
                 ]
             },
@@ -1254,7 +1723,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Design large event get consider. Past tell own song evidence. Far despite rather role nothing class thus."
+                        "value": "Share necessary again house director happen."
                     }
                 ]
             }
@@ -1262,7 +1731,7 @@
     },
     {
         "time": {
-            "created": "2012-09-04T00:00:00.000000Z",
+            "created": "2013-08-06T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -1271,14 +1740,73 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2003-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
+                "ASSIGNER": "annecherry@student_18.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Bonilla Inc",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "nation",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "this, such, how, join, area, cut, participant, large"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Down-sized executive hierarchy"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.mendez.com/app/category.asp",
+                        "url": "https://www.mendez.com/app/category.asp"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Philip Lee",
+                        "url": "https://sullivan.com/blog/search.htm"
+                    },
+                    {
+                        "refsource": "PHYSICAL",
+                        "name": "Lisa Fuller",
+                        "url": "https://www.gordon.com/app/register.asp"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Charles Mcclure",
+                        "url": "http://sanchez-long.org/"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Note yes drop long serve matter. Agreement simply community they. Claim for page drive computer enjoy."
+                        "value": "Leave ready everything crime. Condition animal really spring wind international. Expect organization quality wide."
                     }
                 ]
             }
@@ -1286,8 +1814,8 @@
     },
     {
         "time": {
-            "created": "2018-11-17T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:28.116039+00:00"
+            "created": "2014-05-27T00:00:00.000000Z",
+            "modified": null
         },
         "cve": {
             "data_type": "CVE",
@@ -1302,7 +1830,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "New job agent drug. Less little two church. Doctor free value."
+                        "value": "About option test able public daughter. Low democratic fire find lose personal."
                     }
                 ]
             }
@@ -1310,7 +1838,7 @@
     },
     {
         "time": {
-            "created": "2016-12-23T00:00:00.000000Z",
+            "created": "2012-07-31T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -1318,7 +1846,7 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2004-0005",
+                "ID": "CVE-2004-0004",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -1326,7 +1854,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Everyone remain certain firm provide impact. Worker quite blood behavior current."
+                        "value": "Describe glass collection bag firm gun treatment. American town evidence evidence born push hotel style. Read walk he woman whole talk."
                     }
                 ]
             }
@@ -1334,32 +1862,8 @@
     },
     {
         "time": {
-            "created": "2018-06-02T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2004-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Various surface manage organization. Republican total for defense. Above want seat environment."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-10-07T00:00:00.000000Z",
-            "modified": null
+            "created": "2017-01-09T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:24.450299+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -1367,6 +1871,212 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2004-0007",
+                "ASSIGNER": "richardbradshaw@public_20.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Davis Group",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "source",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "really"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Customer-focused asymmetric database"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Emily Mitchell",
+                        "url": "https://bryant.net/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Richard Thomas",
+                        "url": "https://www.smith.com/index/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Dwayne Gomez",
+                        "url": "http://wilson-jimenez.com/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Kristen Davis",
+                        "url": "https://www.harrison-miller.org/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://velazquez.com/privacy/",
+                        "url": "https://velazquez.com/privacy/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://www.hernandez.com/list/wp-content/posts/post.php",
+                        "url": "https://www.hernandez.com/list/wp-content/posts/post.php"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Jennifer Morales",
+                        "url": "https://sutton-melton.com/category/category/category/register.asp"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Elizabeth Bradley",
+                        "url": "https://www.williams.com/"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Michael Smith",
+                        "url": "http://medina.com/app/categories/category/category/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Brandon Johnson",
+                        "url": "http://johnson-bryant.info/category/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Joseph Sanford",
+                        "url": "https://le.biz/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Option something certainly sister chair people eye continue. Series word film any national. Summer four impact draw."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-10-06T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2004-0009",
+                "ASSIGNER": "rebeccaherring@agree_1.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Jenkins-Hicks",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "growth",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "perform, term, tree, executive, sometimes, social, serve"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Customer-focused asymmetric database"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "SPEECH",
+                        "name": "Tiffany Bailey",
+                        "url": "http://young.com/posts/home/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Jeremiah Cobb",
+                        "url": "http://andrade.com/author.php"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Richard Thomas",
+                        "url": "https://www.smith.com/index/"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Christian Murray",
+                        "url": "https://www.smith.com/faq/"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Joseph Weber",
+                        "url": "https://campbell-murphy.com/app/app/author/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Such chance teach entire boy. How language dinner far."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2016-06-06T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:25.172288+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2005-0001",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -1374,7 +2084,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Exist cause style lawyer. Shake environment decade treat full because at step. Draw environmental head minute approach. Team party avoid recent film it."
+                        "value": "Meet remain trade. We wall six serve actually military chance. From important her current after cost price."
                     }
                 ]
             }
@@ -1382,96 +2092,8 @@
     },
     {
         "time": {
-            "created": "2019-07-28T00:00:00.000000Z",
+            "created": "2012-04-10T00:00:00.000000Z",
             "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2004-0010",
-                "ASSIGNER": "codymurphy@cost_12.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Smith-Howe",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "instead",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "board, somebody, morning, business, television, with, she, both"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "De-engineered uniform open system"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://www.reynolds.com/posts/main/explore/author.htm",
-                        "url": "https://www.reynolds.com/posts/main/explore/author.htm"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "http://www.thompson-gibson.info/post.htm",
-                        "url": "http://www.thompson-gibson.info/post.htm"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Eric Thompson",
-                        "url": "https://nunez.com/blog/homepage.html"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Logan Vazquez",
-                        "url": "http://wilson.com/main/blog/login.asp"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Dr. Roger Patterson Jr.",
-                        "url": "http://rodriguez.com/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Discover mother figure line time water. Yeah take firm capital. Business strong body position. Light travel administration administration to determine feel."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-01-22T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:30.202642+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -1479,73 +2101,14 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2005-0003",
-                "ASSIGNER": "ashleybradley@raise_9.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Hansen Inc",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "family",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "better, general, himself, most, nearly, information, most"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "De-engineered uniform open system"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "DARK",
-                        "name": "Emily Gutierrez",
-                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
-                    },
-                    {
-                        "refsource": "BILL",
-                        "name": "Mary Morales",
-                        "url": "http://www.adams-ramirez.com/search/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Logan Vazquez",
-                        "url": "http://wilson.com/main/blog/login.asp"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
-                    }
-                ]
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Job determine perform work language. Industry news picture record."
+                        "value": "Who not check. Let value five leg interview. Name guess turn health control."
                     }
                 ]
             }
@@ -1553,7 +2116,7 @@
     },
     {
         "time": {
-            "created": "2016-10-04T00:00:00.000000Z",
+            "created": "2020-05-18T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -1561,23 +2124,23 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2005-0005",
-                "ASSIGNER": "williammorris@certain_10.com",
+                "ID": "CVE-2005-0004",
+                "ASSIGNER": "christinediaz@suddenly_4.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Jones, Mitchell and Sims",
+                            "vendor_name": "Hall, Evans and Johnson",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "treat",
+                                        "product_name": "join",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "decision, structure, agency, wait"
+                                                    "version_value": "country, voice, finish, knowledge, sing, box, question"
                                                 }
                                             ]
                                         }
@@ -1603,59 +2166,29 @@
             "references": {
                 "reference_data": [
                     {
+                        "refsource": "ISSUE",
+                        "name": "Emily Mitchell",
+                        "url": "https://bryant.net/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Dwayne Gomez",
+                        "url": "http://wilson-jimenez.com/"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Amy Graves",
+                        "url": "https://taylor.net/privacy/"
+                    },
+                    {
                         "refsource": "MISC",
-                        "name": "https://clark.biz/",
-                        "url": "https://clark.biz/"
+                        "name": "https://velazquez.com/privacy/",
+                        "url": "https://velazquez.com/privacy/"
                     },
                     {
-                        "refsource": "BALL",
-                        "name": "Tammy Phillips",
-                        "url": "https://lee.com/posts/register/"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "Sara Erickson",
-                        "url": "http://www.williams.com/"
-                    },
-                    {
-                        "refsource": "BILL",
-                        "name": "Matthew Gonzales",
-                        "url": "https://www.ross-jackson.com/privacy/"
-                    },
-                    {
-                        "refsource": "BILL",
-                        "name": "Mary Morales",
-                        "url": "http://www.adams-ramirez.com/search/"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Jared Reyes",
-                        "url": "https://www.holloway.biz/"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Amy Morgan",
-                        "url": "https://hart.com/list/post.php"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Dr. Roger Patterson Jr.",
-                        "url": "http://rodriguez.com/"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://www.morales.com/tags/main/home.asp",
-                        "url": "https://www.morales.com/tags/main/home.asp"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Matthew Wheeler",
-                        "url": "http://www.davis.org/"
-                    },
-                    {
-                        "refsource": "HAPPY",
-                        "name": "Joshua Walls",
-                        "url": "https://www.arroyo.biz/post/"
+                        "refsource": "UNIT",
+                        "name": "Jeffrey Johnson",
+                        "url": "https://smith.com/terms.jsp"
                     }
                 ]
             },
@@ -1663,7 +2196,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Store story hard. Cultural sea art school set recent. Measure explain computer worry. Consumer specific indeed know pick very fact."
+                        "value": "Detail sure deal join food age. Ball must subject. Realize sea dark research kitchen."
                     }
                 ]
             }
@@ -1671,100 +2204,7 @@
     },
     {
         "time": {
-            "created": "2018-08-14T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:30.860142+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2005-0006",
-                "ASSIGNER": "sandrabrown@song_3.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Cross-Allen",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "lay",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "improve, ok, number, somebody, it, effort, PM, fund"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Cross-platform logistical artificial intelligence"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Jared Reyes",
-                        "url": "https://www.holloway.biz/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Jeffrey Garcia",
-                        "url": "http://www.vega-fuentes.com/search/list/about/"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Amy Morgan",
-                        "url": "https://hart.com/list/post.php"
-                    },
-                    {
-                        "refsource": "HAPPY",
-                        "name": "Mr. Matthew Nguyen MD",
-                        "url": "https://www.decker.com/explore/blog/faq.jsp"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "John Sullivan",
-                        "url": "http://www.palmer.com/author/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "You ground family keep within."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-01-11T00:00:00.000000Z",
+            "created": "2018-07-08T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -1772,23 +2212,23 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2005-0008",
-                "ASSIGNER": "dominiquefrench@ok_17.com",
+                "ID": "CVE-2005-0007",
+                "ASSIGNER": "annecherry@student_18.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Brown PLC",
+                            "vendor_name": "Walker Inc",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "sometimes",
+                                        "product_name": "happy",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "hair, firm, chair"
+                                                    "version_value": "blood, everyone, cause, anything, research, professor"
                                                 }
                                             ]
                                         }
@@ -1805,7 +2245,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "De-engineered uniform open system"
+                                "value": "Streamlined background software"
                             }
                         ]
                     }
@@ -1814,9 +2254,44 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "PARTICULAR",
-                        "name": "Catherine Adams",
-                        "url": "https://www.sanchez.com/posts/posts/app/author/"
+                        "refsource": "TREATMENT",
+                        "name": "Loretta Navarro",
+                        "url": "https://www.harris.org/wp-content/list/wp-content/about.html"
+                    },
+                    {
+                        "refsource": "SPEECH",
+                        "name": "Tiffany Bailey",
+                        "url": "http://young.com/posts/home/"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Wyatt Patrick",
+                        "url": "http://www.mitchell.com/wp-content/tags/tags/about/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Dwayne Gomez",
+                        "url": "http://wilson-jimenez.com/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Rebecca Johnson",
+                        "url": "https://james.com/wp-content/blog/main.jsp"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Kayla Jackson",
+                        "url": "http://www.rivera.com/wp-content/category/category/register.html"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Joseph Weber",
+                        "url": "https://campbell-murphy.com/app/app/author/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.collins.org/search/main/privacy.html",
+                        "url": "https://www.collins.org/search/main/privacy.html"
                     }
                 ]
             },
@@ -1824,7 +2299,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Culture ever woman. Benefit meet public certainly whose."
+                        "value": "Make team together up professional story. Which child serve including manager operation wonder."
                     }
                 ]
             }
@@ -1832,8 +2307,8 @@
     },
     {
         "time": {
-            "created": "2019-12-31T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:31.242774+00:00"
+            "created": "2017-03-04T00:00:00.000000Z",
+            "modified": null
         },
         "cve": {
             "data_type": "CVE",
@@ -1848,7 +2323,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Glass point yard stop clearly. Bag car time response game. Garden yard above upon so particular."
+                        "value": "Road statement affect both body. Affect become force realize certain safe black."
                     }
                 ]
             }
@@ -1856,7 +2331,7 @@
     },
     {
         "time": {
-            "created": "2012-11-18T00:00:00.000000Z",
+            "created": "2014-05-14T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -1864,120 +2339,7 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2006-0001",
-                "ASSIGNER": "sandrabrown@song_3.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Rios, Nichols and Bradley",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "evidence",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "religious, seven, pull, bit"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Digitized eco-centric frame"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "BECAUSE",
-                        "name": "Kristina Carter",
-                        "url": "http://www.pennington.com/explore/index/"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://www.reynolds.com/posts/main/explore/author.htm",
-                        "url": "https://www.reynolds.com/posts/main/explore/author.htm"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://willis.info/main/",
-                        "url": "https://willis.info/main/"
-                    },
-                    {
-                        "refsource": "HAPPY",
-                        "name": "Christopher Lewis",
-                        "url": "https://www.saunders-wright.com/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Emily Gutierrez",
-                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Logan Vazquez",
-                        "url": "http://wilson.com/main/blog/login.asp"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Jared Reyes",
-                        "url": "https://www.holloway.biz/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Jeffrey Garcia",
-                        "url": "http://www.vega-fuentes.com/search/list/about/"
-                    },
-                    {
-                        "refsource": "BILL",
-                        "name": "Erin Taylor",
-                        "url": "http://www.miller.com/search/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Physical cause along health shake return. Political art store guy how reach throughout. Sit market serve city myself difficult."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-01-23T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2006-0004",
+                "ID": "CVE-2005-0010",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -1985,7 +2347,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Purpose share that spend black. Color seven when hold."
+                        "value": "Human since become establish. Unit analysis always board create him image. Single college build machine trip."
                     }
                 ]
             }
@@ -1993,8 +2355,32 @@
     },
     {
         "time": {
-            "created": "2017-09-07T00:00:00.000000Z",
+            "created": "2012-08-08T00:00:00.000000Z",
             "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2006-0002",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Including central west management police. Movie by scientist case project whom."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-10-07T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:27.764484+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -2002,22 +2388,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2006-0005",
-                "ASSIGNER": "rebeccahenry@difference_16.com",
+                "ASSIGNER": "calvinthompson@several_14.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Perry Group",
+                            "vendor_name": "Stewart-Rodriguez",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "computer",
+                                        "product_name": "order",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "full, resource, represent, friend, somebody, decade, minute, join"
+                                                    "version_value": "beautiful, assume, season, receive"
                                                 }
                                             ]
                                         }
@@ -2034,7 +2420,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Digitized eco-centric frame"
+                                "value": "Diverse executive concept"
                             }
                         ]
                     }
@@ -2043,24 +2429,9 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "THESE",
-                        "name": "Michael Carroll",
-                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Jeffrey Garcia",
-                        "url": "http://www.vega-fuentes.com/search/list/about/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Scott Wise",
-                        "url": "http://www.gardner.com/main/post/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                        "refsource": "CONFIRM",
+                        "name": "https://www.mendez.com/app/category.asp",
+                        "url": "https://www.mendez.com/app/category.asp"
                     }
                 ]
             },
@@ -2068,7 +2439,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Republican tough lawyer left make yard control. Nearly rich east structure bad smile. None somebody central across fight."
+                        "value": "Nature experience certain economic. Bring life point a happy drug side."
                     }
                 ]
             }
@@ -2076,8 +2447,8 @@
     },
     {
         "time": {
-            "created": "2015-01-22T00:00:00.000000Z",
-            "modified": null
+            "created": "2020-06-22T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:27.949695+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -2085,46 +2456,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2006-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Financial behavior appear make cultural."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-02-26T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2006-0007",
-                "ASSIGNER": "jeffreyfigueroa@man_5.com",
+                "ASSIGNER": "annecherry@student_18.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Lozano-Brown",
+                            "vendor_name": "Becker-Ramirez",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "down",
+                                        "product_name": "interview",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "blue, own, rate"
+                                                    "version_value": "man, much, goal, last, drive, mean"
                                                 }
                                             ]
                                         }
@@ -2141,7 +2488,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Open-source 6thgeneration standardization"
+                                "value": "n/a"
                             }
                         ]
                     }
@@ -2150,9 +2497,14 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "DARK",
-                        "name": "Jeffrey Garcia",
-                        "url": "http://www.vega-fuentes.com/search/list/about/"
+                        "refsource": "SPEECH",
+                        "name": "Tiffany Bailey",
+                        "url": "http://young.com/posts/home/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://jacobson.net/category/tags/list/register.htm",
+                        "url": "https://jacobson.net/category/tags/list/register.htm"
                     }
                 ]
             },
@@ -2160,7 +2512,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Other least true discussion who. Second build too use page heavy hope computer."
+                        "value": "Finally own white teacher various."
                     }
                 ]
             }
@@ -2168,8 +2520,258 @@
     },
     {
         "time": {
-            "created": "2016-12-18T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:33.317397+00:00"
+            "created": "2017-09-08T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2006-0008",
+                "ASSIGNER": "jacobdouglas@senior_19.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Cannon and Sons",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "despite",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "quite, property, upon"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Diverse executive concept"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Emily Mitchell",
+                        "url": "https://bryant.net/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Jeremiah Cobb",
+                        "url": "http://andrade.com/author.php"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Dwayne Gomez",
+                        "url": "http://wilson-jimenez.com/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Kristen Davis",
+                        "url": "https://www.harrison-miller.org/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Kristi Wiggins",
+                        "url": "https://patterson.com/search/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "http://mcmillan.com/posts/index.html",
+                        "url": "http://mcmillan.com/posts/index.html"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Larry Hicks",
+                        "url": "https://www.baker-garcia.org/terms/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.mendez.com/app/category.asp",
+                        "url": "https://www.mendez.com/app/category.asp"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.collins.org/search/main/privacy.html",
+                        "url": "https://www.collins.org/search/main/privacy.html"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Charles Mcclure",
+                        "url": "http://sanchez-long.org/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Require member somebody TV."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2011-06-10T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2006-0010",
+                "ASSIGNER": "ryanschmidt@man_8.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Holmes-Spencer",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "while",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "add, consumer, help, capital, than, about, time"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Streamlined background software"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "SPEECH",
+                        "name": "Tiffany Bailey",
+                        "url": "http://young.com/posts/home/"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Wyatt Patrick",
+                        "url": "http://www.mitchell.com/wp-content/tags/tags/about/"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Gary Doyle",
+                        "url": "http://www.gonzalez-holland.com/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://velazquez.com/privacy/",
+                        "url": "https://velazquez.com/privacy/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "http://mcmillan.com/posts/index.html",
+                        "url": "http://mcmillan.com/posts/index.html"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Larry Hicks",
+                        "url": "https://www.baker-garcia.org/terms/"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Joseph Weber",
+                        "url": "https://campbell-murphy.com/app/app/author/"
+                    },
+                    {
+                        "refsource": "PHYSICAL",
+                        "name": "Stacy Salazar",
+                        "url": "https://mckenzie.com/main/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Jeffrey Johnson",
+                        "url": "https://smith.com/terms.jsp"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Tina Blevins",
+                        "url": "https://www.carney-hernandez.biz/category/explore/index.php"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Magazine economic people. Prove whether able cultural mouth first."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2021-03-20T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:28.793876+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2007-0001",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Argue red help another push oil. Take unit performance fall. Table teacher most Mr election."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2012-02-26T00:00:00.000000Z",
+            "modified": null
         },
         "cve": {
             "data_type": "CVE",
@@ -2177,46 +2779,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2007-0002",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Quite lose low loss among describe since. Attack leave provide. Expert order better quality his southern stand."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-02-13T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2007-0004",
-                "ASSIGNER": "stephenjohnson@accept_19.com",
+                "ASSIGNER": "annecherry@student_18.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Lucas, Jones and Glass",
+                            "vendor_name": "Tucker, Howard and Shaw",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "per",
+                                        "product_name": "product",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "person, kind"
+                                                    "version_value": "fact, others, economy, dinner, hit, blood, where, return, grow"
                                                 }
                                             ]
                                         }
@@ -2233,7 +2811,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "De-engineered uniform open system"
+                                "value": "Down-sized executive hierarchy"
                             }
                         ]
                     }
@@ -2242,59 +2820,44 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "CONFIRM",
-                        "name": "http://www.thompson-gibson.info/post.htm",
-                        "url": "http://www.thompson-gibson.info/post.htm"
+                        "refsource": "TREATMENT",
+                        "name": "Loretta Navarro",
+                        "url": "https://www.harris.org/wp-content/list/wp-content/about.html"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Karen Rogers",
-                        "url": "https://www.willis.biz/list/tags/main/"
+                        "refsource": "ISSUE",
+                        "name": "Emily Mitchell",
+                        "url": "https://bryant.net/"
                     },
                     {
-                        "refsource": "CONFIRM",
-                        "name": "https://willis.info/main/",
-                        "url": "https://willis.info/main/"
+                        "refsource": "MISC",
+                        "name": "http://cowan.com/",
+                        "url": "http://cowan.com/"
                     },
                     {
-                        "refsource": "THOUGH",
-                        "name": "Sara Erickson",
-                        "url": "http://www.williams.com/"
+                        "refsource": "ISSUE",
+                        "name": "Jennifer Morales",
+                        "url": "https://sutton-melton.com/category/category/category/register.asp"
                     },
                     {
-                        "refsource": "BALL",
-                        "name": "April Silva",
-                        "url": "http://henry.biz/category/register/"
+                        "refsource": "EIGHT",
+                        "name": "Keith Yates",
+                        "url": "https://massey.com/app/search/homepage.asp"
                     },
                     {
-                        "refsource": "PARTICULAR",
-                        "name": "Kathleen Garcia",
-                        "url": "http://www.morris.com/app/index/"
+                        "refsource": "UNIT",
+                        "name": "Larry Hicks",
+                        "url": "https://www.baker-garcia.org/terms/"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Emily Gutierrez",
-                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
+                        "refsource": "UNIT",
+                        "name": "Drew Ford",
+                        "url": "https://www.reynolds.com/"
                     },
                     {
-                        "refsource": "ITEM",
-                        "name": "Amy Morgan",
-                        "url": "https://hart.com/list/post.php"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://www.morales.com/tags/main/home.asp",
-                        "url": "https://www.morales.com/tags/main/home.asp"
-                    },
-                    {
-                        "refsource": "BECAUSE",
-                        "name": "Samantha Heath MD",
-                        "url": "http://knapp.com/blog/blog/category.php"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                        "refsource": "HIM",
+                        "name": "Kristine Farrell",
+                        "url": "https://wilson.biz/app/search/main.php"
                     }
                 ]
             },
@@ -2302,7 +2865,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Pass pay say million. Seven affect create mention. But manage give thus image."
+                        "value": "Cover deep free control what week. Professional bill poor party learn should local than."
                     }
                 ]
             }
@@ -2310,7 +2873,31 @@
     },
     {
         "time": {
-            "created": "2016-07-30T00:00:00.000000Z",
+            "created": "2019-04-27T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2007-0005",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Home him tell argue entire enough. Language fish film address produce raise identify. Field low then know course. Anyone business prove real final."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-04-07T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -2326,7 +2913,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Yet little trial beautiful her then. Team upon successful same."
+                        "value": "Decision future treat statement. Performance personal television manager. Yeah ago very officer."
                     }
                 ]
             }
@@ -2334,7 +2921,7 @@
     },
     {
         "time": {
-            "created": "2019-03-15T00:00:00.000000Z",
+            "created": "2014-10-01T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -2343,22 +2930,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2007-0010",
-                "ASSIGNER": "nicolecallahan@whether_20.com",
+                "ASSIGNER": "andrewgriffith@level_16.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Vargas, Collins and Parker",
+                            "vendor_name": "Henry-Dixon",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "compare",
+                                        "product_name": "response",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "ok, thing, peace, late, improve"
+                                                    "version_value": "yet, tough, learn"
                                                 }
                                             ]
                                         }
@@ -2375,7 +2962,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Total systemic portal"
+                                "value": "Streamlined background software"
                             }
                         ]
                     }
@@ -2384,44 +2971,59 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "THESE",
-                        "name": "Michael Carroll",
-                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
+                        "refsource": "TREATMENT",
+                        "name": "Loretta Navarro",
+                        "url": "https://www.harris.org/wp-content/list/wp-content/about.html"
                     },
                     {
-                        "refsource": "MISC",
-                        "name": "https://www.andrews.com/faq/",
-                        "url": "https://www.andrews.com/faq/"
+                        "refsource": "SPEECH",
+                        "name": "Tiffany Bailey",
+                        "url": "http://young.com/posts/home/"
                     },
                     {
-                        "refsource": "BILL",
-                        "name": "Matthew Gonzales",
-                        "url": "https://www.ross-jackson.com/privacy/"
+                        "refsource": "ISSUE",
+                        "name": "Wyatt Patrick",
+                        "url": "http://www.mitchell.com/wp-content/tags/tags/about/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Jeremiah Cobb",
+                        "url": "http://andrade.com/author.php"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Richard Thomas",
+                        "url": "https://www.smith.com/index/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Kristi Wiggins",
+                        "url": "https://patterson.com/search/"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Keith Yates",
+                        "url": "https://massey.com/app/search/homepage.asp"
                     },
                     {
                         "refsource": "CONFIRM",
-                        "name": "https://hall.biz/",
-                        "url": "https://hall.biz/"
+                        "name": "http://mcmillan.com/posts/index.html",
+                        "url": "http://mcmillan.com/posts/index.html"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Logan Vazquez",
-                        "url": "http://wilson.com/main/blog/login.asp"
+                        "refsource": "TREATMENT",
+                        "name": "Heather Lopez",
+                        "url": "http://moore-jackson.info/search/home.htm"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Jeffrey Garcia",
-                        "url": "http://www.vega-fuentes.com/search/list/about/"
+                        "refsource": "UNIT",
+                        "name": "Jeffrey Johnson",
+                        "url": "https://smith.com/terms.jsp"
                     },
                     {
-                        "refsource": "THOUGH",
-                        "name": "Allison Jensen",
-                        "url": "https://www.miller.com/terms.htm"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "John Sullivan",
-                        "url": "http://www.palmer.com/author/"
+                        "refsource": "FAR",
+                        "name": "Brian Jones",
+                        "url": "http://www.rios-wells.com/"
                     }
                 ]
             },
@@ -2429,7 +3031,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Should pay finally over find build. Thing find always entire try. Season actually let."
+                        "value": "Us race behavior not outside right. Professor focus industry it management be individual."
                     }
                 ]
             }
@@ -2437,7 +3039,95 @@
     },
     {
         "time": {
-            "created": "2015-10-28T00:00:00.000000Z",
+            "created": "2012-01-15T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:30.527112+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2008-0001",
+                "ASSIGNER": "amybass@now_11.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Morgan Ltd",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "institution",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "help, technology, Republican, truth"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Streamlined background software"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "FAR",
+                        "name": "Rebecca Johnson",
+                        "url": "https://james.com/wp-content/blog/main.jsp"
+                    },
+                    {
+                        "refsource": "SEA",
+                        "name": "Deborah Odonnell",
+                        "url": "http://morrison.org/category/explore/main/author/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Elizabeth Bradley",
+                        "url": "https://www.williams.com/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Larry Hicks",
+                        "url": "https://www.baker-garcia.org/terms/"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Michael Smith",
+                        "url": "http://medina.com/app/categories/category/category/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Various more rate go analysis thus. Radio quality yet life ago today nearly."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2018-06-17T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -2445,23 +3135,23 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2008-0003",
-                "ASSIGNER": "jeffreyfigueroa@man_5.com",
+                "ID": "CVE-2008-0004",
+                "ASSIGNER": "debrasmith@body_2.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Hubbard Inc",
+                            "vendor_name": "Collins Ltd",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "past",
+                                        "product_name": "book",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "medical, my"
+                                                    "version_value": "eye, some, work, commercial"
                                                 }
                                             ]
                                         }
@@ -2478,7 +3168,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "n/a"
+                                "value": "Down-sized executive hierarchy"
                             }
                         ]
                     }
@@ -2487,34 +3177,49 @@
             "references": {
                 "reference_data": [
                     {
+                        "refsource": "TREATMENT",
+                        "name": "Loretta Navarro",
+                        "url": "https://www.harris.org/wp-content/list/wp-content/about.html"
+                    },
+                    {
+                        "refsource": "SPEECH",
+                        "name": "Tiffany Bailey",
+                        "url": "http://young.com/posts/home/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Dwayne Gomez",
+                        "url": "http://wilson-jimenez.com/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Kristen Davis",
+                        "url": "https://www.harrison-miller.org/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Rebecca Johnson",
+                        "url": "https://james.com/wp-content/blog/main.jsp"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://www.hernandez.com/list/wp-content/posts/post.php",
+                        "url": "https://www.hernandez.com/list/wp-content/posts/post.php"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Joseph Weber",
+                        "url": "https://campbell-murphy.com/app/app/author/"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Heather Lopez",
+                        "url": "http://moore-jackson.info/search/home.htm"
+                    },
+                    {
                         "refsource": "CONFIRM",
-                        "name": "https://www.reynolds.com/posts/main/explore/author.htm",
-                        "url": "https://www.reynolds.com/posts/main/explore/author.htm"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://clark.biz/",
-                        "url": "https://clark.biz/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://www.andrews.com/faq/",
-                        "url": "https://www.andrews.com/faq/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Emily Gutierrez",
-                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
-                    },
-                    {
-                        "refsource": "BILL",
-                        "name": "Erin Taylor",
-                        "url": "http://www.miller.com/search/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                        "name": "https://www.mendez.com/app/category.asp",
+                        "url": "https://www.mendez.com/app/category.asp"
                     }
                 ]
             },
@@ -2522,7 +3227,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Instead maybe staff sea wall. Brother more factor defense he. Very strategy mother surface professional protect."
+                        "value": "Page know pattern marriage respond by middle time. Carry moment skin box value."
                     }
                 ]
             }
@@ -2530,8 +3235,8 @@
     },
     {
         "time": {
-            "created": "2019-07-13T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:35.637722+00:00"
+            "created": "2013-02-24T00:00:00.000000Z",
+            "modified": null
         },
         "cve": {
             "data_type": "CVE",
@@ -2539,46 +3244,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2008-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Institution grow management gas require star. Most board need Congress spring bag responsibility course."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-01-26T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2008-0006",
-                "ASSIGNER": "nicolecallahan@whether_20.com",
+                "ASSIGNER": "andrewgriffith@level_16.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Larsen-Allen",
+                            "vendor_name": "Ford, Evans and Wheeler",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "morning",
+                                        "product_name": "onto",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "into"
+                                                    "version_value": "year"
                                                 }
                                             ]
                                         }
@@ -2595,7 +3276,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Cross-platform logistical artificial intelligence"
+                                "value": "Integrated radical array"
                             }
                         ]
                     }
@@ -2604,24 +3285,59 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "ITEM",
-                        "name": "Eric Thompson",
-                        "url": "https://nunez.com/blog/homepage.html"
+                        "refsource": "ISSUE",
+                        "name": "Emily Mitchell",
+                        "url": "https://bryant.net/"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Logan Vazquez",
-                        "url": "http://wilson.com/main/blog/login.asp"
+                        "refsource": "UNIT",
+                        "name": "Jeremiah Cobb",
+                        "url": "http://andrade.com/author.php"
                     },
                     {
-                        "refsource": "ITEM",
-                        "name": "Matthew Wheeler",
-                        "url": "http://www.davis.org/"
+                        "refsource": "FAR",
+                        "name": "Dwayne Gomez",
+                        "url": "http://wilson-jimenez.com/"
                     },
                     {
-                        "refsource": "HAPPY",
-                        "name": "Mr. Matthew Nguyen MD",
-                        "url": "https://www.decker.com/explore/blog/faq.jsp"
+                        "refsource": "TYPE",
+                        "name": "Elizabeth Bradley",
+                        "url": "https://www.williams.com/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Kristi Wiggins",
+                        "url": "https://patterson.com/search/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Jeffrey Johnson",
+                        "url": "https://smith.com/terms.jsp"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Brian Jones",
+                        "url": "http://www.rios-wells.com/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Drew Ford",
+                        "url": "https://www.reynolds.com/"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Tina Blevins",
+                        "url": "https://www.carney-hernandez.biz/category/explore/index.php"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Philip Lee",
+                        "url": "https://sullivan.com/blog/search.htm"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.collins.org/search/main/privacy.html",
+                        "url": "https://www.collins.org/search/main/privacy.html"
                     }
                 ]
             },
@@ -2629,7 +3345,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Difficult concern wrong stage. Year home true. Project ok store spend."
+                        "value": "Return responsibility from area would nor they teacher. Power writer important different thought ago old."
                     }
                 ]
             }
@@ -2637,7 +3353,124 @@
     },
     {
         "time": {
-            "created": "2011-11-17T00:00:00.000000Z",
+            "created": "2013-03-25T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2008-0007",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Identify watch firm long race single."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2013-06-22T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:31.859879+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2008-0008",
+                "ASSIGNER": "ryanschmidt@man_8.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Scott-Elliott",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "change",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "well, operation, support, baby, must, at, amount, movie, hit"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Diverse executive concept"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "UNIT",
+                        "name": "Jeremiah Cobb",
+                        "url": "http://andrade.com/author.php"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://velazquez.com/privacy/",
+                        "url": "https://velazquez.com/privacy/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://www.hernandez.com/list/wp-content/posts/post.php",
+                        "url": "https://www.hernandez.com/list/wp-content/posts/post.php"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Larry Hicks",
+                        "url": "https://www.baker-garcia.org/terms/"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Heather Lopez",
+                        "url": "http://moore-jackson.info/search/home.htm"
+                    },
+                    {
+                        "refsource": "PHYSICAL",
+                        "name": "Stacy Salazar",
+                        "url": "https://mckenzie.com/main/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Use himself visit window born store indicate. Practice and recognize drop."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-07-04T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -2653,7 +3486,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Industry idea trade everyone court. Agent sister test we."
+                        "value": "World send big care. Present realize work spend. Us across thing laugh."
                     }
                 ]
             }
@@ -2661,7 +3494,7 @@
     },
     {
         "time": {
-            "created": "2014-04-04T00:00:00.000000Z",
+            "created": "2019-11-24T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -2670,1116 +3503,7 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2009-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Oil once senior so head ago give. Statement idea arrive concern."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-09-13T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:37.176885+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2009-0003",
-                "ASSIGNER": "sandrabrown@song_3.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Chung, Carroll and Gibson",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "wait",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "treatment, then, should, culture, factor, in, town"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Cross-platform logistical artificial intelligence"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "BECAUSE",
-                        "name": "Kristina Carter",
-                        "url": "http://www.pennington.com/explore/index/"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Angela Anderson",
-                        "url": "http://drake.net/search.jsp"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.mendoza-ruiz.com/search/main/posts/terms.html",
-                        "url": "http://www.mendoza-ruiz.com/search/main/posts/terms.html"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://www.andrews.com/faq/",
-                        "url": "https://www.andrews.com/faq/"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://hall.biz/",
-                        "url": "https://hall.biz/"
-                    },
-                    {
-                        "refsource": "BECAUSE",
-                        "name": "Angelica Delgado",
-                        "url": "https://perry.com/register.html"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Jared Reyes",
-                        "url": "https://www.holloway.biz/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Dr. Roger Patterson Jr.",
-                        "url": "http://rodriguez.com/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Race vote change tell apply. Capital answer fund."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-03-17T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2009-0004",
-                "ASSIGNER": "colleentorres@opportunity_13.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Smith-Johnson",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "yourself",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "maintain, box, than, memory, service"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Total systemic portal"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Patrick Ross",
-                        "url": "http://www.aguilar.com/"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "Sara Erickson",
-                        "url": "http://www.williams.com/"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "April Silva",
-                        "url": "http://henry.biz/category/register/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Marcia Johnson",
-                        "url": "https://smith-perkins.net/tags/terms.jsp"
-                    },
-                    {
-                        "refsource": "HAPPY",
-                        "name": "Mr. Matthew Nguyen MD",
-                        "url": "https://www.decker.com/explore/blog/faq.jsp"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "John Sullivan",
-                        "url": "http://www.palmer.com/author/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Charge record action. Stop the significant level."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-04-24T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:37.579993+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2009-0005",
-                "ASSIGNER": "stephenjohnson@accept_19.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Miller-Rivas",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "teach",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "worry, office, away, future, ok, different, teacher, news, various"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Patrick Ross",
-                        "url": "http://www.aguilar.com/"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://willis.info/main/",
-                        "url": "https://willis.info/main/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://www.andrews.com/faq/",
-                        "url": "https://www.andrews.com/faq/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Emily Gutierrez",
-                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://escobar.com/homepage.php",
-                        "url": "http://escobar.com/homepage.php"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Jared Reyes",
-                        "url": "https://www.holloway.biz/"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Matthew Wheeler",
-                        "url": "http://www.davis.org/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Include specific four. Across consumer response heart continue start study."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-06-27T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2009-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Us growth could respond unit professional fact. Pretty west last behind. Lawyer watch teacher morning movement effort current."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-10-06T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:38.706568+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0002",
-                "ASSIGNER": "jamesvaldez@technology_4.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Wilkins, Macias and Stout",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "option",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "other, drop, heart, your, indicate, role, difficult, direction"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "THESE",
-                        "name": "Michael Carroll",
-                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://clark.biz/",
-                        "url": "https://clark.biz/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Brett Krause",
-                        "url": "http://curtis-campbell.com/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Kathleen Garcia",
-                        "url": "http://www.morris.com/app/index/"
-                    },
-                    {
-                        "refsource": "BILL",
-                        "name": "Mary Morales",
-                        "url": "http://www.adams-ramirez.com/search/"
-                    },
-                    {
-                        "refsource": "BECAUSE",
-                        "name": "Angelica Delgado",
-                        "url": "https://perry.com/register.html"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Matthew Wheeler",
-                        "url": "http://www.davis.org/"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "Karen Ray",
-                        "url": "https://www.ruiz.org/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Wear majority once society fish approach. Understand art describe personal."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-03-08T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0005",
-                "ASSIGNER": "stevenvalentine@whatever_18.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Watson, Martin and Moore",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "nature",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "change, pull, society, at, position, join"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Digitized eco-centric frame"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "BECAUSE",
-                        "name": "Kristina Carter",
-                        "url": "http://www.pennington.com/explore/index/"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Troy Gutierrez",
-                        "url": "http://richards.com/post/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://clark.biz/",
-                        "url": "https://clark.biz/"
-                    },
-                    {
-                        "refsource": "HAPPY",
-                        "name": "Christopher Lewis",
-                        "url": "https://www.saunders-wright.com/"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "Sara Erickson",
-                        "url": "http://www.williams.com/"
-                    },
-                    {
-                        "refsource": "THESE",
-                        "name": "Jeffrey Davis",
-                        "url": "http://www.wright-lamb.com/index.html"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.mcgee.biz/index/",
-                        "url": "http://www.mcgee.biz/index/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Logan Vazquez",
-                        "url": "http://wilson.com/main/blog/login.asp"
-                    },
-                    {
-                        "refsource": "HAPPY",
-                        "name": "Mr. Matthew Nguyen MD",
-                        "url": "https://www.decker.com/explore/blog/faq.jsp"
-                    },
-                    {
-                        "refsource": "HAPPY",
-                        "name": "Joshua Walls",
-                        "url": "https://www.arroyo.biz/post/"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "Katherine Richard",
-                        "url": "https://www.holland.biz/tag/app/about/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Debate available risk yet. Science collection possible."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2011-10-24T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:39.354523+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Under visit pressure. Admit traditional stop."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-06-26T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0007",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Child stop develop street nature practice east federal. Success off everybody challenge."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-02-19T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Determine instead each claim respond place middle. Front operation sister difference life religious."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-09-04T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2010-0010",
-                "ASSIGNER": "franciscoanderson@today_2.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Thomas, Wilson and Wiley",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "serve",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "when"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "BECAUSE",
-                        "name": "Kristina Carter",
-                        "url": "http://www.pennington.com/explore/index/"
-                    },
-                    {
-                        "refsource": "THESE",
-                        "name": "Michael Carroll",
-                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Eric Thompson",
-                        "url": "https://nunez.com/blog/homepage.html"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Kathleen Garcia",
-                        "url": "http://www.morris.com/app/index/"
-                    },
-                    {
-                        "refsource": "THESE",
-                        "name": "Jeffrey Davis",
-                        "url": "http://www.wright-lamb.com/index.html"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://hall.biz/",
-                        "url": "https://hall.biz/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Catherine Adams",
-                        "url": "https://www.sanchez.com/posts/posts/app/author/"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Jeffrey Davis",
-                        "url": "https://miller.info/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Scott Wise",
-                        "url": "http://www.gardner.com/main/post/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Community individual like."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-12-20T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0001",
-                "ASSIGNER": "stevenvalentine@whatever_18.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Cooke, Parker and Le",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "carry",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "fly"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Total systemic portal"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Troy Gutierrez",
-                        "url": "http://richards.com/post/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://clark.biz/",
-                        "url": "https://clark.biz/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Brett Krause",
-                        "url": "http://curtis-campbell.com/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://www.andrews.com/faq/",
-                        "url": "https://www.andrews.com/faq/"
-                    },
-                    {
-                        "refsource": "BILL",
-                        "name": "Mary Morales",
-                        "url": "http://www.adams-ramirez.com/search/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Marcia Johnson",
-                        "url": "https://smith-perkins.net/tags/terms.jsp"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Jared Reyes",
-                        "url": "https://www.holloway.biz/"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://www.morales.com/tags/main/home.asp",
-                        "url": "https://www.morales.com/tags/main/home.asp"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Scott Wise",
-                        "url": "http://www.gardner.com/main/post/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Value world modern treat when federal leave. Manager worker however door sell she."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2014-10-10T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:40.678339+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0003",
-                "ASSIGNER": "jamesvaldez@technology_4.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Harris and Sons",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "well",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "finish, crime, certainly, deep, public, writer, consider, window, hold"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Open-source 6thgeneration standardization"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "BALL",
-                        "name": "Tammy Phillips",
-                        "url": "https://lee.com/posts/register/"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Eric Thompson",
-                        "url": "https://nunez.com/blog/homepage.html"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Brett Krause",
-                        "url": "http://curtis-campbell.com/"
-                    },
-                    {
-                        "refsource": "HAPPY",
-                        "name": "Christopher Lewis",
-                        "url": "https://www.saunders-wright.com/"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "Sara Erickson",
-                        "url": "http://www.williams.com/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Emily Gutierrez",
-                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
-                    },
-                    {
-                        "refsource": "THESE",
-                        "name": "Jeffrey Davis",
-                        "url": "http://www.wright-lamb.com/index.html"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://hall.biz/",
-                        "url": "https://hall.biz/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Catherine Adams",
-                        "url": "https://www.sanchez.com/posts/posts/app/author/"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://www.morales.com/tags/main/home.asp",
-                        "url": "https://www.morales.com/tags/main/home.asp"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Treatment give Democrat allow. Popular loss teach leader. Between factor blood light deal picture official."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-08-13T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0004",
-                "ASSIGNER": "davidmcguire@only_6.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Cardenas, Adkins and Moore",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "final",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "entire, line"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "De-engineered uniform open system"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "MISC",
-                        "name": "http://escobar.com/homepage.php",
-                        "url": "http://escobar.com/homepage.php"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Suffer born on Democrat service."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-08-14T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Parent across recognize early different me. Already recent must threat newspaper building. Treat question ever whole."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-01-18T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Several you young peace despite particularly instead. Get shake lose theory world run take. Model experience politics so."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-03-22T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:41.850550+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2011-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Well reality history believe force. Tell anyone drop. Push one out short."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-05-03T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2012-0001",
-                "ASSIGNER": "christianromero@mitre.com",
+                "ASSIGNER": "michellemartin@mitre.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
@@ -3820,34 +3544,9 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "BECAUSE",
-                        "name": "Kristina Carter",
-                        "url": "http://www.pennington.com/explore/index/"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://willis.info/main/",
-                        "url": "https://willis.info/main/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://escobar.com/homepage.php",
-                        "url": "http://escobar.com/homepage.php"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Jeffrey Garcia",
-                        "url": "http://www.vega-fuentes.com/search/list/about/"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Jeffrey Davis",
-                        "url": "https://miller.info/"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Matthew Wheeler",
-                        "url": "http://www.davis.org/"
+                        "refsource": "SEA",
+                        "name": "Chad Villegas",
+                        "url": "http://hill-evans.com/list/tags/blog/author/"
                     }
                 ]
             },
@@ -3855,7 +3554,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Home whose first. Together positive decision perform appear scientist. Certainly painting beat hope themselves response."
+                        "value": "Carry sort thousand dinner whether school determine. Throughout employee else film. Above Republican site street site article none."
                     }
                 ]
             }
@@ -3863,15 +3562,15 @@
     },
     {
         "time": {
-            "created": "2017-05-15T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:43.216533+00:00"
+            "created": "2014-07-17T00:00:00.000000Z",
+            "modified": null
         },
         "cve": {
             "data_type": "CVE",
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2012-0008",
+                "ID": "CVE-2009-0002",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -3879,7 +3578,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Grow impact time thing. Less quality image spring environment poor."
+                        "value": "Thus day from Democrat. Buy small base discussion. Since whatever exactly number bar trade economy."
                     }
                 ]
             }
@@ -3887,7 +3586,1168 @@
     },
     {
         "time": {
-            "created": "2016-10-07T00:00:00.000000Z",
+            "created": "2020-01-26T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2009-0003",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Car air head difference teacher method. Drop read about send Mr. Never later him all they."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2018-08-07T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2009-0006",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Here care author policy executive. Smile election would if final ability about. System open now outside sure."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2017-04-13T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2009-0008",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Very provide history. Face life approach growth."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2016-12-18T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:33.970435+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2010-0001",
+                "ASSIGNER": "michellemartin@mitre.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "n/a",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "n/a"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "vendor_name": "n/a"
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "n/a"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Emily Mitchell",
+                        "url": "https://bryant.net/"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Amy Graves",
+                        "url": "https://taylor.net/privacy/"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Jennifer Morales",
+                        "url": "https://sutton-melton.com/category/category/category/register.asp"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://jacobson.net/category/tags/list/register.htm",
+                        "url": "https://jacobson.net/category/tags/list/register.htm"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Michael Smith",
+                        "url": "http://medina.com/app/categories/category/category/"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Joseph Weber",
+                        "url": "https://campbell-murphy.com/app/app/author/"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Heather Lopez",
+                        "url": "http://moore-jackson.info/search/home.htm"
+                    },
+                    {
+                        "refsource": "PHYSICAL",
+                        "name": "Stacy Salazar",
+                        "url": "https://mckenzie.com/main/"
+                    },
+                    {
+                        "refsource": "SEA",
+                        "name": "William Kelley",
+                        "url": "http://www.jones-medina.info/category.php"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Joseph Bryant",
+                        "url": "https://barrett.net/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.collins.org/search/main/privacy.html",
+                        "url": "https://www.collins.org/search/main/privacy.html"
+                    },
+                    {
+                        "refsource": "HIM",
+                        "name": "James Jones",
+                        "url": "http://stanley.org/app/posts/blog/faq.jsp"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Late bad western building house. Light likely tax remember. Affect piece open ten guess total play."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2016-04-14T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2010-0002",
+                "ASSIGNER": "julieweaver@property_15.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Wiggins, Long and Gardner",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "arm",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "hit, most, language, education, election, feel, event"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Integrated radical array"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "UNIT",
+                        "name": "Jeremiah Cobb",
+                        "url": "http://andrade.com/author.php"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Gary Doyle",
+                        "url": "http://www.gonzalez-holland.com/"
+                    },
+                    {
+                        "refsource": "SEA",
+                        "name": "Deborah Odonnell",
+                        "url": "http://morrison.org/category/explore/main/author/"
+                    },
+                    {
+                        "refsource": "SPEECH",
+                        "name": "Evan Gallagher",
+                        "url": "http://davis-edwards.net/search/main/list/post/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Kayla Jackson",
+                        "url": "http://www.rivera.com/wp-content/category/category/register.html"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Philip Lee",
+                        "url": "https://sullivan.com/blog/search.htm"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Charles Mcclure",
+                        "url": "http://sanchez-long.org/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Turn direction inside him citizen arrive attention. Local ahead test government manage west bar."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2012-05-10T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2010-0003",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Learn common church rich family next."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2018-01-10T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:35.523756+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2010-0008",
+                "ASSIGNER": "lindavaughn@single_6.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Young-Levy",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "call",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "development, research, along, common, pull, beat, sea, art"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Customer-focused asymmetric database"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "SPEECH",
+                        "name": "Tiffany Bailey",
+                        "url": "http://young.com/posts/home/"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Wyatt Patrick",
+                        "url": "http://www.mitchell.com/wp-content/tags/tags/about/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Richard Thomas",
+                        "url": "https://www.smith.com/index/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Rebecca Johnson",
+                        "url": "https://james.com/wp-content/blog/main.jsp"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Joseph Weber",
+                        "url": "https://campbell-murphy.com/app/app/author/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Jeffrey Johnson",
+                        "url": "https://smith.com/terms.jsp"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.mendez.com/app/category.asp",
+                        "url": "https://www.mendez.com/app/category.asp"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Tina Blevins",
+                        "url": "https://www.carney-hernandez.biz/category/explore/index.php"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Brandon Johnson",
+                        "url": "http://johnson-bryant.info/category/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "http://www.rasmussen-davis.net/",
+                        "url": "http://www.rasmussen-davis.net/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Opportunity understand easy spend stay theory. And various either keep gas example modern. Common hundred push painting modern deep program real."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2013-03-09T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2010-0009",
+                "ASSIGNER": "amybass@now_11.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Smith Inc",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "eat",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "two"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Streamlined background software"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Wyatt Patrick",
+                        "url": "http://www.mitchell.com/wp-content/tags/tags/about/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Kristi Wiggins",
+                        "url": "https://patterson.com/search/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Inside program low. Agency game today better. Evening remember some."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-07-27T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:35.809350+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2010-0010",
+                "ASSIGNER": "rebeccaherring@agree_1.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Simmons and Sons",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "group",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "support, reduce, respond, thus, now, conference, life, scene, eat"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Customer-focused asymmetric database"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "UNIT",
+                        "name": "Jeremiah Cobb",
+                        "url": "http://andrade.com/author.php"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Jennifer Morales",
+                        "url": "https://sutton-melton.com/category/category/category/register.asp"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Kayla Jackson",
+                        "url": "http://www.rivera.com/wp-content/category/category/register.html"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.mendez.com/app/category.asp",
+                        "url": "https://www.mendez.com/app/category.asp"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.hood.com/explore/post/",
+                        "url": "https://www.hood.com/explore/post/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Character gun woman. Keep there imagine third former fly strong."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2018-07-29T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:36.164762+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2011-0002",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Month drug trade environment show. Dream will actually cut. Rate area stop tonight set."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2016-10-31T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2011-0004",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Keep debate keep wind remain could race. Tend himself receive. Through issue major investment front create state."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2015-09-01T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2011-0006",
+                "ASSIGNER": "cynthiabrooks@bad_10.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Vasquez, Dixon and Smith",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "hope",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "politics, around, others, bring, money, course, computer, seek"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "n/a"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "UNIT",
+                        "name": "Jeremiah Cobb",
+                        "url": "http://andrade.com/author.php"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Michael Smith",
+                        "url": "http://medina.com/app/categories/category/category/"
+                    },
+                    {
+                        "refsource": "HIM",
+                        "name": "James Jones",
+                        "url": "http://stanley.org/app/posts/blog/faq.jsp"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Act go interesting base goal surface wish. Doctor hit develop compare."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2012-06-10T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2011-0007",
+                "ASSIGNER": "lindavaughn@single_6.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Paul, Alvarez and Floyd",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "interest",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "agency, policy, strategy, let, different, medical, senior, they"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Customer-focused asymmetric database"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Wyatt Patrick",
+                        "url": "http://www.mitchell.com/wp-content/tags/tags/about/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Kristen Davis",
+                        "url": "https://www.harrison-miller.org/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "https://www.hernandez.com/list/wp-content/posts/post.php",
+                        "url": "https://www.hernandez.com/list/wp-content/posts/post.php"
+                    },
+                    {
+                        "refsource": "SPEECH",
+                        "name": "Evan Gallagher",
+                        "url": "http://davis-edwards.net/search/main/list/post/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.mendez.com/app/category.asp",
+                        "url": "https://www.mendez.com/app/category.asp"
+                    },
+                    {
+                        "refsource": "HIM",
+                        "name": "James Jones",
+                        "url": "http://stanley.org/app/posts/blog/faq.jsp"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Learn high far such situation official. Economy onto upon else ask."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2014-02-12T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:38.318141+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2012-0004",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Same full role often must everybody. Almost try summer stand case couple computer leave."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2017-03-24T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:38.463010+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2012-0005",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Nor later plant meeting."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-12-04T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2012-0006",
+                "ASSIGNER": "alecmitchell@drive_13.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Sharp Ltd",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "add",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "receive"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Down-sized executive hierarchy"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Brenda Medina",
+                        "url": "http://wang-collins.info/faq.html"
+                    },
+                    {
+                        "refsource": "SEA",
+                        "name": "Deborah Odonnell",
+                        "url": "http://morrison.org/category/explore/main/author/"
+                    },
+                    {
+                        "refsource": "SPEECH",
+                        "name": "Evan Gallagher",
+                        "url": "http://davis-edwards.net/search/main/list/post/"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Michael Smith",
+                        "url": "http://medina.com/app/categories/category/category/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Time better sense lose human time general return."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2014-09-24T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2012-0009",
+                "ASSIGNER": "andrewgriffith@level_16.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Tran-Sutton",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "why",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "wait, individual"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Customer-focused asymmetric database"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "MISC",
+                        "name": "https://velazquez.com/privacy/",
+                        "url": "https://velazquez.com/privacy/"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Rebecca Walker",
+                        "url": "https://johnson.com/main.htm"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Larry Hicks",
+                        "url": "https://www.baker-garcia.org/terms/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Kayla Jackson",
+                        "url": "http://www.rivera.com/wp-content/category/category/register.html"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Joseph Weber",
+                        "url": "https://campbell-murphy.com/app/app/author/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Brian Jones",
+                        "url": "http://www.rios-wells.com/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Brandon Johnson",
+                        "url": "http://johnson-bryant.info/category/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.hood.com/explore/post/",
+                        "url": "https://www.hood.com/explore/post/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Huge after million argue onto. Different over ago mind."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2011-12-09T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2012-0010",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Scene whose goal scene source."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2012-08-20T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2013-0001",
+                "ASSIGNER": "louisrose@eight_3.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Schneider Inc",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "Mrs",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "important, suddenly, have, explain, consider, pass, make, policy, school"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Integrated radical array"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Emily Mitchell",
+                        "url": "https://bryant.net/"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Wyatt Patrick",
+                        "url": "http://www.mitchell.com/wp-content/tags/tags/about/"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Amy Graves",
+                        "url": "https://taylor.net/privacy/"
+                    },
+                    {
+                        "refsource": "MISC",
+                        "name": "http://www.hall.biz/",
+                        "url": "http://www.hall.biz/"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Keith Yates",
+                        "url": "https://massey.com/app/search/homepage.asp"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "http://mcmillan.com/posts/index.html",
+                        "url": "http://mcmillan.com/posts/index.html"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Turn message position determine past. Modern word modern arrive us leave. Or our figure foot operation light."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2015-07-07T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -3896,14 +4756,93 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2013-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
+                "ASSIGNER": "louisrose@eight_3.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Lee, Butler and Ramos",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "newspaper",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "executive, five, provide"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Down-sized executive hierarchy"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "SPEECH",
+                        "name": "Tiffany Bailey",
+                        "url": "http://young.com/posts/home/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Kristen Davis",
+                        "url": "https://www.harrison-miller.org/"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Joseph Weber",
+                        "url": "https://campbell-murphy.com/app/app/author/"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Heather Lopez",
+                        "url": "http://moore-jackson.info/search/home.htm"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Jeffrey Johnson",
+                        "url": "https://smith.com/terms.jsp"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Brian Jones",
+                        "url": "http://www.rios-wells.com/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Joseph Bryant",
+                        "url": "https://barrett.net/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Joseph Sanford",
+                        "url": "https://le.biz/"
+                    }
+                ]
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Shake cause forward appear later American impact. Strategy benefit those get. This campaign agent parent process TV."
+                        "value": "Purpose back impact deal. Southern husband can enjoy eat others."
                     }
                 ]
             }
@@ -3911,7 +4850,7 @@
     },
     {
         "time": {
-            "created": "2018-05-15T00:00:00.000000Z",
+            "created": "2019-08-01T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -3927,7 +4866,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Teacher treatment number."
+                        "value": "Huge job through who language suddenly. Her let despite property. How machine quickly avoid their impact road."
                     }
                 ]
             }
@@ -3935,31 +4874,7 @@
     },
     {
         "time": {
-            "created": "2018-09-28T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:44.814266+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2013-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Drug yes middle around culture. Stand skin only arrive store. Tend wide might study task."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-07-16T00:00:00.000000Z",
+            "created": "2013-04-28T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -3975,7 +4890,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Career improve material mention interview direction. Garden individual support seat sit poor. Positive middle mind where own several."
+                        "value": "Sit my author clear hot tax mind leave. Expert his discuss cause push until."
                     }
                 ]
             }
@@ -3983,7 +4898,7 @@
     },
     {
         "time": {
-            "created": "2016-12-12T00:00:00.000000Z",
+            "created": "2018-07-11T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -3999,7 +4914,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Network live yard participant evening."
+                        "value": "Budget five town plan note event hot."
                     }
                 ]
             }
@@ -4007,90 +4922,7 @@
     },
     {
         "time": {
-            "created": "2020-10-24T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2014-0001",
-                "ASSIGNER": "stevenvalentine@whatever_18.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Brown-Benton",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "environment",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "goal, picture"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Total systemic portal"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://www.reynolds.com/posts/main/explore/author.htm",
-                        "url": "https://www.reynolds.com/posts/main/explore/author.htm"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Angela Anderson",
-                        "url": "http://drake.net/search.jsp"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://clark.biz/",
-                        "url": "https://clark.biz/"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://hall.biz/",
-                        "url": "https://hall.biz/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Sister born important. Be gun world paper future relate. Establish special early."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-08-25T00:00:00.000000Z",
+            "created": "2020-02-09T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -4099,52 +4931,28 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2014-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Program trouble offer huge space war. Same country different community choice strong apply in."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-05-24T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:45.907401+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2014-0004",
-                "ASSIGNER": "franciscoanderson@today_2.com",
+                "ASSIGNER": "michellemartin@mitre.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Davis, Johnson and Jacobson",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "by",
+                                        "product_name": "n/a",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "break, rock, goal, reflect, father, bag, foreign, place, door"
+                                                    "version_value": "n/a"
                                                 }
                                             ]
                                         }
                                     }
                                 ]
-                            }
+                            },
+                            "vendor_name": "n/a"
                         }
                     ]
                 }
@@ -4155,7 +4963,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Open-source 6thgeneration standardization"
+                                "value": "n/a"
                             }
                         ]
                     }
@@ -4164,54 +4972,44 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "GENERATION",
-                        "name": "Troy Gutierrez",
-                        "url": "http://richards.com/post/"
+                        "refsource": "ISSUE",
+                        "name": "Wyatt Patrick",
+                        "url": "http://www.mitchell.com/wp-content/tags/tags/about/"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Karen Rogers",
-                        "url": "https://www.willis.biz/list/tags/main/"
+                        "refsource": "FAR",
+                        "name": "Dwayne Gomez",
+                        "url": "http://wilson-jimenez.com/"
                     },
                     {
-                        "refsource": "ITEM",
-                        "name": "Eric Thompson",
-                        "url": "https://nunez.com/blog/homepage.html"
+                        "refsource": "EIGHT",
+                        "name": "Christian Murray",
+                        "url": "https://www.smith.com/faq/"
                     },
                     {
-                        "refsource": "PARTICULAR",
-                        "name": "Kathleen Garcia",
-                        "url": "http://www.morris.com/app/index/"
+                        "refsource": "UNIT",
+                        "name": "Larry Hicks",
+                        "url": "https://www.baker-garcia.org/terms/"
                     },
                     {
-                        "refsource": "THESE",
-                        "name": "Jeffrey Davis",
-                        "url": "http://www.wright-lamb.com/index.html"
+                        "refsource": "UNIT",
+                        "name": "Jeffrey Johnson",
+                        "url": "https://smith.com/terms.jsp"
                     },
                     {
-                        "refsource": "BECAUSE",
-                        "name": "Angelica Delgado",
-                        "url": "https://perry.com/register.html"
+                        "refsource": "TYPE",
+                        "name": "Philip Lee",
+                        "url": "https://sullivan.com/blog/search.htm"
                     },
                     {
-                        "refsource": "PARTICULAR",
-                        "name": "Kristy Lewis",
-                        "url": "http://www.berry-romero.com/search/tags/category/privacy.php"
+                        "refsource": "PHYSICAL",
+                        "name": "Lisa Fuller",
+                        "url": "https://www.gordon.com/app/register.asp"
                     },
                     {
-                        "refsource": "MISC",
-                        "name": "http://escobar.com/homepage.php",
-                        "url": "http://escobar.com/homepage.php"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Matthew Wheeler",
-                        "url": "http://www.davis.org/"
-                    },
-                    {
-                        "refsource": "THESE",
-                        "name": "Bradley Mckee",
-                        "url": "https://jones.com/post.asp"
+                        "refsource": "TYPE",
+                        "name": "Joseph Sanford",
+                        "url": "https://le.biz/"
                     }
                 ]
             },
@@ -4219,7 +5017,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Six scientist ever official wait not treatment. What wish big. Suddenly smile wide brother interest model reduce."
+                        "value": "Could people employee task grow produce. Form new off. Majority watch issue station want social others sell."
                     }
                 ]
             }
@@ -4227,86 +5025,8 @@
     },
     {
         "time": {
-            "created": "2019-03-05T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:46.100573+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2014-0005",
-                "ASSIGNER": "jameshansen@magazine_15.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Pitts, Williams and Hurst",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "century",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "issue, hotel, me, speak, list, dog"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Cross-platform logistical artificial intelligence"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Kathleen Garcia",
-                        "url": "http://www.morris.com/app/index/"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Jared Reyes",
-                        "url": "https://www.holloway.biz/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Position green let amount small rest without nice. Cold doctor no meet road national itself. Stuff student economy behavior happy."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-02-05T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:46.142113+00:00"
+            "created": "2020-11-20T00:00:00.000000Z",
+            "modified": null
         },
         "cve": {
             "data_type": "CVE",
@@ -4314,22 +5034,46 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2014-0006",
-                "ASSIGNER": "williammorris@certain_10.com",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Good same power sport heavy writer. Interview you sometimes close bank financial raise."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2015-11-03T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2014-0007",
+                "ASSIGNER": "debrasmith@body_2.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Collins PLC",
+                            "vendor_name": "Carter-Gill",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "science",
+                                        "product_name": "analysis",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "plant"
+                                                    "version_value": "field"
                                                 }
                                             ]
                                         }
@@ -4355,9 +5099,9 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "BILL",
-                        "name": "Matthew Gonzales",
-                        "url": "https://www.ross-jackson.com/privacy/"
+                        "refsource": "PHYSICAL",
+                        "name": "Lisa Fuller",
+                        "url": "https://www.gordon.com/app/register.asp"
                     }
                 ]
             },
@@ -4365,7 +5109,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Them not add recent. Attack listen officer develop level tax understand own. Mouth hold item newspaper land interview social behavior."
+                        "value": "Bank receive suddenly land."
                     }
                 ]
             }
@@ -4373,32 +5117,8 @@
     },
     {
         "time": {
-            "created": "2019-01-31T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:46.455629+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2014-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Itself answer much free team few name."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2019-05-20T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:46.663022+00:00"
+            "created": "2011-11-01T00:00:00.000000Z",
+            "modified": null
         },
         "cve": {
             "data_type": "CVE",
@@ -4406,22 +5126,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2014-0009",
-                "ASSIGNER": "stevenvalentine@whatever_18.com",
+                "ASSIGNER": "christophercook@theory_9.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Fernandez and Sons",
+                            "vendor_name": "Gomez Ltd",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "foreign",
+                                        "product_name": "a",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "heart, stuff, rate, receive"
+                                                    "version_value": "impact, least, perhaps, edge, enough"
                                                 }
                                             ]
                                         }
@@ -4438,7 +5158,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Digitized eco-centric frame"
+                                "value": "Diverse executive concept"
                             }
                         ]
                     }
@@ -4447,44 +5167,24 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "GENERATION",
-                        "name": "Troy Gutierrez",
-                        "url": "http://richards.com/post/"
+                        "refsource": "TREATMENT",
+                        "name": "Loretta Navarro",
+                        "url": "https://www.harris.org/wp-content/list/wp-content/about.html"
                     },
                     {
-                        "refsource": "BALL",
-                        "name": "Tammy Phillips",
-                        "url": "https://lee.com/posts/register/"
+                        "refsource": "TREATMENT",
+                        "name": "Joseph Weber",
+                        "url": "https://campbell-murphy.com/app/app/author/"
                     },
                     {
-                        "refsource": "CONFIRM",
-                        "name": "https://willis.info/main/",
-                        "url": "https://willis.info/main/"
+                        "refsource": "FAR",
+                        "name": "Brian Jones",
+                        "url": "http://www.rios-wells.com/"
                     },
                     {
-                        "refsource": "THESE",
-                        "name": "Jeffrey Davis",
-                        "url": "http://www.wright-lamb.com/index.html"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Jeffrey Garcia",
-                        "url": "http://www.vega-fuentes.com/search/list/about/"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "John Sullivan",
-                        "url": "http://www.palmer.com/author/"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "Katherine Richard",
-                        "url": "https://www.holland.biz/tag/app/about/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                        "refsource": "FAR",
+                        "name": "Brandon Johnson",
+                        "url": "http://johnson-bryant.info/category/"
                     }
                 ]
             },
@@ -4492,7 +5192,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Bit professional force."
+                        "value": "Health like team onto leader particularly serve work. A lawyer response. Fish experience of sort color. Him institution media think find message standard."
                     }
                 ]
             }
@@ -4500,8 +5200,106 @@
     },
     {
         "time": {
-            "created": "2012-08-10T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:47.060724+00:00"
+            "created": "2013-12-10T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2014-0010",
+                "ASSIGNER": "michellemartin@mitre.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "n/a",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "n/a"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            },
+                            "vendor_name": "n/a"
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "n/a"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Christian Murray",
+                        "url": "https://www.smith.com/faq/"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "http://mcmillan.com/posts/index.html",
+                        "url": "http://mcmillan.com/posts/index.html"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Michael Smith",
+                        "url": "http://medina.com/app/categories/category/category/"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Joseph Weber",
+                        "url": "https://campbell-murphy.com/app/app/author/"
+                    },
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Heather Lopez",
+                        "url": "http://moore-jackson.info/search/home.htm"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Charles Mcclure",
+                        "url": "http://sanchez-long.org/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Joseph Sanford",
+                        "url": "https://le.biz/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Wife machine over threat eye little. Item remember can behind new mother fill. Between with owner blood seat rich live."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2018-02-15T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:43.001418+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -4516,7 +5314,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Agreement sign evening mission make tonight team. Whose spring unit sit design."
+                        "value": "Charge travel management song. Line lose beyond give avoid message lead less. Maybe whose visit short shoulder."
                     }
                 ]
             }
@@ -4524,79 +5322,31 @@
     },
     {
         "time": {
-            "created": "2015-06-23T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:47.421911+00:00"
+            "created": "2015-11-19T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:43.622712+00:00"
         },
         "cve": {
             "data_type": "CVE",
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2015-0004",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "He natural fall finish receive. Out clearly community speech. Happy against impact concern summer history."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-03-20T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2015-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Result but risk agreement never. Four skill something tend none rather. Radio perhaps letter series quality money."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2013-09-19T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2016-0001",
-                "ASSIGNER": "stevenvalentine@whatever_18.com",
+                "ID": "CVE-2015-0006",
+                "ASSIGNER": "louisrose@eight_3.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Escobar, Padilla and Henderson",
+                            "vendor_name": "Mcdonald, Goodwin and Green",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "international",
+                                        "product_name": "kitchen",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "per, star, cover, no, less, item, year, green, any"
+                                                    "version_value": "door, organization, event, citizen, while, son"
                                                 }
                                             ]
                                         }
@@ -4613,7 +5363,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Total systemic portal"
+                                "value": "n/a"
                             }
                         ]
                     }
@@ -4622,64 +5372,39 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "THESE",
-                        "name": "Michael Carroll",
-                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
+                        "refsource": "FAR",
+                        "name": "Dwayne Gomez",
+                        "url": "http://wilson-jimenez.com/"
                     },
                     {
-                        "refsource": "BALL",
-                        "name": "April Silva",
-                        "url": "http://henry.biz/category/register/"
+                        "refsource": "TYPE",
+                        "name": "Elizabeth Bradley",
+                        "url": "https://www.williams.com/"
                     },
                     {
-                        "refsource": "THESE",
-                        "name": "Jeffrey Davis",
-                        "url": "http://www.wright-lamb.com/index.html"
+                        "refsource": "FAR",
+                        "name": "Kayla Jackson",
+                        "url": "http://www.rivera.com/wp-content/category/category/register.html"
                     },
                     {
-                        "refsource": "MISC",
-                        "name": "http://www.mcgee.biz/index/",
-                        "url": "http://www.mcgee.biz/index/"
+                        "refsource": "FAR",
+                        "name": "Brian Jones",
+                        "url": "http://www.rios-wells.com/"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Marcia Johnson",
-                        "url": "https://smith-perkins.net/tags/terms.jsp"
+                        "refsource": "SEA",
+                        "name": "William Kelley",
+                        "url": "http://www.jones-medina.info/category.php"
                     },
                     {
-                        "refsource": "MISC",
-                        "name": "http://escobar.com/homepage.php",
-                        "url": "http://escobar.com/homepage.php"
+                        "refsource": "TYPE",
+                        "name": "Joseph Sanford",
+                        "url": "https://le.biz/"
                     },
                     {
-                        "refsource": "BILL",
-                        "name": "Erin Taylor",
-                        "url": "http://www.miller.com/search/"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Amy Morgan",
-                        "url": "https://hart.com/list/post.php"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Matthew Wheeler",
-                        "url": "http://www.davis.org/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Scott Wise",
-                        "url": "http://www.gardner.com/main/post/"
-                    },
-                    {
-                        "refsource": "BECAUSE",
-                        "name": "Samantha Heath MD",
-                        "url": "http://knapp.com/blog/blog/category.php"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "John Sullivan",
-                        "url": "http://www.palmer.com/author/"
+                        "refsource": "SEA",
+                        "name": "Chad Villegas",
+                        "url": "http://hill-evans.com/list/tags/blog/author/"
                     }
                 ]
             },
@@ -4687,7 +5412,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Stage leave answer message. Buy protect her notice recent guess attack."
+                        "value": "Law return fast notice kid tax."
                     }
                 ]
             }
@@ -4695,7 +5420,202 @@
     },
     {
         "time": {
-            "created": "2019-04-06T00:00:00.000000Z",
+            "created": "2013-07-07T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:43.780724+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2015-0007",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Return fish task million maybe somebody eight certain. Town throughout live specific personal phone beyond."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2016-08-12T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:44.017808+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2015-0009",
+                "ASSIGNER": "bethanybryant@threat_12.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Foster, Malone and Adams",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "nearly",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "deal, treat"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "n/a"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "TREATMENT",
+                        "name": "Loretta Navarro",
+                        "url": "https://www.harris.org/wp-content/list/wp-content/about.html"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Wyatt Patrick",
+                        "url": "http://www.mitchell.com/wp-content/tags/tags/about/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Rebecca Johnson",
+                        "url": "https://james.com/wp-content/blog/main.jsp"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Rebecca Walker",
+                        "url": "https://johnson.com/main.htm"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Joseph Bryant",
+                        "url": "https://barrett.net/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Green even two. Community last enough. Process goal sport bed sport four."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2013-03-18T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:44.492438+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2016-0001",
+                "ASSIGNER": "ryanschmidt@man_8.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Carter-Wilson",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "pay",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "save, determine, benefit, understand, be, rock, people"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Diverse executive concept"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "FAR",
+                        "name": "Kayla Jackson",
+                        "url": "http://www.rivera.com/wp-content/category/category/register.html"
+                    },
+                    {
+                        "refsource": "CONFIRM",
+                        "name": "https://www.mendez.com/app/category.asp",
+                        "url": "https://www.mendez.com/app/category.asp"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Brandon Johnson",
+                        "url": "http://johnson-bryant.info/category/"
+                    },
+                    {
+                        "refsource": "SEA",
+                        "name": "Chad Villegas",
+                        "url": "http://hill-evans.com/list/tags/blog/author/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Property writer family national couple station page gas. Our ball value increase method chair realize decade."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2020-12-09T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -4704,22 +5624,46 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2016-0003",
-                "ASSIGNER": "jameshansen@magazine_15.com",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Attorney kind professional this mind professor. This natural former reach fill. Think yet believe change."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2012-07-04T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2016-0004",
+                "ASSIGNER": "richardbradshaw@public_20.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Brock-West",
+                            "vendor_name": "Miller-Morris",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "lay",
+                                        "product_name": "certainly",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "leg, drop, hair, sit, create, like, price"
+                                                    "version_value": "day, security"
                                                 }
                                             ]
                                         }
@@ -4736,7 +5680,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Total systemic portal"
+                                "value": "Streamlined background software"
                             }
                         ]
                     }
@@ -4745,44 +5689,9 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "GENERATION",
-                        "name": "Troy Gutierrez",
-                        "url": "http://richards.com/post/"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "Sara Erickson",
-                        "url": "http://www.williams.com/"
-                    },
-                    {
-                        "refsource": "THESE",
-                        "name": "Jeffrey Davis",
-                        "url": "http://www.wright-lamb.com/index.html"
-                    },
-                    {
-                        "refsource": "BILL",
-                        "name": "Mary Morales",
-                        "url": "http://www.adams-ramirez.com/search/"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Matthew Wheeler",
-                        "url": "http://www.davis.org/"
-                    },
-                    {
-                        "refsource": "THESE",
-                        "name": "Bradley Mckee",
-                        "url": "https://jones.com/post.asp"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "Katherine Richard",
-                        "url": "https://www.holland.biz/tag/app/about/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                        "refsource": "MISC",
+                        "name": "https://www.hernandez.com/list/wp-content/posts/post.php",
+                        "url": "https://www.hernandez.com/list/wp-content/posts/post.php"
                     }
                 ]
             },
@@ -4790,7 +5699,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Available site throw nothing successful social. Message small sometimes involve his drug pass. Some pull require person four debate right. Try lay phone anyone."
+                        "value": "Theory beat picture year special. Important wonder away medical."
                     }
                 ]
             }
@@ -4798,7 +5707,7 @@
     },
     {
         "time": {
-            "created": "2015-12-09T00:00:00.000000Z",
+            "created": "2014-11-03T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -4807,70 +5716,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2016-0005",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Any son administration dinner analysis general can. Evening option month. Business less leave actually."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-06-24T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:49.739324+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2016-0006",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Conference star push community provide trouble. Few easy but."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-02-07T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:49.988306+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2016-0007",
-                "ASSIGNER": "kimmiller@from_11.com",
+                "ASSIGNER": "jacobdouglas@senior_19.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Burns PLC",
+                            "vendor_name": "Velez-Murillo",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "apply",
+                                        "product_name": "can",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "central, technology, him, public"
+                                                    "version_value": "between, car, visit, his, magazine, ahead, cover, reflect"
                                                 }
                                             ]
                                         }
@@ -4887,7 +5748,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Digitized eco-centric frame"
+                                "value": "Integrated radical array"
                             }
                         ]
                     }
@@ -4896,54 +5757,54 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "THESE",
-                        "name": "Michael Carroll",
-                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
+                        "refsource": "TREATMENT",
+                        "name": "Loretta Navarro",
+                        "url": "https://www.harris.org/wp-content/list/wp-content/about.html"
                     },
                     {
-                        "refsource": "BALL",
-                        "name": "April Silva",
-                        "url": "http://henry.biz/category/register/"
+                        "refsource": "FAR",
+                        "name": "Rebecca Johnson",
+                        "url": "https://james.com/wp-content/blog/main.jsp"
                     },
                     {
-                        "refsource": "MISC",
-                        "name": "https://www.andrews.com/faq/",
-                        "url": "https://www.andrews.com/faq/"
+                        "refsource": "SEA",
+                        "name": "Deborah Odonnell",
+                        "url": "http://morrison.org/category/explore/main/author/"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Emily Gutierrez",
-                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
+                        "refsource": "SPEECH",
+                        "name": "Evan Gallagher",
+                        "url": "http://davis-edwards.net/search/main/list/post/"
                     },
                     {
                         "refsource": "CONFIRM",
-                        "name": "https://hall.biz/",
-                        "url": "https://hall.biz/"
+                        "name": "http://mcmillan.com/posts/index.html",
+                        "url": "http://mcmillan.com/posts/index.html"
                     },
                     {
-                        "refsource": "MISC",
-                        "name": "http://www.mcgee.biz/index/",
-                        "url": "http://www.mcgee.biz/index/"
+                        "refsource": "TREATMENT",
+                        "name": "Joseph Weber",
+                        "url": "https://campbell-murphy.com/app/app/author/"
                     },
                     {
-                        "refsource": "ITEM",
-                        "name": "Amy Morgan",
-                        "url": "https://hart.com/list/post.php"
+                        "refsource": "TREATMENT",
+                        "name": "Heather Lopez",
+                        "url": "http://moore-jackson.info/search/home.htm"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Dr. Roger Patterson Jr.",
-                        "url": "http://rodriguez.com/"
+                        "refsource": "TREATMENT",
+                        "name": "Tina Blevins",
+                        "url": "https://www.carney-hernandez.biz/category/explore/index.php"
                     },
                     {
-                        "refsource": "HAPPY",
-                        "name": "Joshua Walls",
-                        "url": "https://www.arroyo.biz/post/"
+                        "refsource": "PHYSICAL",
+                        "name": "Lisa Fuller",
+                        "url": "https://www.gordon.com/app/register.asp"
                     },
                     {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                        "refsource": "HIM",
+                        "name": "James Jones",
+                        "url": "http://stanley.org/app/posts/blog/faq.jsp"
                     }
                 ]
             },
@@ -4951,7 +5812,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Media face return authority wear item another. Hard manager believe act measure side."
+                        "value": "However reveal box Republican enter that crime."
                     }
                 ]
             }
@@ -4959,7 +5820,7 @@
     },
     {
         "time": {
-            "created": "2011-05-25T00:00:00.000000Z",
+            "created": "2020-11-16T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -4968,22 +5829,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2016-0008",
-                "ASSIGNER": "jasongray@concern_8.com",
+                "ASSIGNER": "calvinthompson@several_14.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Smith-Page",
+                            "vendor_name": "Ward, Moore and Strickland",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "should",
+                                        "product_name": "commercial",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "morning, hand, mind, side, you, attorney, which, any"
+                                                    "version_value": "happy, husband"
                                                 }
                                             ]
                                         }
@@ -5000,7 +5861,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Total systemic portal"
+                                "value": "Diverse executive concept"
                             }
                         ]
                     }
@@ -5010,38 +5871,23 @@
                 "reference_data": [
                     {
                         "refsource": "MISC",
-                        "name": "http://www.mendoza-ruiz.com/search/main/posts/terms.html",
-                        "url": "http://www.mendoza-ruiz.com/search/main/posts/terms.html"
+                        "name": "http://cowan.com/",
+                        "url": "http://cowan.com/"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Karen Rogers",
-                        "url": "https://www.willis.biz/list/tags/main/"
+                        "refsource": "TYPE",
+                        "name": "Elizabeth Bradley",
+                        "url": "https://www.williams.com/"
                     },
                     {
-                        "refsource": "CONFIRM",
-                        "name": "https://willis.info/main/",
-                        "url": "https://willis.info/main/"
+                        "refsource": "EIGHT",
+                        "name": "Michael Smith",
+                        "url": "http://medina.com/app/categories/category/category/"
                     },
                     {
-                        "refsource": "BILL",
-                        "name": "Matthew Gonzales",
-                        "url": "https://www.ross-jackson.com/privacy/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://escobar.com/homepage.php",
-                        "url": "http://escobar.com/homepage.php"
-                    },
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://www.morales.com/tags/main/home.asp",
-                        "url": "https://www.morales.com/tags/main/home.asp"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "John Sullivan",
-                        "url": "http://www.palmer.com/author/"
+                        "refsource": "SEA",
+                        "name": "Chad Villegas",
+                        "url": "http://hill-evans.com/list/tags/blog/author/"
                     }
                 ]
             },
@@ -5049,7 +5895,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "When home pick here. Toward land week."
+                        "value": "Weight necessary movie edge. Owner face bring staff else. Necessary no fill remain indeed prove that night."
                     }
                 ]
             }
@@ -5057,129 +5903,7 @@
     },
     {
         "time": {
-            "created": "2020-01-18T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:50.470691+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2016-0009",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Clearly show admit color role. Wind old have scene also."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-09-01T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:50.617098+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2016-0010",
-                "ASSIGNER": "janetdean@value_14.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Gonzalez, Warren and Keith",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "world",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "me, later, sort, light, writer"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Digitized eco-centric frame"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://www.reynolds.com/posts/main/explore/author.htm",
-                        "url": "https://www.reynolds.com/posts/main/explore/author.htm"
-                    },
-                    {
-                        "refsource": "THESE",
-                        "name": "Michael Carroll",
-                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "April Silva",
-                        "url": "http://henry.biz/category/register/"
-                    },
-                    {
-                        "refsource": "BILL",
-                        "name": "Mary Morales",
-                        "url": "http://www.adams-ramirez.com/search/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Marcia Johnson",
-                        "url": "https://smith-perkins.net/tags/terms.jsp"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Jared Reyes",
-                        "url": "https://www.holloway.biz/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Dr. Roger Patterson Jr.",
-                        "url": "http://rodriguez.com/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Administration away upon indeed. Success community and I story drive single."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2018-06-03T00:00:00.000000Z",
+            "created": "2020-12-03T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -5188,46 +5912,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2017-0001",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "And season member million. No majority follow. Collection scene drive."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2016-01-14T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2017-0002",
-                "ASSIGNER": "jasongray@concern_8.com",
+                "ASSIGNER": "julieweaver@property_15.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Robinson-Fischer",
+                            "vendor_name": "Sullivan-Williams",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "prove",
+                                        "product_name": "recently",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "one"
+                                                    "version_value": "operation, identify, since, civil, institution"
                                                 }
                                             ]
                                         }
@@ -5244,7 +5944,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Total systemic portal"
+                                "value": "Streamlined background software"
                             }
                         ]
                     }
@@ -5253,44 +5953,49 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "CONFIRM",
-                        "name": "https://willis.info/main/",
-                        "url": "https://willis.info/main/"
+                        "refsource": "SPEECH",
+                        "name": "Tiffany Bailey",
+                        "url": "http://young.com/posts/home/"
                     },
                     {
-                        "refsource": "CONFIRM",
-                        "name": "https://hall.biz/",
-                        "url": "https://hall.biz/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Catherine Adams",
-                        "url": "https://www.sanchez.com/posts/posts/app/author/"
+                        "refsource": "EIGHT",
+                        "name": "Christian Murray",
+                        "url": "https://www.smith.com/faq/"
                     },
                     {
                         "refsource": "MISC",
-                        "name": "http://www.mcgee.biz/index/",
-                        "url": "http://www.mcgee.biz/index/"
+                        "name": "https://www.hernandez.com/list/wp-content/posts/post.php",
+                        "url": "https://www.hernandez.com/list/wp-content/posts/post.php"
                     },
                     {
-                        "refsource": "MISC",
-                        "name": "http://escobar.com/homepage.php",
-                        "url": "http://escobar.com/homepage.php"
+                        "refsource": "SPEECH",
+                        "name": "Evan Gallagher",
+                        "url": "http://davis-edwards.net/search/main/list/post/"
                     },
                     {
-                        "refsource": "BILL",
-                        "name": "Erin Taylor",
-                        "url": "http://www.miller.com/search/"
+                        "refsource": "PHYSICAL",
+                        "name": "Stacy Salazar",
+                        "url": "https://mckenzie.com/main/"
                     },
                     {
-                        "refsource": "THESE",
-                        "name": "Bradley Mckee",
-                        "url": "https://jones.com/post.asp"
+                        "refsource": "UNIT",
+                        "name": "Jeffrey Johnson",
+                        "url": "https://smith.com/terms.jsp"
                     },
                     {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
+                        "refsource": "CONFIRM",
+                        "name": "https://www.mendez.com/app/category.asp",
+                        "url": "https://www.mendez.com/app/category.asp"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Drew Ford",
+                        "url": "https://www.reynolds.com/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Joseph Sanford",
+                        "url": "https://le.biz/"
                     }
                 ]
             },
@@ -5298,7 +6003,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Ten make left doctor practice however tough."
+                        "value": "Design past face yet back. How day five hour modern minute."
                     }
                 ]
             }
@@ -5306,8 +6011,8 @@
     },
     {
         "time": {
-            "created": "2020-03-08T00:00:00.000000Z",
-            "modified": null
+            "created": "2013-08-12T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:46.679660+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -5315,22 +6020,22 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2017-0004",
-                "ASSIGNER": "codymurphy@cost_12.com",
+                "ASSIGNER": "logannewman@film_17.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Manning and Sons",
+                            "vendor_name": "Olson, Richards and Phillips",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "thus",
+                                        "product_name": "seem",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "general, with, apply, partner, good, story, return"
+                                                    "version_value": "friend, PM, season"
                                                 }
                                             ]
                                         }
@@ -5347,7 +6052,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Cross-platform logistical artificial intelligence"
+                                "value": "Customer-focused asymmetric database"
                             }
                         ]
                     }
@@ -5356,29 +6061,9 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "DARK",
-                        "name": "Brett Krause",
-                        "url": "http://curtis-campbell.com/"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "Sara Erickson",
-                        "url": "http://www.williams.com/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://www.andrews.com/faq/",
-                        "url": "https://www.andrews.com/faq/"
-                    },
-                    {
-                        "refsource": "ITEM",
-                        "name": "Amy Morgan",
-                        "url": "https://hart.com/list/post.php"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "Karen Ray",
-                        "url": "https://www.ruiz.org/"
+                        "refsource": "PHYSICAL",
+                        "name": "Stacy Salazar",
+                        "url": "https://mckenzie.com/main/"
                     }
                 ]
             },
@@ -5386,7 +6071,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Party truth heart me former act avoid country. Purpose teach Democrat left."
+                        "value": "Program soldier worry firm scientist ability each. Commercial product gas soon whom allow."
                     }
                 ]
             }
@@ -5394,8 +6079,8 @@
     },
     {
         "time": {
-            "created": "2019-02-17T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:51.418178+00:00"
+            "created": "2020-02-12T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:46.950259+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -5410,7 +6095,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Involve ask important mother laugh along. Others white suffer three movement raise reveal."
+                        "value": "Mouth system act amount away. Practice trade child kitchen evening girl others. Speak market worry."
                     }
                 ]
             }
@@ -5418,15 +6103,171 @@
     },
     {
         "time": {
-            "created": "2018-02-08T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:51.575737+00:00"
+            "created": "2017-04-11T00:00:00.000000Z",
+            "modified": null
         },
         "cve": {
             "data_type": "CVE",
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2017-0006",
+                "ID": "CVE-2018-0001",
+                "ASSIGNER": "annecherry@student_18.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Farrell Inc",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "woman",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "three, song"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Integrated radical array"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "UNIT",
+                        "name": "Larry Hicks",
+                        "url": "https://www.baker-garcia.org/terms/"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Michael Smith",
+                        "url": "http://medina.com/app/categories/category/category/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Consider space price parent. Look set federal whether TV. Ever man child easy."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2012-07-09T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:47.990380+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2018-0002",
+                "ASSIGNER": "calvinthompson@several_14.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Hall, Adkins and Dunn",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "about",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "in, particularly, husband, place, concern, floor, like, culture"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Customer-focused asymmetric database"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "UNIT",
+                        "name": "Jeremiah Cobb",
+                        "url": "http://andrade.com/author.php"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Amy Graves",
+                        "url": "https://taylor.net/privacy/"
+                    },
+                    {
+                        "refsource": "UNIT",
+                        "name": "Kristen Davis",
+                        "url": "https://www.harrison-miller.org/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Joseph Bryant",
+                        "url": "https://barrett.net/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "True feeling picture candidate service piece participant couple. Black section age pressure."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2018-01-16T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2018-0003",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -5434,7 +6275,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Include eat garden upon small night sign. Vote several thank then attorney trouble amount fund."
+                        "value": "Able doctor else understand fast."
                     }
                 ]
             }
@@ -5442,7 +6283,7 @@
     },
     {
         "time": {
-            "created": "2011-08-09T00:00:00.000000Z",
+            "created": "2012-01-30T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -5450,23 +6291,23 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2017-0007",
-                "ASSIGNER": "jameshansen@magazine_15.com",
+                "ID": "CVE-2018-0005",
+                "ASSIGNER": "annecherry@student_18.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Robbins Group",
+                            "vendor_name": "Rodriguez, Bennett and Grant",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "on",
+                                        "product_name": "star",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "represent, movement, political, hair, itself, everybody, when"
+                                                    "version_value": "main, then, high, baby, page, born, gas, marriage, huge"
                                                 }
                                             ]
                                         }
@@ -5483,7 +6324,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "De-engineered uniform open system"
+                                "value": "Diverse executive concept"
                             }
                         ]
                     }
@@ -5492,19 +6333,19 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "DARK",
-                        "name": "Karen Rogers",
-                        "url": "https://www.willis.biz/list/tags/main/"
+                        "refsource": "EIGHT",
+                        "name": "Brenda Medina",
+                        "url": "http://wang-collins.info/faq.html"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Jeffrey Garcia",
-                        "url": "http://www.vega-fuentes.com/search/list/about/"
+                        "refsource": "UNIT",
+                        "name": "Jeffrey Johnson",
+                        "url": "https://smith.com/terms.jsp"
                     },
                     {
-                        "refsource": "BALL",
-                        "name": "Katherine Richard",
-                        "url": "https://www.holland.biz/tag/app/about/"
+                        "refsource": "UNIT",
+                        "name": "Drew Ford",
+                        "url": "https://www.reynolds.com/"
                     }
                 ]
             },
@@ -5512,7 +6353,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Front gun value country offer maintain break back. Movement move require onto. Executive herself right."
+                        "value": "Hour treatment system response various deep. Network many bag. Father create decide event nation business former account."
                     }
                 ]
             }
@@ -5520,7 +6361,7 @@
     },
     {
         "time": {
-            "created": "2011-07-24T00:00:00.000000Z",
+            "created": "2013-05-27T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -5528,47 +6369,23 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2017-0008",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Police every answer land pay next detail. Around case affect woman picture. According mouth action whom green admit nearly."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2015-03-03T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2017-0010",
-                "ASSIGNER": "dominiquefrench@ok_17.com",
+                "ID": "CVE-2018-0007",
+                "ASSIGNER": "richardbradshaw@public_20.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Taylor Ltd",
+                            "vendor_name": "Dunlap Group",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "you",
+                                        "product_name": "affect",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "nice, small, see, pick, something, not, image, newspaper, American"
+                                                    "version_value": "seat, boy"
                                                 }
                                             ]
                                         }
@@ -5585,7 +6402,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Digitized eco-centric frame"
+                                "value": "Streamlined background software"
                             }
                         ]
                     }
@@ -5594,117 +6411,29 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "ITEM",
-                        "name": "Matthew Wheeler",
-                        "url": "http://www.davis.org/"
+                        "refsource": "MISC",
+                        "name": "https://jacobson.net/category/tags/list/register.htm",
+                        "url": "https://jacobson.net/category/tags/list/register.htm"
                     },
                     {
-                        "refsource": "THOUGH",
-                        "name": "John Sullivan",
-                        "url": "http://www.palmer.com/author/"
+                        "refsource": "FAR",
+                        "name": "Kayla Jackson",
+                        "url": "http://www.rivera.com/wp-content/category/category/register.html"
                     },
                     {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
+                        "refsource": "TREATMENT",
+                        "name": "Heather Lopez",
+                        "url": "http://moore-jackson.info/search/home.htm"
+                    },
                     {
-                        "lang": "eng",
-                        "value": "Piece report here. Maybe wait society soon war toward our. Year country education couple board. Movement of gun phone building."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2021-01-29T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2018-0004",
-                "ASSIGNER": "jasongray@concern_8.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Combs, Mcbride and Henderson",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "more",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "shake, station, newspaper, true, three, cut, letter, hundred, family"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Open-source 6thgeneration standardization"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Angela Anderson",
-                        "url": "http://drake.net/search.jsp"
+                        "refsource": "UNIT",
+                        "name": "Jeffrey Johnson",
+                        "url": "https://smith.com/terms.jsp"
                     },
                     {
                         "refsource": "CONFIRM",
-                        "name": "http://www.thompson-gibson.info/post.htm",
-                        "url": "http://www.thompson-gibson.info/post.htm"
-                    },
-                    {
-                        "refsource": "HAPPY",
-                        "name": "Christopher Lewis",
-                        "url": "https://www.saunders-wright.com/"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "April Silva",
-                        "url": "http://henry.biz/category/register/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Kathleen Garcia",
-                        "url": "http://www.morris.com/app/index/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.mcgee.biz/index/",
-                        "url": "http://www.mcgee.biz/index/"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "John Sullivan",
-                        "url": "http://www.palmer.com/author/"
+                        "name": "https://www.collins.org/search/main/privacy.html",
+                        "url": "https://www.collins.org/search/main/privacy.html"
                     }
                 ]
             },
@@ -5712,7 +6441,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Reality total course reveal. Work collection boy serve."
+                        "value": "Focus stage marriage office even. Skin knowledge memory throw lot few its. Form I task executive. Campaign top huge military."
                     }
                 ]
             }
@@ -5720,7 +6449,7 @@
     },
     {
         "time": {
-            "created": "2020-02-16T00:00:00.000000Z",
+            "created": "2013-06-01T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -5728,95 +6457,7 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2018-0006",
-                "ASSIGNER": "jameshansen@magazine_15.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Carson-Collins",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "drop",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "my, game, crime, inside, experience, reason, scientist, plan, without"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "De-engineered uniform open system"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://www.reynolds.com/posts/main/explore/author.htm",
-                        "url": "https://www.reynolds.com/posts/main/explore/author.htm"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.mendoza-ruiz.com/search/main/posts/terms.html",
-                        "url": "http://www.mendoza-ruiz.com/search/main/posts/terms.html"
-                    },
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Patrick Ross",
-                        "url": "http://www.aguilar.com/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Emily Gutierrez",
-                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
-                    },
-                    {
-                        "refsource": "BECAUSE",
-                        "name": "Angelica Delgado",
-                        "url": "https://perry.com/register.html"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Defense box sport wear recent. Side nor describe inside bring."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2012-12-16T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2018-0010",
+                "ID": "CVE-2018-0008",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -5824,7 +6465,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Price environment factor in around. Treatment true any reality owner. Firm there real who movement."
+                        "value": "Wish less environment hold Democrat. Cause somebody here."
                     }
                 ]
             }
@@ -5832,7 +6473,31 @@
     },
     {
         "time": {
-            "created": "2018-01-08T00:00:00.000000Z",
+            "created": "2015-12-27T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:48.863372+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2018-0009",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Difficult write nothing time those. His entire inside way interest husband."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2019-10-09T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -5848,7 +6513,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Consider surface book pull low but. Form myself small quickly blood process that practice."
+                        "value": "Finally enough I after risk product. Hear black they. Guy grow poor nation."
                     }
                 ]
             }
@@ -5856,8 +6521,8 @@
     },
     {
         "time": {
-            "created": "2011-09-01T00:00:00.000000Z",
-            "modified": null
+            "created": "2015-01-06T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:49.297846+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -5865,93 +6530,14 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2019-0002",
-                "ASSIGNER": "jameshansen@magazine_15.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Hill, Williams and Wright",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "beautiful",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "put, water, place, soon, take, world"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "n/a"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "BECAUSE",
-                        "name": "Kristina Carter",
-                        "url": "http://www.pennington.com/explore/index/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Karen Rogers",
-                        "url": "https://www.willis.biz/list/tags/main/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://www.andrews.com/faq/",
-                        "url": "https://www.andrews.com/faq/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.mcgee.biz/index/",
-                        "url": "http://www.mcgee.biz/index/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://escobar.com/homepage.php",
-                        "url": "http://escobar.com/homepage.php"
-                    },
-                    {
-                        "refsource": "BILL",
-                        "name": "Erin Taylor",
-                        "url": "http://www.miller.com/search/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Dr. Roger Patterson Jr.",
-                        "url": "http://rodriguez.com/"
-                    },
-                    {
-                        "refsource": "THOUGH",
-                        "name": "Allison Jensen",
-                        "url": "https://www.miller.com/terms.htm"
-                    }
-                ]
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Plan miss lay material. Little difficult rock though effect. History information purpose usually scientist dog simple."
+                        "value": "Painting stuff see year identify. Board new use large later. Year best friend ahead general only threat eye."
                     }
                 ]
             }
@@ -5959,7 +6545,7 @@
     },
     {
         "time": {
-            "created": "2019-09-21T00:00:00.000000Z",
+            "created": "2016-01-29T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -5975,7 +6561,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Occur become read door investment fund court two. Year Mr back star year hotel director. Quite few star."
+                        "value": "Church spend many past. Hear phone somebody attack beat drop."
                     }
                 ]
             }
@@ -5983,15 +6569,15 @@
     },
     {
         "time": {
-            "created": "2017-04-06T00:00:00.000000Z",
-            "modified": null
+            "created": "2020-06-14T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:49.534435+00:00"
         },
         "cve": {
             "data_type": "CVE",
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2019-0010",
+                "ID": "CVE-2019-0004",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -5999,7 +6585,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Spend research key miss. System across ability quite college learn."
+                        "value": "That whole audience fund idea. Black color see charge him military question. Modern most ok what wind record though."
                     }
                 ]
             }
@@ -6007,31 +6593,31 @@
     },
     {
         "time": {
-            "created": "2015-09-09T00:00:00.000000Z",
-            "modified": null
+            "created": "2019-10-02T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:49.717360+00:00"
         },
         "cve": {
             "data_type": "CVE",
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2020-0001",
-                "ASSIGNER": "rebeccahenry@difference_16.com",
+                "ID": "CVE-2019-0005",
+                "ASSIGNER": "cynthiabrooks@bad_10.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Ward, Brown and Vargas",
+                            "vendor_name": "Le-Duran",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "way",
+                                        "product_name": "head",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "force, success, public, second, herself, those"
+                                                    "version_value": "protect"
                                                 }
                                             ]
                                         }
@@ -6048,7 +6634,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "Open-source 6thgeneration standardization"
+                                "value": "Diverse executive concept"
                             }
                         ]
                     }
@@ -6057,54 +6643,44 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "BECAUSE",
-                        "name": "Kristina Carter",
-                        "url": "http://www.pennington.com/explore/index/"
+                        "refsource": "ISSUE",
+                        "name": "Wyatt Patrick",
+                        "url": "http://www.mitchell.com/wp-content/tags/tags/about/"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Karen Rogers",
-                        "url": "https://www.willis.biz/list/tags/main/"
+                        "refsource": "FAR",
+                        "name": "Rebecca Johnson",
+                        "url": "https://james.com/wp-content/blog/main.jsp"
                     },
                     {
-                        "refsource": "ITEM",
-                        "name": "Eric Thompson",
-                        "url": "https://nunez.com/blog/homepage.html"
+                        "refsource": "EIGHT",
+                        "name": "Rebecca Walker",
+                        "url": "https://johnson.com/main.htm"
                     },
                     {
-                        "refsource": "BILL",
-                        "name": "Mary Morales",
-                        "url": "http://www.adams-ramirez.com/search/"
-                    },
-                    {
-                        "refsource": "BECAUSE",
-                        "name": "Angelica Delgado",
-                        "url": "https://perry.com/register.html"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Logan Vazquez",
-                        "url": "http://wilson.com/main/blog/login.asp"
+                        "refsource": "ISSUE",
+                        "name": "Jennifer Morales",
+                        "url": "https://sutton-melton.com/category/category/category/register.asp"
                     },
                     {
                         "refsource": "MISC",
-                        "name": "http://escobar.com/homepage.php",
-                        "url": "http://escobar.com/homepage.php"
+                        "name": "https://jacobson.net/category/tags/list/register.htm",
+                        "url": "https://jacobson.net/category/tags/list/register.htm"
                     },
                     {
-                        "refsource": "HAPPY",
-                        "name": "Mr. Matthew Nguyen MD",
-                        "url": "https://www.decker.com/explore/blog/faq.jsp"
+                        "refsource": "TYPE",
+                        "name": "Joseph Bryant",
+                        "url": "https://barrett.net/"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Scott Wise",
-                        "url": "http://www.gardner.com/main/post/"
+                        "refsource": "TYPE",
+                        "name": "Philip Lee",
+                        "url": "https://sullivan.com/blog/search.htm"
                     },
                     {
-                        "refsource": "HAPPY",
-                        "name": "Joshua Walls",
-                        "url": "https://www.arroyo.biz/post/"
+                        "refsource": "SEA",
+                        "name": "Chad Villegas",
+                        "url": "http://hill-evans.com/list/tags/blog/author/"
                     }
                 ]
             },
@@ -6112,7 +6688,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Morning ask meeting whose could star. Low trade sing keep guy. Edge hair model ready notice door money baby."
+                        "value": "Radio decision quickly class certainly try decade. Treat response impact main newspaper before. Movement wear century nice per gun be write."
                     }
                 ]
             }
@@ -6120,7 +6696,79 @@
     },
     {
         "time": {
-            "created": "2014-06-29T00:00:00.000000Z",
+            "created": "2012-02-21T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:50.086181+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2019-0007",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Cost moment spend impact Congress need. Type activity system."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2021-02-27T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:50.240332+00:00"
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2019-0008",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Wait own play pick project. Audience whatever impact face country modern have dog. Fund reduce become military. Practice fast where never person crime."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2017-04-05T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2020-0001",
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "Drive door very throw. Because be fish in. Stay suggest product material."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2021-04-06T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -6136,7 +6784,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Their five professor politics rate. Along per wide tree single. Kind discuss right interest our rich."
+                        "value": "Bit trial hold rise yeah heart assume behavior. Exactly idea understand movement air computer. Capital run bit person assume professor quickly."
                     }
                 ]
             }
@@ -6144,7 +6792,7 @@
     },
     {
         "time": {
-            "created": "2021-03-15T00:00:00.000000Z",
+            "created": "2020-04-13T00:00:00.000000Z",
             "modified": null
         },
         "cve": {
@@ -6152,7 +6800,7 @@
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2020-0004",
+                "ID": "CVE-2020-0007",
                 "ASSIGNER": "cve@mitre.org",
                 "STATE": "REJECT"
             },
@@ -6160,7 +6808,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Something want such early prove popular miss. Song section peace senior organization artist. Our service entire law summer."
+                        "value": "Describe source population must meet. Under guess suddenly least."
                     }
                 ]
             }
@@ -6168,154 +6816,8 @@
     },
     {
         "time": {
-            "created": "2020-03-10T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2020-0005",
-                "ASSIGNER": "janetdean@value_14.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Bolton, Hammond and Gordon",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "step",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "affect, home, edge, people, prove, whole"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "Total systemic portal"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "CONFIRM",
-                        "name": "https://www.reynolds.com/posts/main/explore/author.htm",
-                        "url": "https://www.reynolds.com/posts/main/explore/author.htm"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Emily Gutierrez",
-                        "url": "https://gonzalez.org/main/wp-content/tags/home.htm"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Quickly positive people evening base statement issue. Simply name campaign many mind center. Also clear majority which within technology."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2017-03-27T00:00:00.000000Z",
-            "modified": null
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2020-0006",
-                "ASSIGNER": "dominiquefrench@ok_17.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Wallace, Barajas and Mullins",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "manager",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "grow, happen, cause, soon, entire, wish, character"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "De-engineered uniform open system"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Catherine Adams",
-                        "url": "https://www.sanchez.com/posts/posts/app/author/"
-                    },
-                    {
-                        "refsource": "BILL",
-                        "name": "Erin Taylor",
-                        "url": "http://www.miller.com/search/"
-                    }
-                ]
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Treat note several single less available record. Away safe another good carry."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2021-02-07T00:00:00.000000Z",
-            "modified": null
+            "created": "2012-05-22T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:52.410612+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -6330,7 +6832,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Nearly bad right personal decide join. What represent money practice mission."
+                        "value": "Listen age position since radio. Leave great general sit investment show rise. Future under could Congress shake different none. Institution travel fund during become series."
                     }
                 ]
             }
@@ -6338,55 +6840,31 @@
     },
     {
         "time": {
-            "created": "2013-11-04T00:00:00.000000Z",
-            "modified": null
+            "created": "2015-11-15T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:52.592931+00:00"
         },
         "cve": {
             "data_type": "CVE",
             "data_format": "MITRE",
             "data_version": "4.0",
             "CVE_data_meta": {
-                "ID": "CVE-2021-0003",
-                "ASSIGNER": "cve@mitre.org",
-                "STATE": "REJECT"
-            },
-            "description": {
-                "description_data": [
-                    {
-                        "lang": "eng",
-                        "value": "Bank morning same pretty radio. Who join happy billion good lawyer chair."
-                    }
-                ]
-            }
-        }
-    },
-    {
-        "time": {
-            "created": "2020-08-02T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:57.522905+00:00"
-        },
-        "cve": {
-            "data_type": "CVE",
-            "data_format": "MITRE",
-            "data_version": "4.0",
-            "CVE_data_meta": {
-                "ID": "CVE-2021-0004",
-                "ASSIGNER": "franciscoanderson@today_2.com",
+                "ID": "CVE-2021-0001",
+                "ASSIGNER": "annecherry@student_18.com",
                 "STATE": "PUBLIC"
             },
             "affects": {
                 "vendor": {
                     "vendor_data": [
                         {
-                            "vendor_name": "Myers, Snow and Christian",
+                            "vendor_name": "Hardy, Robbins and Riley",
                             "product": {
                                 "product_data": [
                                     {
-                                        "product_name": "away",
+                                        "product_name": "task",
                                         "version": {
                                             "version_data": [
                                                 {
-                                                    "version_value": "fine, sometimes, visit, various, two, maintain"
+                                                    "version_value": "per"
                                                 }
                                             ]
                                         }
@@ -6403,7 +6881,7 @@
                         "description": [
                             {
                                 "lang": "eng",
-                                "value": "De-engineered uniform open system"
+                                "value": "Customer-focused asymmetric database"
                             }
                         ]
                     }
@@ -6412,19 +6890,39 @@
             "references": {
                 "reference_data": [
                     {
-                        "refsource": "THESE",
-                        "name": "Michael Carroll",
-                        "url": "http://jones-blackburn.org/blog/tag/posts/post/"
+                        "refsource": "UNIT",
+                        "name": "Jeremiah Cobb",
+                        "url": "http://andrade.com/author.php"
+                    },
+                    {
+                        "refsource": "ISSUE",
+                        "name": "Amy Graves",
+                        "url": "https://taylor.net/privacy/"
+                    },
+                    {
+                        "refsource": "EIGHT",
+                        "name": "Christian Murray",
+                        "url": "https://www.smith.com/faq/"
                     },
                     {
                         "refsource": "MISC",
-                        "name": "https://clark.biz/",
-                        "url": "https://clark.biz/"
+                        "name": "https://jacobson.net/category/tags/list/register.htm",
+                        "url": "https://jacobson.net/category/tags/list/register.htm"
                     },
                     {
-                        "refsource": "DARK",
-                        "name": "Dr. Roger Patterson Jr.",
-                        "url": "http://rodriguez.com/"
+                        "refsource": "SEA",
+                        "name": "William Kelley",
+                        "url": "http://www.jones-medina.info/category.php"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Joseph Bryant",
+                        "url": "https://barrett.net/"
+                    },
+                    {
+                        "refsource": "TYPE",
+                        "name": "Joseph Sanford",
+                        "url": "https://le.biz/"
                     }
                 ]
             },
@@ -6432,7 +6930,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Deep all certain. Then send how dark pick specific. Not general face any cup."
+                        "value": "Pretty even economic paper dream executive walk. Month including goal doctor detail trade."
                     }
                 ]
             }
@@ -6440,8 +6938,81 @@
     },
     {
         "time": {
-            "created": "2018-07-31T00:00:00.000000Z",
-            "modified": "2021-04-21 02:08:58.206514+00:00"
+            "created": "2013-02-26T00:00:00.000000Z",
+            "modified": null
+        },
+        "cve": {
+            "data_type": "CVE",
+            "data_format": "MITRE",
+            "data_version": "4.0",
+            "CVE_data_meta": {
+                "ID": "CVE-2021-0006",
+                "ASSIGNER": "logannewman@film_17.com",
+                "STATE": "PUBLIC"
+            },
+            "affects": {
+                "vendor": {
+                    "vendor_data": [
+                        {
+                            "vendor_name": "Atkinson Group",
+                            "product": {
+                                "product_data": [
+                                    {
+                                        "product_name": "build",
+                                        "version": {
+                                            "version_data": [
+                                                {
+                                                    "version_value": "in"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            },
+            "problemtype": {
+                "problemtype_data": [
+                    {
+                        "description": [
+                            {
+                                "lang": "eng",
+                                "value": "Customer-focused asymmetric database"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "references": {
+                "reference_data": [
+                    {
+                        "refsource": "UNIT",
+                        "name": "Drew Ford",
+                        "url": "https://www.reynolds.com/"
+                    },
+                    {
+                        "refsource": "FAR",
+                        "name": "Brandon Johnson",
+                        "url": "http://johnson-bryant.info/category/"
+                    }
+                ]
+            },
+            "description": {
+                "description_data": [
+                    {
+                        "lang": "eng",
+                        "value": "For huge window read democratic. Development responsibility population remain happen mention baby."
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "time": {
+            "created": "2013-05-13T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:53.640602+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -6456,7 +7027,7 @@
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Community red into model east. Success him use. Tough growth resource simply factor."
+                        "value": "Energy fill pay indeed life. Law probably government build step society. Carry thank kid pass sport second defense."
                     }
                 ]
             }
@@ -6464,8 +7035,8 @@
     },
     {
         "time": {
-            "created": "2017-11-01T00:00:00.000000Z",
-            "modified": null
+            "created": "2018-04-29T00:00:00.000000Z",
+            "modified": "2021-05-11 02:56:53.789837+00:00"
         },
         "cve": {
             "data_type": "CVE",
@@ -6473,98 +7044,14 @@
             "data_version": "4.0",
             "CVE_data_meta": {
                 "ID": "CVE-2021-0009",
-                "ASSIGNER": "jasongray@concern_8.com",
-                "STATE": "PUBLIC"
-            },
-            "affects": {
-                "vendor": {
-                    "vendor_data": [
-                        {
-                            "vendor_name": "Valenzuela, Hughes and Ramirez",
-                            "product": {
-                                "product_data": [
-                                    {
-                                        "product_name": "choice",
-                                        "version": {
-                                            "version_data": [
-                                                {
-                                                    "version_value": "girl, rest, view, cultural"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                ]
-                            }
-                        }
-                    ]
-                }
-            },
-            "problemtype": {
-                "problemtype_data": [
-                    {
-                        "description": [
-                            {
-                                "lang": "eng",
-                                "value": "De-engineered uniform open system"
-                            }
-                        ]
-                    }
-                ]
-            },
-            "references": {
-                "reference_data": [
-                    {
-                        "refsource": "GENERATION",
-                        "name": "Angela Anderson",
-                        "url": "http://drake.net/search.jsp"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.mendoza-ruiz.com/search/main/posts/terms.html",
-                        "url": "http://www.mendoza-ruiz.com/search/main/posts/terms.html"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "April Silva",
-                        "url": "http://henry.biz/category/register/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "https://www.andrews.com/faq/",
-                        "url": "https://www.andrews.com/faq/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Catherine Adams",
-                        "url": "https://www.sanchez.com/posts/posts/app/author/"
-                    },
-                    {
-                        "refsource": "MISC",
-                        "name": "http://www.mcgee.biz/index/",
-                        "url": "http://www.mcgee.biz/index/"
-                    },
-                    {
-                        "refsource": "DARK",
-                        "name": "Dr. Roger Patterson Jr.",
-                        "url": "http://rodriguez.com/"
-                    },
-                    {
-                        "refsource": "BALL",
-                        "name": "Karen Ray",
-                        "url": "https://www.ruiz.org/"
-                    },
-                    {
-                        "refsource": "PARTICULAR",
-                        "name": "Teresa Graves",
-                        "url": "http://rodriguez-dunn.net/blog/tags/faq/"
-                    }
-                ]
+                "ASSIGNER": "cve@mitre.org",
+                "STATE": "REJECT"
             },
             "description": {
                 "description_data": [
                     {
                         "lang": "eng",
-                        "value": "Live wind glass leader. Goal power well. Live just successful fund hot administration."
+                        "value": "Ready wall decade. Stuff film buy human. Plan stand seek trade home attack. Rule present also yard."
                     }
                 ]
             }

--- a/datadump/pre-population/orgs.json
+++ b/datadump/pre-population/orgs.json
@@ -9,11 +9,11 @@
         "name": "MITRE Corporation",
         "short_name": "mitre",
         "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
         },
         "policies": {
-            "id_quota": 829
+            "id_quota": 850
         }
     },
     {
@@ -22,14 +22,14 @@
                 "CNA"
             ]
         },
-        "name": "Wise LLC",
-        "short_name": "here_1",
+        "name": "Watson, Jones and Hall",
+        "short_name": "agree_1",
         "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
         },
         "policies": {
-            "id_quota": 511
+            "id_quota": 1161
         }
     },
     {
@@ -38,14 +38,14 @@
                 "CNA"
             ]
         },
-        "name": "Robinson-Johnson",
-        "short_name": "today_2",
+        "name": "Buckley, Watkins and Avery",
+        "short_name": "body_2",
         "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
         },
         "policies": {
-            "id_quota": 736
+            "id_quota": 542
         }
     },
     {
@@ -54,14 +54,14 @@
                 "CNA"
             ]
         },
-        "name": "Miller-Brown",
-        "short_name": "song_3",
+        "name": "Barnes, Hill and Smith",
+        "short_name": "eight_3",
         "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
         },
         "policies": {
-            "id_quota": 968
+            "id_quota": 735
         }
     },
     {
@@ -70,14 +70,14 @@
                 "CNA"
             ]
         },
-        "name": "Mendez-Ramos",
-        "short_name": "technology_4",
+        "name": "Warner-Carter",
+        "short_name": "suddenly_4",
         "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
         },
         "policies": {
-            "id_quota": 588
+            "id_quota": 911
         }
     },
     {
@@ -86,14 +86,14 @@
                 "CNA"
             ]
         },
-        "name": "Sanchez Ltd",
-        "short_name": "man_5",
+        "name": "Cook-Torres",
+        "short_name": "film_5",
         "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
         },
         "policies": {
-            "id_quota": 1323
+            "id_quota": 691
         }
     },
     {
@@ -102,14 +102,14 @@
                 "CNA"
             ]
         },
-        "name": "Rose-Porter",
-        "short_name": "only_6",
+        "name": "Velasquez-Taylor",
+        "short_name": "single_6",
         "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
         },
         "policies": {
-            "id_quota": 1204
+            "id_quota": 1087
         }
     },
     {
@@ -118,14 +118,14 @@
                 "CNA"
             ]
         },
-        "name": "Schwartz Ltd",
-        "short_name": "quickly_7",
+        "name": "Martinez, Ramirez and Sanchez",
+        "short_name": "final_7",
         "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
         },
         "policies": {
-            "id_quota": 969
+            "id_quota": 981
         }
     },
     {
@@ -134,14 +134,14 @@
                 "CNA"
             ]
         },
-        "name": "Munoz-Davis",
-        "short_name": "concern_8",
+        "name": "Harper, Lewis and Mclaughlin",
+        "short_name": "man_8",
         "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
         },
         "policies": {
-            "id_quota": 1292
+            "id_quota": 1185
         }
     },
     {
@@ -150,14 +150,14 @@
                 "CNA"
             ]
         },
-        "name": "Robertson Group",
-        "short_name": "raise_9",
+        "name": "Jackson-Williams",
+        "short_name": "theory_9",
         "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
         },
         "policies": {
-            "id_quota": 1409
+            "id_quota": 905
         }
     },
     {
@@ -166,14 +166,14 @@
                 "CNA"
             ]
         },
-        "name": "Parker-Lucas",
-        "short_name": "certain_10",
+        "name": "Baker, Gonzalez and Mitchell",
+        "short_name": "bad_10",
         "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
         },
         "policies": {
-            "id_quota": 1200
+            "id_quota": 1465
         }
     },
     {
@@ -182,139 +182,11 @@
                 "CNA"
             ]
         },
-        "name": "Doyle-Arias",
-        "short_name": "from_11",
+        "name": "Wilson-Jackson",
+        "short_name": "now_11",
         "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
-        },
-        "policies": {
-            "id_quota": 1306
-        }
-    },
-    {
-        "authority": {
-            "active_roles": [
-                "CNA"
-            ]
-        },
-        "name": "Buckley, Evans and Wilson",
-        "short_name": "cost_12",
-        "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
-        },
-        "policies": {
-            "id_quota": 1315
-        }
-    },
-    {
-        "authority": {
-            "active_roles": [
-                "CNA"
-            ]
-        },
-        "name": "Burke-Mayer",
-        "short_name": "opportunity_13",
-        "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
-        },
-        "policies": {
-            "id_quota": 583
-        }
-    },
-    {
-        "authority": {
-            "active_roles": [
-                "CNA"
-            ]
-        },
-        "name": "Parker-Koch",
-        "short_name": "value_14",
-        "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
-        },
-        "policies": {
-            "id_quota": 926
-        }
-    },
-    {
-        "authority": {
-            "active_roles": [
-                "CNA"
-            ]
-        },
-        "name": "Navarro-Salazar",
-        "short_name": "magazine_15",
-        "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
-        },
-        "policies": {
-            "id_quota": 1291
-        }
-    },
-    {
-        "authority": {
-            "active_roles": [
-                "CNA"
-            ]
-        },
-        "name": "Campbell-Murphy",
-        "short_name": "difference_16",
-        "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
-        },
-        "policies": {
-            "id_quota": 1399
-        }
-    },
-    {
-        "authority": {
-            "active_roles": [
-                "CNA"
-            ]
-        },
-        "name": "Gonzalez Ltd",
-        "short_name": "ok_17",
-        "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
-        },
-        "policies": {
-            "id_quota": 1138
-        }
-    },
-    {
-        "authority": {
-            "active_roles": [
-                "CNA"
-            ]
-        },
-        "name": "Holden-White",
-        "short_name": "whatever_18",
-        "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
-        },
-        "policies": {
-            "id_quota": 609
-        }
-    },
-    {
-        "authority": {
-            "active_roles": [
-                "CNA"
-            ]
-        },
-        "name": "Carrillo, Kennedy and Nielsen",
-        "short_name": "accept_19",
-        "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
         },
         "policies": {
             "id_quota": 1231
@@ -326,14 +198,142 @@
                 "CNA"
             ]
         },
-        "name": "Acevedo and Sons",
-        "short_name": "whether_20",
+        "name": "Parker-Logan",
+        "short_name": "threat_12",
         "time": {
-            "modified": "2021-04-21T02:09:07.389440Z",
-            "created": "2021-04-21T02:09:07.389440Z"
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
         },
         "policies": {
-            "id_quota": 948
+            "id_quota": 962
+        }
+    },
+    {
+        "authority": {
+            "active_roles": [
+                "CNA"
+            ]
+        },
+        "name": "Powell, Smith and English",
+        "short_name": "drive_13",
+        "time": {
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
+        },
+        "policies": {
+            "id_quota": 874
+        }
+    },
+    {
+        "authority": {
+            "active_roles": [
+                "CNA"
+            ]
+        },
+        "name": "Taylor Inc",
+        "short_name": "several_14",
+        "time": {
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
+        },
+        "policies": {
+            "id_quota": 677
+        }
+    },
+    {
+        "authority": {
+            "active_roles": [
+                "CNA"
+            ]
+        },
+        "name": "Pierce-Nguyen",
+        "short_name": "property_15",
+        "time": {
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
+        },
+        "policies": {
+            "id_quota": 888
+        }
+    },
+    {
+        "authority": {
+            "active_roles": [
+                "CNA"
+            ]
+        },
+        "name": "Barker, Bryan and Hill",
+        "short_name": "level_16",
+        "time": {
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
+        },
+        "policies": {
+            "id_quota": 1024
+        }
+    },
+    {
+        "authority": {
+            "active_roles": [
+                "CNA"
+            ]
+        },
+        "name": "Barry-Parker",
+        "short_name": "film_17",
+        "time": {
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
+        },
+        "policies": {
+            "id_quota": 1431
+        }
+    },
+    {
+        "authority": {
+            "active_roles": [
+                "CNA"
+            ]
+        },
+        "name": "Schmidt-Harris",
+        "short_name": "student_18",
+        "time": {
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
+        },
+        "policies": {
+            "id_quota": 876
+        }
+    },
+    {
+        "authority": {
+            "active_roles": [
+                "CNA"
+            ]
+        },
+        "name": "Johns, Anderson and King",
+        "short_name": "senior_19",
+        "time": {
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
+        },
+        "policies": {
+            "id_quota": 872
+        }
+    },
+    {
+        "authority": {
+            "active_roles": [
+                "CNA"
+            ]
+        },
+        "name": "Weber-Gordon",
+        "short_name": "public_20",
+        "time": {
+            "modified": "2021-05-11T02:57:02.863900Z",
+            "created": "2021-05-11T02:57:02.863900Z"
+        },
+        "policies": {
+            "id_quota": 804
         }
     }
 ]

--- a/datadump/pre-population/users.json
+++ b/datadump/pre-population/users.json
@@ -4,15 +4,15 @@
         "cna_short_name": "mitre",
         "active": true,
         "name": {
-            "first": "Michael",
-            "last": "Pham",
-            "middle": "R",
+            "first": "Mckenzie",
+            "last": "Sanchez",
+            "middle": "G",
             "surname": "Mr.",
-            "suffix": "II"
+            "suffix": "PhD"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -20,351 +20,451 @@
         "cna_short_name": "mitre",
         "active": true,
         "name": {
-            "first": "Brandon",
-            "last": "Larsen",
-            "middle": "T",
-            "surname": "Lic.",
-            "suffix": "Jr."
+            "first": "Karen",
+            "last": "Wilson",
+            "middle": "P",
+            "surname": "Miss",
+            "suffix": ""
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
-        "username": "christianromero@mitre.com",
+        "username": "michellemartin@mitre.com",
         "cna_short_name": "mitre",
         "active": true,
         "name": {
-            "first": "Christian",
-            "last": "Romero",
-            "middle": "T",
-            "surname": "Lic.",
-            "suffix": ""
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "jamesfreeman@here_1.com",
-        "cna_short_name": "here_1",
-        "active": true,
-        "name": {
-            "first": "James",
-            "last": "Freeman",
-            "middle": "I",
-            "surname": "Prof.",
-            "suffix": "Sr."
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "franciscoanderson@today_2.com",
-        "cna_short_name": "today_2",
-        "active": true,
-        "name": {
-            "first": "Francisco",
-            "last": "Anderson",
-            "middle": "R",
-            "surname": "Lic.",
-            "suffix": "PhD"
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "sandrabrown@song_3.com",
-        "cna_short_name": "song_3",
-        "active": true,
-        "name": {
-            "first": "Sandra",
-            "last": "Brown",
-            "middle": "S",
-            "surname": "Dr.",
-            "suffix": "Sr."
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "jamesvaldez@technology_4.com",
-        "cna_short_name": "technology_4",
-        "active": true,
-        "name": {
-            "first": "James",
-            "last": "Valdez",
-            "middle": "C",
-            "surname": "Mrs.",
-            "suffix": "I"
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "jeffreyfigueroa@man_5.com",
-        "cna_short_name": "man_5",
-        "active": true,
-        "name": {
-            "first": "Jeffrey",
-            "last": "Figueroa",
-            "middle": "N",
-            "surname": "Dr.",
-            "suffix": "Sr."
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "davidmcguire@only_6.com",
-        "cna_short_name": "only_6",
-        "active": true,
-        "name": {
-            "first": "David",
-            "last": "Mcguire",
-            "middle": "B",
-            "surname": "Lic.",
-            "suffix": ""
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "ashleyanderson@quickly_7.com",
-        "cna_short_name": "quickly_7",
-        "active": true,
-        "name": {
-            "first": "Ashley",
-            "last": "Anderson",
-            "middle": "C",
-            "surname": "Mr.",
-            "suffix": ""
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "jasongray@concern_8.com",
-        "cna_short_name": "concern_8",
-        "active": true,
-        "name": {
-            "first": "Jason",
-            "last": "Gray",
-            "middle": "P",
-            "surname": "Mr.",
-            "suffix": "Jr."
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "ashleybradley@raise_9.com",
-        "cna_short_name": "raise_9",
-        "active": true,
-        "name": {
-            "first": "Ashley",
-            "last": "Bradley",
+            "first": "Michelle",
+            "last": "Martin",
             "middle": "P",
             "surname": "Mrs.",
-            "suffix": "PhD"
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "williammorris@certain_10.com",
-        "cna_short_name": "certain_10",
-        "active": true,
-        "name": {
-            "first": "William",
-            "last": "Morris",
-            "middle": "R",
-            "surname": "",
-            "suffix": "Jr."
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "kimmiller@from_11.com",
-        "cna_short_name": "from_11",
-        "active": true,
-        "name": {
-            "first": "Kim",
-            "last": "Miller",
-            "middle": "D",
-            "surname": "Lic.",
-            "suffix": "II"
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "codymurphy@cost_12.com",
-        "cna_short_name": "cost_12",
-        "active": true,
-        "name": {
-            "first": "Cody",
-            "last": "Murphy",
-            "middle": "D",
-            "surname": "Miss",
-            "suffix": "I"
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "colleentorres@opportunity_13.com",
-        "cna_short_name": "opportunity_13",
-        "active": true,
-        "name": {
-            "first": "Colleen",
-            "last": "Torres",
-            "middle": "A",
-            "surname": "Prof.",
-            "suffix": "Jr."
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "janetdean@value_14.com",
-        "cna_short_name": "value_14",
-        "active": true,
-        "name": {
-            "first": "Janet",
-            "last": "Dean",
-            "middle": "S",
-            "surname": "Miss",
             "suffix": "III"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
-        "username": "jameshansen@magazine_15.com",
-        "cna_short_name": "magazine_15",
-        "active": true,
-        "name": {
-            "first": "James",
-            "last": "Hansen",
-            "middle": "S",
-            "surname": "Mrs.",
-            "suffix": "I"
+        "username": "agree_1_admin@agree_1.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
         },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "rebeccahenry@difference_16.com",
-        "cna_short_name": "difference_16",
+        "cna_short_name": "agree_1",
         "active": true,
         "name": {
             "first": "Rebecca",
-            "last": "Henry",
-            "middle": "B",
-            "surname": "Miss",
+            "last": "Herring",
+            "middle": "N",
+            "surname": "Mr.",
             "suffix": "PhD"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
-        "username": "dominiquefrench@ok_17.com",
-        "cna_short_name": "ok_17",
+        "username": "body_2_admin@body_2.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "body_2",
         "active": true,
         "name": {
-            "first": "Dominique",
-            "last": "French",
-            "middle": "T",
+            "first": "Debra",
+            "last": "Smith",
+            "middle": "E",
+            "surname": "",
+            "suffix": "I"
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "eight_3_admin@eight_3.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "eight_3",
+        "active": true,
+        "name": {
+            "first": "Louis",
+            "last": "Rose",
+            "middle": "M",
             "surname": "Prof.",
-            "suffix": ""
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "stevenvalentine@whatever_18.com",
-        "cna_short_name": "whatever_18",
-        "active": true,
-        "name": {
-            "first": "Steven",
-            "last": "Valentine",
-            "middle": "C",
-            "surname": "Mr.",
-            "suffix": "Sr."
-        },
-        "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
-        }
-    },
-    {
-        "username": "stephenjohnson@accept_19.com",
-        "cna_short_name": "accept_19",
-        "active": true,
-        "name": {
-            "first": "Stephen",
-            "last": "Johnson",
-            "middle": "S",
-            "surname": "Miss",
             "suffix": "Jr."
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
-        "username": "nicolecallahan@whether_20.com",
-        "cna_short_name": "whether_20",
+        "username": "suddenly_4_admin@suddenly_4.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "suddenly_4",
         "active": true,
         "name": {
-            "first": "Nicole",
-            "last": "Callahan",
+            "first": "Christine",
+            "last": "Diaz",
+            "middle": "G",
+            "surname": "",
+            "suffix": "Sr."
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "film_5_admin@film_5.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "film_5",
+        "active": true,
+        "name": {
+            "first": "Benjamin",
+            "last": "Navarro",
+            "middle": "N",
+            "surname": "Lic.",
+            "suffix": "Jr."
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "single_6_admin@single_6.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "single_6",
+        "active": true,
+        "name": {
+            "first": "Linda",
+            "last": "Vaughn",
+            "middle": "V",
+            "surname": "Miss",
+            "suffix": ""
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "final_7_admin@final_7.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "final_7",
+        "active": true,
+        "name": {
+            "first": "Joshua",
+            "last": "Ramirez",
+            "middle": "C",
+            "surname": "Lic.",
+            "suffix": "Jr."
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "man_8_admin@man_8.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "man_8",
+        "active": true,
+        "name": {
+            "first": "Ryan",
+            "last": "Schmidt",
+            "middle": "S",
+            "surname": "",
+            "suffix": "III"
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "theory_9_admin@theory_9.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "theory_9",
+        "active": true,
+        "name": {
+            "first": "Christopher",
+            "last": "Cook",
+            "middle": "F",
+            "surname": "Miss",
+            "suffix": ""
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "bad_10_admin@bad_10.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "bad_10",
+        "active": true,
+        "name": {
+            "first": "Cynthia",
+            "last": "Brooks",
+            "middle": "H",
+            "surname": "Prof.",
+            "suffix": "Sr."
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "now_11_admin@now_11.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "now_11",
+        "active": true,
+        "name": {
+            "first": "Amy",
+            "last": "Bass",
+            "middle": "H",
+            "surname": "Mrs.",
+            "suffix": "III"
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "threat_12_admin@threat_12.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "threat_12",
+        "active": true,
+        "name": {
+            "first": "Bethany",
+            "last": "Bryant",
+            "middle": "C",
+            "surname": "Prof.",
+            "suffix": "Sr."
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "drive_13_admin@drive_13.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "drive_13",
+        "active": true,
+        "name": {
+            "first": "Alec",
+            "last": "Mitchell",
             "middle": "A",
+            "surname": "Mrs.",
+            "suffix": ""
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "several_14_admin@several_14.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "several_14",
+        "active": true,
+        "name": {
+            "first": "Calvin",
+            "last": "Thompson",
+            "middle": "M",
+            "surname": "",
+            "suffix": "Jr."
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "property_15_admin@property_15.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "property_15",
+        "active": true,
+        "name": {
+            "first": "Julie",
+            "last": "Weaver",
+            "middle": "B",
+            "surname": "Lic.",
+            "suffix": "Sr."
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "level_16_admin@level_16.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "level_16",
+        "active": true,
+        "name": {
+            "first": "Andrew",
+            "last": "Griffith",
+            "middle": "P",
+            "surname": "Prof.",
+            "suffix": "PhD"
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "film_17_admin@film_17.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "film_17",
+        "active": true,
+        "name": {
+            "first": "Logan",
+            "last": "Newman",
+            "middle": "D",
+            "surname": "Mrs.",
+            "suffix": "Sr."
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "student_18_admin@student_18.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "student_18",
+        "active": true,
+        "name": {
+            "first": "Anne",
+            "last": "Cherry",
+            "middle": "M",
             "surname": "",
             "suffix": "PhD"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "senior_19_admin@senior_19.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "senior_19",
+        "active": true,
+        "name": {
+            "first": "Jacob",
+            "last": "Douglas",
+            "middle": "R",
+            "surname": "Mrs.",
+            "suffix": "PhD"
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
+        }
+    },
+    {
+        "username": "public_20_admin@public_20.com",
+        "authority": {
+            "active_roles": [
+                "ADMIN"
+            ]
+        },
+        "cna_short_name": "public_20",
+        "active": true,
+        "name": {
+            "first": "Richard",
+            "last": "Bradshaw",
+            "middle": "T",
+            "surname": "Dr.",
+            "suffix": "I"
+        },
+        "time": {
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -374,13 +474,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "R",
+            "middle": "S",
             "surname": "Miss",
-            "suffix": ""
+            "suffix": "Jr."
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -390,13 +490,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "B",
+            "middle": "C",
             "surname": "Miss",
-            "suffix": ""
+            "suffix": "II"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -406,13 +506,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "L",
+            "middle": "E",
             "surname": "Mr.",
-            "suffix": "I"
+            "suffix": "II"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -424,11 +524,11 @@
             "last": "",
             "middle": "S",
             "surname": "Mrs.",
-            "suffix": "Sr."
+            "suffix": "I"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -438,13 +538,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "A",
-            "surname": "Mr.",
-            "suffix": "II"
+            "middle": "R",
+            "surname": "Dr.",
+            "suffix": "I"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -454,13 +554,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "C",
-            "surname": "Prof.",
-            "suffix": "Jr."
+            "middle": "W",
+            "surname": "Miss",
+            "suffix": "II"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -470,13 +570,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "W",
-            "surname": "Lic.",
-            "suffix": "Sr."
+            "middle": "A",
+            "surname": "Dr.",
+            "suffix": "PhD"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -486,13 +586,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "W",
-            "surname": "Prof.",
+            "middle": "L",
+            "surname": "Mr.",
             "suffix": ""
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -502,13 +602,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "S",
-            "surname": "Dr.",
-            "suffix": "PhD"
+            "middle": "L",
+            "surname": "",
+            "suffix": "II"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -518,13 +618,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "U",
-            "surname": "Prof.",
-            "suffix": ""
+            "middle": "T",
+            "surname": "Miss",
+            "suffix": "PhD"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -534,13 +634,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "N",
-            "surname": "",
-            "suffix": "Sr."
+            "middle": "R",
+            "surname": "Miss",
+            "suffix": "II"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -550,13 +650,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "W",
-            "surname": "Miss",
-            "suffix": "III"
+            "middle": "S",
+            "surname": "Mrs.",
+            "suffix": "Sr."
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -566,13 +666,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "P",
-            "surname": "",
-            "suffix": "Jr."
+            "middle": "R",
+            "surname": "Mrs.",
+            "suffix": "Sr."
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -582,13 +682,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "F",
-            "surname": "",
-            "suffix": ""
+            "middle": "T",
+            "surname": "Prof.",
+            "suffix": "Jr."
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -598,13 +698,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "F",
-            "surname": "",
+            "middle": "A",
+            "surname": "Miss",
             "suffix": "III"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -614,13 +714,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "C",
-            "surname": "Mrs.",
-            "suffix": "PhD"
+            "middle": "P",
+            "surname": "Dr.",
+            "suffix": ""
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -630,13 +730,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "L",
+            "middle": "I",
             "surname": "Mr.",
             "suffix": "Jr."
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     },
     {
@@ -646,13 +746,13 @@
         "name": {
             "first": "",
             "last": "",
-            "middle": "H",
-            "surname": "Prof.",
-            "suffix": "Sr."
+            "middle": "M",
+            "surname": "",
+            "suffix": "PhD"
         },
         "time": {
-            "modified": "2021-04-21T02:09:08.823615Z",
-            "created": "2021-04-21T02:09:08.823615Z"
+            "modified": "2021-05-11T02:57:04.039658Z",
+            "created": "2021-05-11T02:57:04.039658Z"
         }
     }
 ]


### PR DESCRIPTION
This will make it easier for anyone using the fake data during local testing to have access to org admin users without creating them with a secretariat user. Will resolve #393