### PR TITLE
Add 'staging' as a deployment application environment in 'default.jso…

### DIFF
--- a/docker/default.json-docker
+++ b/docker/default.json-docker
@@ -9,6 +9,13 @@
     "host": "docdb",
     "port": 27017
   },
+  "staging": {
+    "username": null,
+    "password": null,
+    "database": "cve_stage",
+    "host": "docdb",
+    "port": 27017
+  },
   "integration": {
     "username": null,
     "password": null,


### PR DESCRIPTION
…n-docker' so that it applies to local containerized and AWS ECS deployments.

Description of the Change

Added creation of "staging.json" config file in each "default.json-docker" so it will apply to ECS deployments.

Quantitative Performance Benefits
N/A

Possible Drawbacks
None

Verification Process

Exec'd into the most recent version of the cveawg container and printed out the "default.json" file and verified that "staging" had not been added. It was only added to the regular "default.json" to run the node app locally.

Applicable Issues
None

Release Notes
None.
