### PR TITLE
Fixes bad yaml syntax in openapi.yml

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -925,7 +925,7 @@ paths:
             format: date-time
         - in: query
           name: state
-          description: Filter by CVE state. Accepted values: [PUBLIC, REJECT].
+          description: 'Filter by CVE state. Accepted values: [PUBLIC, REJECT].'
           required: false
           schema:
             type: string         


### PR DESCRIPTION
Fixes #477 

The description field used to be a simple string, but now includes a `:` which must be escaped

### Identify the Bug
* #477
  
### Description of the Change
*  escapes the `:` by placing single quotes around the entire description value
### Alternate Designs
* One could remove the `:` from the value or revert the change
### Possible Drawbacks
* None
### Verification Process
* Ensure that `openapi-generator generate -i https://raw.githubusercontent.com/CVEProject/cve-services/dev/docs/openapi.yml -g $my_language` does not fail
### Release Notes
Fixes bug in openapi.yml which caused attempts to parse openapi.yml to fail when generating an API