### PR TITLE
Release UpdateCve Fix

### DIFF
--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -161,12 +161,12 @@ async function updateCve (req, res, next) {
     const cveIdRepo = req.ctx.repositories.getCveIdRepository()
     const orgRepo = req.ctx.repositories.getOrgRepository()
 
-    // cve id in body must match id in URL param
+    // CVE id in body must match id in URL param
     if (cveId !== cve.CVE_data_meta.ID) {
       return res.status(400).json(error.cveIdMismatch())
     }
 
-    // check that cve does not have status 'RESERVED'
+    // check that CVE does not have status 'RESERVED'
     if (newCve.cve.CVE_data_meta.STATE === CONSTANTS.CVE_STATES.RESERVED) {
       return res.status(400).json(error.cveUpdateUnsupportedState(CONSTANTS.CVE_STATES.RESERVED))
     }

--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -171,7 +171,7 @@ async function updateCve (req, res, next) {
       return res.status(400).json(error.cveUpdateUnsupportedState(CONSTANTS.CVE_STATES.RESERVED))
     }
 
-    // find cve record first
+    // find CVE record first
     let result = await cveRepo.findOneByCveId(cveId)
 
     // check if CVE record was found
@@ -180,7 +180,7 @@ async function updateCve (req, res, next) {
       return res.status(403).json(error.cveRecordDne())
     }
 
-    // find cve id
+    // find CVE id
     result = await cveIdRepo.findOneByCveId(cveId)
 
     // check if CVE id was found
@@ -192,7 +192,7 @@ async function updateCve (req, res, next) {
     // update CVE record
     result = await cveRepo.updateByCveId(cveId, newCve)
 
-    // update cve id
+    // update CVE id
     result = await cveIdRepo.updateByCveId(cveId, { state: newCve.cve.CVE_data_meta.STATE })
 
     const responseMessage = {

--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -171,23 +171,29 @@ async function updateCve (req, res, next) {
       return res.status(400).json(error.cveUpdateUnsupportedState(CONSTANTS.CVE_STATES.RESERVED))
     }
 
-    // update the cve id in MongoDB
-    let result = await cveIdRepo.updateByCveId(cveId, { state: newCve.cve.CVE_data_meta.STATE })
+    // find cve record first
+    let result = await cveRepo.findOneByCveId(cveId)
 
-    // check if cve id was found and updated
-    if (result.n === 0) {
+    // check if CVE record was found
+    if (!result) {
+      logger.info(cveId + ' does not exist.')
+      return res.status(403).json(error.cveRecordDne())
+    }
+
+    // find cve id
+    result = await cveIdRepo.findOneByCveId(cveId)
+
+    // check if cve id was found
+    if (!result) {
       logger.info(cveId + ' does not exist.')
       return res.status(403).json(error.cveDne())
     }
 
-    // update CVE record if it exists
+    // update CVE record
     result = await cveRepo.updateByCveId(cveId, newCve)
 
-    // check if CVE record was found and updated
-    if (result.n === 0) {
-      logger.info(cveId + ' does not exist.')
-      return res.status(403).json(error.cveRecordDne())
-    }
+    // update cve id
+    result = await cveIdRepo.updateByCveId(cveId, { state: newCve.cve.CVE_data_meta.STATE })
 
     const responseMessage = {
       message: cveId + ' record was successfully updated.',

--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -183,7 +183,7 @@ async function updateCve (req, res, next) {
     // find cve id
     result = await cveIdRepo.findOneByCveId(cveId)
 
-    // check if cve id was found
+    // check if CVE id was found
     if (!result) {
       logger.info(cveId + ' does not exist.')
       return res.status(403).json(error.cveDne())

--- a/test/unit-tests/cve/cveUpdateTest.js
+++ b/test/unit-tests/cve/cveUpdateTest.js
@@ -89,6 +89,8 @@ describe('Testing the PUT /cve/:id endpoint in Cve Controller', () => {
       }
       class CveRepo {
         async updateByCveId (cveId, newCve) {
+          // test shouldn't reach here
+          expect.fail()
           return null
         }
 
@@ -102,7 +104,7 @@ describe('Testing the PUT /cve/:id endpoint in Cve Controller', () => {
         }
 
         async findOneByCveId () {
-          return null
+          return true
         }
       }
       class UserRepo {
@@ -150,6 +152,8 @@ describe('Testing the PUT /cve/:id endpoint in Cve Controller', () => {
       }
       class CveRepo {
         async updateByCveId (cveId, newCve) {
+          // test shouldn't reach here
+          expect.fail()
           return null
         }
 

--- a/test/unit-tests/cve/cveUpdateTest.js
+++ b/test/unit-tests/cve/cveUpdateTest.js
@@ -30,9 +30,17 @@ describe('Testing the PUT /cve/:id endpoint in Cve Controller', () => {
         async updateByCveId (cveId, newCve) {
           return null
         }
+
+        async findOneByCveId () {
+          return null
+        }
       }
       class CveIdRepo {
         async updateByCveId (cveId, newCve) {
+          return null
+        }
+
+        async findOneByCveId () {
           return null
         }
       }
@@ -81,12 +89,20 @@ describe('Testing the PUT /cve/:id endpoint in Cve Controller', () => {
       }
       class CveRepo {
         async updateByCveId (cveId, newCve) {
-          return { n: 0 }
+          return null
+        }
+
+        async findOneByCveId () {
+          return null
         }
       }
       class CveIdRepo {
         async updateByCveId (cveId, newCve) {
-          return { n: 1 }
+          return null
+        }
+
+        async findOneByCveId () {
+          return null
         }
       }
       class UserRepo {
@@ -136,10 +152,19 @@ describe('Testing the PUT /cve/:id endpoint in Cve Controller', () => {
         async updateByCveId (cveId, newCve) {
           return null
         }
+
+        async findOneByCveId () {
+          // set to anything not false to pass the check
+          return true
+        }
       }
       class CveIdRepo {
         async updateByCveId (cveId, newCve) {
-          return { n: 0 }
+          return null
+        }
+
+        async findOneByCveId () {
+          return null
         }
       }
       class UserRepo {
@@ -240,14 +265,22 @@ describe('Testing the PUT /cve/:id endpoint in Cve Controller', () => {
         async updateByCveId (cveId, newCve) {
           expect(cveId).to.equal(cveIdPublic4)
           expect(newCve).to.have.nested.property('cve.CVE_data_meta.STATE').and.to.equal(CONSTANTS.CVE_STATES.PUBLIC)
-          return { n: 1 }
+          return null
+        }
+
+        async findOneByCveId () {
+          return true
         }
       }
       class CveIdRepo {
         async updateByCveId (cveId, newCve) {
           expect(cveId).to.equal(cveIdPublic4)
           expect(newCve).to.have.property('state')
-          return { n: 1 }
+          return null
+        }
+
+        async findOneByCveId () {
+          return true
         }
       }
       class UserRepo {
@@ -293,12 +326,19 @@ describe('Testing the PUT /cve/:id endpoint in Cve Controller', () => {
       }
       class CveRepo {
         async updateByCveId (cveId, newCve) {
-          return { n: 1 }
+          return null
+        }
+        async findOneByCveId () {
+          return true
         }
       }
       class CveIdRepo {
         async updateByCveId (cveId, newCve) {
-          return { n: 1 }
+          return null
+        }
+
+        async findOneByCveId () {
+          return true
         }
       }
       class UserRepo {

--- a/test/unit-tests/cve/cveUpdateTest.js
+++ b/test/unit-tests/cve/cveUpdateTest.js
@@ -328,6 +328,7 @@ describe('Testing the PUT /cve/:id endpoint in Cve Controller', () => {
         async updateByCveId (cveId, newCve) {
           return null
         }
+
         async findOneByCveId () {
           return true
         }


### PR DESCRIPTION
Problem:

Endpoint shouldn't update cve record when cve ID doesn't exist.

Solution:

Before updating, check if both the Record and ID exist then proceed or respond.

Note: 
Updated tests to reflect on changes, no longer checking if objects exist after updating.