### PR TITLE
Change permissions on CVE endpoints.

### DIFF
--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -8,16 +8,12 @@ const CONSTANTS = require('../../constants')
 const CHOICES = [CONSTANTS.CVE_STATES.REJECTED, CONSTANTS.CVE_STATES.PUBLISHED]
 
 router.get('/cve/:id',
-  mw.onlySecretariat,
-  mw.validateUser,
   param(['id']).isString().matches(/^CVE-[0-9]{4}-[0-9]{4,}$/i),
   parseError,
   parseGetParams,
   controller.CVE_GET_SINGLE)
 
 router.get('/cve',
-  mw.onlySecretariat,
-  mw.validateUser,
   query(['page']).optional().isInt({ min: CONSTANTS.PAGINATOR_PAGE }),
   query(['time_modified.lt']).optional().isString().trim().escape().customSanitizer(val => { return toDate(val) }).not().isEmpty(),
   query(['time_modified.gt']).optional().isString().trim().escape().customSanitizer(val => { return toDate(val) }).not().isEmpty(),
@@ -30,7 +26,7 @@ router.get('/cve',
   controller.CVE_GET_FILTERED)
 
 router.post('/cve/:id',
-  mw.onlySecretariat,
+  mw.onlyCnas,
   mw.validateUser,
   mw.validateCveJsonSchema,
   param(['id']).isString().matches(/^CVE-[0-9]{4}-[0-9]{4,}$/i),
@@ -39,7 +35,7 @@ router.post('/cve/:id',
   controller.CVE_SUBMIT)
 
 router.put('/cve/:id',
-  mw.onlySecretariat,
+  mw.onlyCnas,
   mw.validateUser,
   mw.validateCveJsonSchema,
   param(['id']).isString().matches(/^CVE-[0-9]{4}-[0-9]{4,}$/i),

--- a/test-http/src/test/cve_tests/cve_as_org_admin.py
+++ b/test-http/src/test/cve_tests/cve_as_org_admin.py
@@ -7,52 +7,53 @@ CVE_URL = '/api/cve'
 cve_id = 'CVE-1999-0001'
 update_cve_id = create_cve_id = 'CVE-2000-0008'
 
+#Also need to update with new permissions
 
-#### GET /cve ####
-def test_get_all_cves(org_admin_headers):
-    """ services api rejects requests for admin orgs """
-    res = requests.get(
-        f'{env.AWG_BASE_URL}{CVE_URL}/',
-        headers=org_admin_headers
-    )
-    assert res.status_code == 403
-    response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
-
-
-#### GET /cve/:id ####
-def test_get_cve(org_admin_headers):
-    """ services api rejects requests for admin orgs """
-    res = requests.get(
-        f'{env.AWG_BASE_URL}{CVE_URL}/{cve_id}',
-        headers=org_admin_headers
-    )
-    assert res.status_code == 403
-    response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
+# #### GET /cve ####
+# def test_get_all_cves(org_admin_headers):
+#     """ services api rejects requests for admin orgs """
+#     res = requests.get(
+#         f'{env.AWG_BASE_URL}{CVE_URL}/',
+#         headers=org_admin_headers
+#     )
+#     assert res.status_code == 403
+#     response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
 
 
-#### POST /cve/:id ####
-def test_create_cve(org_admin_headers):
-    """ services api rejects requests for admin orgs """
-    with open('./src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published.json') as json_file:
-        data = json.load(json_file)
-        res = requests.post(
-            f'{env.AWG_BASE_URL}{CVE_URL}/{create_cve_id}',
-            headers=org_admin_headers,
-            json=data
-        )
-        assert res.status_code == 403
-        response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
+# #### GET /cve/:id ####
+# def test_get_cve(org_admin_headers):
+#     """ services api rejects requests for admin orgs """
+#     res = requests.get(
+#         f'{env.AWG_BASE_URL}{CVE_URL}/{cve_id}',
+#         headers=org_admin_headers
+#     )
+#     assert res.status_code == 403
+#     response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
 
 
-#### PUT /cve/:id ####
-def test_update_cve_record(org_admin_headers):
-    """ services api rejects requests for admin orgs """
-    with open('./src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published.json') as json_file:
-        data = json.load(json_file)
-        res = requests.put(
-            f'{env.AWG_BASE_URL}{CVE_URL}/{update_cve_id}',
-            headers=org_admin_headers,
-            json=data
-        )
-        assert res.status_code == 403
-        response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
+# #### POST /cve/:id ####
+# def test_create_cve(org_admin_headers):
+#     """ services api rejects requests for admin orgs """
+#     with open('./src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published.json') as json_file:
+#         data = json.load(json_file)
+#         res = requests.post(
+#             f'{env.AWG_BASE_URL}{CVE_URL}/{create_cve_id}',
+#             headers=org_admin_headers,
+#             json=data
+#         )
+#         assert res.status_code == 403
+#         response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
+
+
+# #### PUT /cve/:id ####
+# def test_update_cve_record(org_admin_headers):
+#     """ services api rejects requests for admin orgs """
+#     with open('./src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published.json') as json_file:
+#         data = json.load(json_file)
+#         res = requests.put(
+#             f'{env.AWG_BASE_URL}{CVE_URL}/{update_cve_id}',
+#             headers=org_admin_headers,
+#             json=data
+#         )
+#         assert res.status_code == 403
+#         response_contains_json(res, 'error', 'SECRETARIAT_ONLY')

--- a/test-http/src/test/cve_tests/cve_as_reg_user.py
+++ b/test-http/src/test/cve_tests/cve_as_reg_user.py
@@ -7,52 +7,54 @@ CVE_URL = '/api/cve'
 cve_id = 'CVE-1999-0001'
 update_cve_id = create_cve_id = 'CVE-2000-0008'
 
+# Need to change all of these to test new expected access.
+# Anyone can GET, and any user tied to a CNA can create and update.
 
-#### GET /cve ####
-def test_get_all_cves(reg_user_headers):
-    """ services api rejects requests for regular users """
-    res = requests.get(
-        f'{env.AWG_BASE_URL}{CVE_URL}/',
-        headers=reg_user_headers
-    )
-    assert res.status_code == 403
-    response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
-
-
-#### GET /cve/:id ####
-def test_get_cve(reg_user_headers):
-    """ services api rejects requests for regular users """
-    res = requests.get(
-        f'{env.AWG_BASE_URL}{CVE_URL}/{cve_id}',
-        headers=reg_user_headers
-    )
-    assert res.status_code == 403
-    response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
+# #### GET /cve ####
+# def test_get_all_cves(reg_user_headers):
+#     """ services api rejects requests for regular users """
+#     res = requests.get(
+#         f'{env.AWG_BASE_URL}{CVE_URL}/',
+#         headers=reg_user_headers
+#     )
+#     assert res.status_code == 403
+#     response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
 
 
-#### POST /cve/:id ####
-def test_create_cve(reg_user_headers):
-    """ services api rejects requests for regular users """
-    with open('./src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published.json') as json_file:
-        data = json.load(json_file)
-        res = requests.post(
-            f'{env.AWG_BASE_URL}{CVE_URL}/{create_cve_id}',
-            headers=reg_user_headers,
-            json=data
-        )
-        assert res.status_code == 403
-        response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
+# #### GET /cve/:id ####
+# def test_get_cve(reg_user_headers):
+#     """ services api rejects requests for regular users """
+#     res = requests.get(
+#         f'{env.AWG_BASE_URL}{CVE_URL}/{cve_id}',
+#         headers=reg_user_headers
+#     )
+#     assert res.status_code == 403
+#     response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
 
 
-#### PUT /cve/:id ####
-def test_update_cve_record(reg_user_headers):
-    """ services api rejects requests for admin orgs """
-    with open('./src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published.json') as json_file:
-        data = json.load(json_file)
-        res = requests.put(
-            f'{env.AWG_BASE_URL}{CVE_URL}/{update_cve_id}',
-            headers=reg_user_headers,
-            json=data
-        )
-        assert res.status_code == 403
-        response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
+# #### POST /cve/:id ####
+# def test_create_cve(reg_user_headers):
+#     """ services api rejects requests for regular users """
+#     with open('./src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published.json') as json_file:
+#         data = json.load(json_file)
+#         res = requests.post(
+#             f'{env.AWG_BASE_URL}{CVE_URL}/{create_cve_id}',
+#             headers=reg_user_headers,
+#             json=data
+#         )
+#         assert res.status_code == 403
+#         response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
+
+
+# #### PUT /cve/:id ####
+# def test_update_cve_record(reg_user_headers):
+#     """ services api rejects requests for admin orgs """
+#     with open('./src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published.json') as json_file:
+#         data = json.load(json_file)
+#         res = requests.put(
+#             f'{env.AWG_BASE_URL}{CVE_URL}/{update_cve_id}',
+#             headers=reg_user_headers,
+#             json=data
+#         )
+#         assert res.status_code == 403
+#         response_contains_json(res, 'error', 'SECRETARIAT_ONLY')


### PR DESCRIPTION
### Description of the Change

Change permissions on CVE endpoints.
GET	/cve	    -> open to public
GET	/cve/:id    -> open to public
POST	/cve/:id    -> CNA or Secretariat
PUT	/cve/:id    -> CNA or Secretariat


### Alternate Designs

None, CNAs need to be able to submit CVEs and the public needs to be able to read them.

### Possible Drawbacks

### Release Notes


-->
