### PR TITLE
Merge recent changes from Dev to Dockerfiles for Staging app environment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,7 @@ COPY config /app/config
 COPY docker/entrypoint.sh /app/entrypoint.sh
 RUN echo '{}' > /app/config/dev.json
 RUN echo '{}' > /app/config/test.json
+RUN echo '{}' > /app/config/staging.json
 
 # Change db hostname from localhost to docdb for use inside docker
 COPY docker/default.json-docker /app/config/default.json

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -39,6 +39,7 @@ RUN echo '{}' > /app/config/development.json
 RUN echo '{}' > /app/config/integration.json
 RUN echo '{}' > /app/config/production.json
 RUN echo '{}' > /app/config/test.json
+RUN echo '{}' > /app/config/staging.json
 
 # we don't need to expose ports that are exposed in our compose file
 ENTRYPOINT '/app/entrypoint.sh'


### PR DESCRIPTION
Description of the Change

Added creation of "staging.json" config file in each Dockerfile.

Quantitative Performance Benefits
N/A

Possible Drawbacks
None

Verification Process

Manually created an empty "staging.json" before starting the node app and confirmed that the error seen in AWS cloudWatch no longer exists.

Applicable Issues
None

Release Notes
Forgot to include this change required for ECS/Fargate since I was testing locally without containers.
