### PR TITLE
ValidateJsonSchema should not return a 500

### DIFF
--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -148,6 +148,10 @@ function validateCveJsonSchema (req, res, next) {
   const cve = req.body
   const cveVersion = cve.dataVersion
   let cveState = cve.cveMetadata
+  if (cveState === undefined) {
+    logger.error(JSON.stringify({ uuid: req.ctx.uuid, message: 'CVE JSON schema validation FAILED.' }))
+    return res.status(400).json(error.invalidJsonSchema(['instance.cveMetadata is not defined']))
+  }
   cveState = cveState.state
 
   logger.info({ uuid: req.ctx.uuid, message: 'Validating CVE JSON schema.' })

--- a/test/schemas/5.0/CVE-2017-4024_fail_cveMetadata.json
+++ b/test/schemas/5.0/CVE-2017-4024_fail_cveMetadata.json
@@ -1,0 +1,274 @@
+{
+    "dataType": "CVE",
+    "dataFormat": "MITRE",
+    "dataVersion": "5.0",
+    "cvemetadata": {
+        "id": "CVE-2017-4024",
+        "assigner": "88c02595-c8f7-4864-a0e7-e09b3e1da691",
+        "assignerShortname": "cisco",
+        "requester": "1fcbf829-81ae-4b53-a61d-9fa04711447f",
+        "state": "DUPLICATE"
+    },
+    "containers": {
+        "adp": [
+            {
+                "metrics": [
+                    {
+                        "format": "uyi",
+                        "scenario": "kjk",
+                        "other": {
+                            "type": "oio",
+                            "content": {
+                                "kjgk": "kjgkhg"
+                            }
+                        },
+                        "uu": 8
+                    }
+                ],
+                "affected": {
+                    "affectsCpes": [
+                        {
+                            "hi": "i"
+                        }
+                    ],
+                    "vendors": [
+                        {
+                            "vendorName": "u",
+                            "products": [
+                                {
+                                    "productName": "yuyi",
+                                    "versions": [
+                                        {
+                                            "versionValue": "uuy",
+                                            "versionAffected": "=",
+                                            "references": [
+                                                {
+                                                    "url": "https://cwe.mitre.org/data/definitions/284.html",
+                                                    "name": "12345",
+                                                    "refsource": "123459"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "packageName": "kgkug"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "providerMetadata": {
+                    "id": "88c02595-c8f7-4864-a0e7-e09b3e1da691",
+                    "shortName": "cisco",
+                    "updated": "2018-11-13T20:20:39+00:00"
+                },
+                "descriptions": [
+                    {
+                        "lang": "e",
+                        "value": "y"
+                    }
+                ],
+                "problemTypes": [
+                    {
+                        "descriptions": [
+                            {
+                                "lang": "e",
+                                "description": "y",
+                                "CWE-ID": "CWE-9",
+                                "type": "u",
+                                "references": [
+                                    {
+                                        "url": "https://cwe.mitre.org/data/definitions/284.html"
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "references": [
+                    {
+                        "url": "https://cwe.mitre.org/data/definitions/284.html",
+                        "name": "12345",
+                        "refsource": "12345",
+                        "tags": [
+                            "Broken Link"
+                        ]
+                    }
+                ],
+                "impacts": [
+                    {
+                        "descriptions": [
+                            {
+                                "lang": "e",
+                                "value": "y"
+                            }
+                        ],
+                        "capecId": "y"
+                    }
+                ],
+                "configuration": [
+                    {
+                        "lang": "e",
+                        "value": "y"
+                    }
+                ],
+                "workaround": [
+                    {
+                        "lang": "e",
+                        "value": "y"
+                    }
+                ],
+                "exploit": [
+                    {
+                        "lang": "e",
+                        "value": "y"
+                    }
+                ],
+                "timeline": [
+                    {
+                        "time": "2018-11-13T20:20:39+00:00",
+                        "lang": "i",
+                        "value": "y"
+                    }
+                ],
+                "credit": [
+                    {
+                        "lang": "e",
+                        "value": "y"
+                    }
+                ],
+                "source": {
+                    "discoverer": "Tom Smith"
+                }
+            }
+        ],
+        "cna": {
+            "metrics": [
+                {
+                    "format": "uyi",
+                    "scenario": "kjk",
+                    "other": {
+                        "type": "oio",
+                        "content": {
+                            "kjgk": "kjgkhg"
+                        }
+                    },
+                    "uu": 8
+                }
+            ],
+            "affected": {
+                "affectsCpes": [
+                    {
+                        "hi": "i"
+                    }
+                ],
+                "vendors": [
+                    {
+                        "vendorName": "u",
+                        "products": [
+                            {
+                                "productName": "yuyi",
+                                "versions": [
+                                    {
+                                        "versionValue": "uuy",
+                                        "versionAffected": "=",
+                                        "references": [
+                                            {
+                                                "url": "https://cwe.mitre.org/data/definitions/284.html",
+                                                "name": "12345",
+                                                "refsource": "12345"
+                                            }
+                                        ]
+                                    }
+                                ],
+                                "packageName": "kgkug"
+                            }
+                        ]
+                    }
+                ]
+            },
+            "providerMetadata": {
+                "id": "88c02595-c8f7-4864-a0e7-e09b3e1da691",
+                "shortName": "cisco",
+                "updated": "2018-11-13T20:20:39+00:00"
+            },
+            "descriptions": [
+                {
+                    "lang": "e",
+                    "value": "y"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "lang": "e",
+                            "description": "y",
+                            "cweId": "CWE-9",
+                            "type": "u",
+                            "references": [
+                                {
+                                    "url": "https://cwe.mitre.org/data/definitions/284.html"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "references": [
+                {
+                    "url": "https://cwe.mitre.org/data/definitions/284.html",
+                    "name": "12345",
+                    "refsource": "12345",
+                    "tags": [
+                        "Broken Link"
+                    ]
+                }
+            ],
+            "impacts": [
+                {
+                    "descriptions": [
+                        {
+                            "lang": "e",
+                            "value": "y"
+                        }
+                    ],
+                    "capecId": "y"
+                }
+            ],
+            "configuration": [
+                {
+                    "lang": "e",
+                    "value": "y"
+                }
+            ],
+            "workaround": [
+                {
+                    "lang": "e",
+                    "value": "y"
+                }
+            ],
+            "exploit": [
+                {
+                    "lang": "e",
+                    "value": "y"
+                }
+            ],
+            "timeline": [
+                {
+                    "time": "2018-11-13T20:20:39+00:00",
+                    "lang": "i",
+                    "value": "y"
+                }
+            ],
+            "credit": [
+                {
+                    "lang": "e",
+                    "value": "y"
+                }
+            ],
+            "source": {
+                "discoverer": "Tom Smith"
+            }
+        }
+    }
+}

--- a/test/unit-tests/middleware/validateJsonSchema5.0.js
+++ b/test/unit-tests/middleware/validateJsonSchema5.0.js
@@ -14,6 +14,7 @@ const mwFixtures = require('./mockObjects.middleware')
 const cveId5 = 'CVE-2017-4024'
 const cvePass5 = require('../../schemas/5.0/' + cveId5 + '_published.json')
 const cveFail5 = require('../../schemas/5.0/' + cveId5 + '_fail.json')
+const cveMetadataFail5 = require('../../schemas/5.0/' + cveId5 + '_fail_cveMetadata.json')
 const cveRejectedFail5 = require('../../schemas/5.0/' + cveId5 + '_rejected_fail.json')
 const cveReservedFail5 = require('../../schemas/5.0/' + cveId5 + '_reserved_fail.json')
 const cvePublishedFail5 = require('../../schemas/5.0/' + cveId5 + '_published_fail.json')
@@ -42,6 +43,26 @@ describe('Test the JSON schema 5.0 validation middleware', () => {
           expect(res.body.message).to.equal('CVE JSON schema validation FAILED.')
           expect(res.body.details).to.have.property('errors').and.to.be.an('array')
           expect(res.body.details.errors[0]).to.have.string('cveMetadata.state is not one of enum values')
+          done()
+        })
+    })
+
+    it('Json validator fails when cveMetadata is not present', (done) => {
+      chai.request(app)
+        .post('/api/test/mw/schema5')
+        .set(mwFixtures.secretariatHeaders)
+        .send(cveMetadataFail5)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          expect(res).to.have.status(400)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          expect(res.body).to.have.property('message').and.to.be.a('string')
+          expect(res.body.message).to.equal('CVE JSON schema validation FAILED.')
+          expect(res.body.details).to.have.property('errors').and.to.be.an('array')
+          expect(res.body.details.errors[0]).to.have.string('instance.cveMetadata is not defined')
           done()
         })
     })


### PR DESCRIPTION
#496 

Fixes issue where ValidateJsonSchema returns a 500 when provided cveMetadata field is misspelled or not present.