### PR TITLE
Fix typos and trailing space in OpenAPI schema file

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -33,7 +33,7 @@ components:
     api-secret-header:
       in: header
       name: CVE-API-KEY
-      description: The user's api key.
+      description: The user's API key.
       required: true
       schema:
         type: string
@@ -51,7 +51,7 @@ components:
       description: The short name of the organization.
       required: true
       schema:
-        type: string   
+        type: string
     username-path:
       in: path
       name: username
@@ -282,7 +282,7 @@ components:
               description: The suffix of the user, if any.
         secret:
           type: string
-          description: The api key of the user.
+          description: The API key of the user.
         authority:
           type: object
           properties:
@@ -390,7 +390,7 @@ components:
         cve_ids:
           type: array
           items:
-            $ref: '#/components/schemas/cve-id-no-time' 
+            $ref: '#/components/schemas/cve-id-no-time'
     errorValidator:
       type: object
       properties:
@@ -449,7 +449,7 @@ components:
               msg:
                 type: string
                 description: Invalid value
-              param: 
+              param:
                 type: string
                 description: The name of the parameter with the error
               location:
@@ -464,7 +464,7 @@ components:
           description: Error name
         message:
           type: string
-          description: Error description   
+          description: Error description
 paths:
   /cve-id-range/{year}:
     parameters:
@@ -479,7 +479,7 @@ paths:
           type: integer
           format: int32
     post:
-      summary: Creates a CVE-ID-Range record for the scpecified year
+      summary: Creates a CVE-ID-Range record for the specified year
       description: |
         <h2>Access Control</h2>
         <p>At least one of the following roles are needed to access the endpoint:</p>
@@ -487,13 +487,13 @@ paths:
         <h2>Expected Behavior</h2>
         <p><b>Secretariat:</b> Can create a CVE-ID-Range record for the specified year</p>
       operationId: cveIdRangeCreate
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: ['SECRETARIAT'] 
+        enum: ['SECRETARIAT']
         description: The user must belong to an Organization with the “SECRETARIAT” role to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       responses:
         200:
@@ -543,13 +543,13 @@ paths:
         <p><b>Admin User:</b> Can only see CVE-IDs owned by the Organization it belongs to</p>
         <p><b>Regular User:</b> Can only see CVE-IDs owned by the Organization it belongs to</p>
       operationId: cveIdGetFiltered
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No Organization roles needed to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       parameters:
         - in: query
@@ -592,7 +592,7 @@ paths:
           required: false
           schema:
             type: string
-            format: date-time  
+            format: date-time
         - $ref: '#/components/parameters/page-query'
       responses:
         200:
@@ -626,7 +626,7 @@ paths:
                     type: integer
                     format: int32
                     description: Next page
-                  cve_ids: 
+                  cve_ids:
                     $ref: '#/components/schemas/arrayOfCveIds'
         400:
           description: Bad Request
@@ -668,18 +668,18 @@ paths:
         <p><b>Secretariat:</b> Can reserve CVE-IDs for any Organization</p>
         <p><b>CNA:</b> Can only reserve CVE-IDs for its Organization</p>
       operationId: cveIdReserve
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: ['CNA'] 
+        enum: ['CNA']
         description: The user must belong to an Organization with the “CNA” role to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       parameters:
         - in: query
           name: batch_type
-          description: When the amount is greater than one, it indicates whether the CVE IDs should be sequential or nonsequential.
+          description: When the amount is greater than one, it indicates whether the CVE IDs should be sequential or non-sequential.
           required: false
           schema:
             type: string
@@ -697,7 +697,7 @@ paths:
           required: true
           schema:
             type: integer
-            format: int32   
+            format: int32
         - in: query
           name: short_name
           description: The CNA that will own the CVE IDs reserved.
@@ -762,14 +762,14 @@ paths:
         <p><b>Secretariat:</b> Can see the full information of a CVE-ID owned by any Organization</p>
         <p><b>Admin User:</b> Can see full information of a CVE-ID owned by the Organization it belongs to, and can only see partial information of a CVE-ID in the “PUBLIC” or “REJECT” state that is owned by another Organization</p>
         <p><b>Regular User:</b> Can see full information of a CVE-ID owned by the Organization it belongs to, and can only see partial information of a CVE-ID in the “PUBLIC” or “REJECT” state that is owned by another Organization</p>
-      operationId: cveIdGetSingle        
-      x-org-roles: 
+      operationId: cveIdGetSingle
+      x-org-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No Organization roles needed to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       responses:
         200:
@@ -817,13 +817,13 @@ paths:
         <h2>Expected Behavior</h2>
         <p><b>Secretariat:</b> Can update a CVE-ID owned by any Organization</p>
       operationId: cveIdUpdateSingle
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: ['SECRETARIAT'] 
+        enum: ['SECRETARIAT']
         description: The user must belong to an Organization with the “SECRETARIAT” role to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       parameters:
         - in: query
@@ -889,13 +889,13 @@ paths:
         <h2>Expected Behavior</h2>
         <p><b>Secretariat:</b> Can see all CVE records owned by any Organization</p>
       operationId: cveGetFiltered
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: ['SECRETARIAT'] 
+        enum: ['SECRETARIAT']
         description: The user must belong to an Organization with the “SECRETARIAT” role to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       parameters:
         - in: query
@@ -972,7 +972,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/errorGeneric'
         500:
-          description: Internal Server 
+          description: Internal Server
           content:
             application/json:
               schema:
@@ -992,13 +992,13 @@ paths:
         <h2>Expected Behavior</h2>
         <p><b>Secretariat:</b> Can see a CVE record owned by any Organization</p>
       operationId: cveGetSingle
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: ['SECRETARIAT'] 
+        enum: ['SECRETARIAT']
         description: The user must belong to an Organization with the “SECRETARIAT” role to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       responses:
         200:
@@ -1043,13 +1043,13 @@ paths:
         <h2>Expected Behavior</h2>
         <p><b>Secretariat:</b> Can create a CVE record owned by any Organization</p>
       operationId: cveSubmit
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: ['SECRETARIAT'] 
+        enum: ['SECRETARIAT']
         description: The user must belong to an Organization with the “SECRETARIAT” role to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       responses:
         200:
@@ -1100,13 +1100,13 @@ paths:
         <h2>Expected Behavior</h2>
         <p><b>Secretariat:</b> Can update a CVE record owned by any Organization</p>
       operationId: cveUpdateSingle
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: ['SECRETARIAT'] 
+        enum: ['SECRETARIAT']
         description: The user must belong to an Organization with the “SECRETARIAT” role to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       responses:
         200:
@@ -1162,13 +1162,13 @@ paths:
         <h2>Expected Behavior</h2>
         <p><b>Secretariat:</b> Can see the information of all Organizations</p>
       operationId: orgAll
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: ['SECRETARIAT'] 
+        enum: ['SECRETARIAT']
         description: The user must belong to an Organization with the “SECRETARIAT” role to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       parameters:
         - $ref: '#/components/parameters/page-query'
@@ -1204,7 +1204,7 @@ paths:
                     type: integer
                     format: int32
                     description: Next page
-                  organizations: 
+                  organizations:
                     $ref: '#/components/schemas/arrayOfOrgs'
         400:
           description: Bad Request
@@ -1239,13 +1239,13 @@ paths:
         <h2>Expected Behavior</h2>
         <p><b>Secretariat:</b> Can create any Organization record</p>
       operationId: orgCreateSingle
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: ['SECRETARIAT'] 
+        enum: ['SECRETARIAT']
         description: The user must belong to an Organization with the “SECRETARIAT” role to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       requestBody:
         content:
@@ -1333,13 +1333,13 @@ paths:
         <p><b>Admin User:</b> Can only see the information of the Organization it belongs to</p>
         <p><b>Regular User:</b> Can only see the information of the Organization it belongs to</p>
       operationId: orgSingle
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No Organization roles needed to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       responses:
         200:
@@ -1372,7 +1372,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/errorGeneric'
-    put: 
+    put:
       summary: Update an organization record
       description: |
         <h2>Access Control</h2>
@@ -1381,13 +1381,13 @@ paths:
         <h2>Expected Behavior</h2>
         <p><b>Secretariat:</b> Can update the information of any Organization</p>
       operationId: orgUpdateSingle
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: ['SECRETARIAT'] 
+        enum: ['SECRETARIAT']
         description: The user must belong to an Organization with the “SECRETARIAT” role to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       parameters:
         - in: query
@@ -1478,13 +1478,13 @@ paths:
         <p><b>Admin User:</b> Can only see the information of users that belongs to the same Organization</p>
         <p><b>Regular User:</b> Can only see the information of users that belongs to the same Organization</p>
       operationId: userAll
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No Organization roles needed to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       parameters:
         - $ref: '#/components/parameters/page-query'
@@ -1563,13 +1563,13 @@ paths:
         <p><b>Secretariat:</b> Can create a user record for any Organization</p>
         <p><b>Admin User:</b> Can only create a user record for users that belongs to the same Organization</p>
       operationId: userCreateSingle
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: ['SECRETARIAT'] 
+        enum: ['SECRETARIAT']
         description: The user must belong to an Organization with the “SECRETARIAT” role to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: ['ADMIN'] 
+        enum: ['ADMIN']
         description: The user must have the “ADMIN” role and must belong to the same Organization as the new user to access the endpoint
       requestBody:
         content:
@@ -1669,13 +1669,13 @@ paths:
         <p><b>Admin User:</b> Can only see the information of a user that belongs to the same Organization</p>
         <p><b>Regular User:</b> Can only see the information of a user that belongs to the same Organization</p>
       operationId: userSingle
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No Organization roles needed to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       responses:
         200:
@@ -1718,14 +1718,14 @@ paths:
         <p><b>Secretariat:</b> Can update a user record for any Organization</p>
         <p><b>Admin User:</b> Can only update a user record for users that belongs to the same Organization</p>
         <p><b>Regular User:</b> Can only update its own user record</p>
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: [''] 
-        description: The organization can have the 'SECRETARIAT' role but it is not required to access the endpoint. 
-      x-user-roles: 
+        enum: ['']
+        description: The organization can have the 'SECRETARIAT' role but it is not required to access the endpoint.
+      x-user-roles:
         type: String
-        enum: [''] 
-        description: The user can have the 'ADMIN' role but it is not required to access the endpoint. 
+        enum: ['']
+        description: The user can have the 'ADMIN' role but it is not required to access the endpoint.
       parameters:
         - in: query
           name: active
@@ -1759,7 +1759,7 @@ paths:
             type: string
         - in: query
           name: name.middle
-          description: Update the middlename of the user record.
+          description: Update the middle name of the user record.
           required: false
           schema:
             type: string
@@ -1832,7 +1832,7 @@ paths:
       - $ref: '#/components/parameters/shortname-path'
       - $ref: '#/components/parameters/username-path'
     put:
-      summary: Reset the api key of the user
+      summary: Reset the API key of the user
       description: |
         <h2>Access Control</h2>
         <p>No roles needed to access the endpoint</p>
@@ -1841,17 +1841,17 @@ paths:
         <p><b>Admin User:</b> Can only reset the API secret of users that belong to the same Organization</p>
         <p><b>Regular User:</b> Can only reset its own API secret</p>
       operationId: userResetSecret
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No Organization roles needed to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       responses:
         200:
-          description: Returns the new api key.
+          description: Returns the new API key.
           content:
             application/json:
               schema:
@@ -1859,7 +1859,7 @@ paths:
                 properties:
                   API-secret:
                     type: string
-                    description: The new api key of the user.
+                    description: The new API key of the user.
         400:
           description: Bad Request
           content:
@@ -1906,13 +1906,13 @@ paths:
         <p><b>Admin User:</b> Can only see the CVE ID quota information of the Organization it belongs to</p>
         <p><b>Regular User:</b> Can only see the CVE ID quota information of the Organization it belongs to</p>
       operationId: orgIdQuota
-      x-org-roles: 
+      x-org-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No Organization roles needed to access the endpoint
-      x-user-roles: 
+      x-user-roles:
         type: String
-        enum: [''] 
+        enum: ['']
         description: No user roles needed to access the endpoint
       responses:
         200:


### PR DESCRIPTION
### Description of the Change

- Fixed a couple of typos in the doc strings of various endpoints.
- Removed a ton of trailing white space in the entire file (sorry for the noise).

### Release Notes

N/A