### PR TITLE
Updated OpenAPI YAML for CVE v5

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -22,7 +22,7 @@ components:
       description: The shortname for the entity (e.g., CNA, ADP) that is authenticated or requesting authentication.
       required: true
       schema:
-        type: string
+        $ref: https://raw.githubusercontent.com/CVEProject/cve-schema/v5.0.0-rc4/schema/v5.0/CVE_JSON_5.0.schema#/definitions/shortName
     api-user-header:
       in: header
       name: CVE-API-USER
@@ -30,6 +30,7 @@ components:
       required: true
       schema:
         type: string
+        # TODO: this should have a length bound
     api-secret-header:
       in: header
       name: CVE-API-KEY
@@ -37,21 +38,21 @@ components:
       required: true
       schema:
         type: string
+        # TODO: this should have a length bound
     cve-id-path:
       in: path
       name: cve-id
       description: The CVE ID for which the record is being submitted.
       required: true
       schema:
-        type: string
-        pattern: '^CVE-[0-9]{4}-[0-9]{4,}$'
+        $ref: https://raw.githubusercontent.com/CVEProject/cve-schema/v5.0.0-rc4/schema/v5.0/CVE_JSON_5.0.schema#/definitions/cveId
     shortname-path:
       in: path
       name: shortname
       description: The short name of the organization.
       required: true
       schema:
-        type: string
+        $ref: https://raw.githubusercontent.com/CVEProject/cve-schema/v5.0.0-rc4/schema/v5.0/CVE_JSON_5.0.schema#/definitions/shortName
     username-path:
       in: path
       name: username
@@ -112,8 +113,7 @@ components:
       type: object
       properties:
         cve_id:
-          type: string
-          pattern: ^CVE-[0-9]{4}-[0-9]{4,}$
+          $ref: https://raw.githubusercontent.com/CVEProject/cve-schema/v5.0.0-rc4/schema/v5.0/CVE_JSON_5.0.schema#/definitions/cveId
         cve_year:
           type: string
           pattern: ^[0-9]{4}$
@@ -359,8 +359,7 @@ components:
       type: array
       items:
         anyOf:
-          - $ref: 'https://raw.githubusercontent.com/CVEProject/cve-schema/master/schema/v4.0/CVE_JSON_4.0_min_public.schema'
-          - $ref: 'https://raw.githubusercontent.com/CVEProject/cve-schema/master/schema/v4.0/CVE_JSON_4.0_min_reject.schema'
+          - $ref: 'service-api-cve-schema.json#/definitions/cveRecord'
     arrayOfOrgs:
       type: array
       items:
@@ -843,6 +842,7 @@ paths:
           required: false
           schema:
             type: string
+        # TODO: missing request body
       responses:
         200:
           description: The updated CVE-ID record is returned.
@@ -1040,10 +1040,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                anyOf:
-                  - $ref: 'https://raw.githubusercontent.com/CVEProject/cve-schema/master/schema/v4.0/CVE_JSON_4.0_min_public.schema'
-                  - $ref: 'https://raw.githubusercontent.com/CVEProject/cve-schema/master/schema/v4.0/CVE_JSON_4.0_min_reject.schema'
+                $ref: service-api-cve-schema.json#/definitions/cveRecord
         400:
           description: Bad Request
           content:
@@ -1085,6 +1082,7 @@ paths:
         type: String
         enum: ['']
         description: No user roles needed to access the endpoint
+      # TODO: missing request body
       responses:
         200:
           description: Returns the CVE record created.
@@ -1097,10 +1095,7 @@ paths:
                     type: string
                     description: Success description
                   created:
-                    type: object
-                    anyOf:
-                      - $ref: 'https://raw.githubusercontent.com/CVEProject/cve-schema/master/schema/v4.0/CVE_JSON_4.0_min_public.schema'
-                      - $ref: 'https://raw.githubusercontent.com/CVEProject/cve-schema/master/schema/v4.0/CVE_JSON_4.0_min_reject.schema'
+                    $ref: service-api-cve-schema.json#/definitions/cveRecord
         400:
           description: Bad Request
           content:
@@ -1160,10 +1155,257 @@ paths:
                     type: string
                     description: Success description
                   updated:
-                    type: object
-                    anyOf:
-                      - $ref: 'https://raw.githubusercontent.com/CVEProject/cve-schema/master/schema/v4.0/CVE_JSON_4.0_min_public.schema'
-                      - $ref: 'https://raw.githubusercontent.com/CVEProject/cve-schema/master/schema/v4.0/CVE_JSON_4.0_min_reject.schema'
+                    $ref: service-api-cve-schema.json#/definitions/cveRecord
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorBadInput'
+        401:
+          description: Not Authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+        403:
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+  /cve/{cve-id}/cna:
+    parameters:
+      - $ref: '#/components/parameters/api-entity-header'
+      - $ref: '#/components/parameters/api-secret-header'
+      - $ref: '#/components/parameters/api-user-header'
+      - $ref: '#/components/parameters/cve-id-path'
+    get:
+      summary: Returns the CVE record's CNA container by CVE ID
+      description: TODO
+      operationId: unknown # TODO: add correct operation
+      x-org-roles: # TODO: not sure what goes here
+        type: String
+        enum: ['']
+        description: No Organization roles needed to access the endpoint
+      x-user-roles: # TODO: not sure what goes here
+        type: String
+        enum: ['']
+        description: No user roles needed to access the endpoint
+      responses:
+        200:
+          description: The requested CVE record is returned.
+          content:
+            application/json:
+              schema:
+                $ref: service-api-cve-schema.json#/definitions/cnaContainer
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorBadInput'
+        403:
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+    post:
+      summary: Creates a CVE Record by ID
+      description: |
+        <h2>Access Control</h2>
+        <p>At least one of the following roles are needed to access the endpoint:</p>
+        <p>- <b>SECRETARIAT:</b> The user must belong to an Organization with the “SECRETARIAT” role</p>
+        <h2>Expected Behavior</h2>
+        <p><b>Secretariat:</b> Can create a CVE record owned by any Organization</p>
+      description: TODO
+      operationId: unknown # TODO: add correct operation
+      x-org-roles: # TODO: not sure what goes here
+        type: String
+        enum: ['']
+        description: No Organization roles needed to access the endpoint
+      x-user-roles: # TODO: not sure what goes here
+        type: String
+        enum: ['']
+        description: No user roles needed to access the endpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: service-api-cve-schema.json#/definitions/cnaContainer
+      responses:
+        200:
+          description: Returns the CVE record created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: Success description
+                  created:
+                    $ref: service-api-cve-schema.json#/definitions/cnaContainer
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorBadInput'
+        401:
+          description: Not Authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+        403:
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+    put:
+      summary: Updates a CVE Record by ID
+      description: TODO
+      operationId: unknown # TODO: add correct operation
+      x-org-roles: # TODO: not sure what goes here
+        type: String
+        enum: ['']
+        description: No Organization roles needed to access the endpoint
+      x-user-roles: # TODO: not sure what goes here
+        type: String
+        enum: ['']
+        description: No user roles needed to access the endpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: service-api-cve-schema.json#/definitions/cnaContainer
+      responses:
+        200:
+          description: Returns the CVE record updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: Success description
+                  updated:
+                    $ref: service-api-cve-schema.json#/definitions/cnaContainer
+        400:
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorBadInput'
+        401:
+          description: Not Authenticated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+        403:
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+        404:
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+        500:
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/errorGeneric'
+  /cve/{cve-id}/cna/rejected:
+    parameters:
+      - $ref: '#/components/parameters/api-entity-header'
+      - $ref: '#/components/parameters/api-secret-header'
+      - $ref: '#/components/parameters/api-user-header'
+      - $ref: '#/components/parameters/cve-id-path'
+    post:
+      summary: Creates a CVE Record by ID
+      description: |
+        <h2>Access Control</h2>
+        <p>At least one of the following roles are needed to access the endpoint:</p>
+        <p>- <b>SECRETARIAT:</b> The user must belong to an Organization with the “SECRETARIAT” role</p>
+        <h2>Expected Behavior</h2>
+        <p><b>Secretariat:</b> Can create a CVE record owned by any Organization</p>
+      description: TODO
+      operationId: unknown # TODO: add correct operation
+      x-org-roles: # TODO: not sure what goes here
+        type: String
+        enum: ['']
+        description: No Organization roles needed to access the endpoint
+      x-user-roles: # TODO: not sure what goes here
+        type: String
+        enum: ['']
+        description: No user roles needed to access the endpoint
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: service-api-cve-schema.json#/definitions/rejected
+      responses:
+        200:
+          description: Returns the CVE record created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: Success description
+                  created:
+                    $ref: service-api-cve-schema.json#/definitions/rejected
         400:
           description: Bad Request
           content:

--- a/docs/service-api-cve-schema.json
+++ b/docs/service-api-cve-schema.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "https://cve.org/api/2",
+    "type": "object",
+    "title": "CVE JSON record format",
+    "description": "cve-schema specifies the CVE JSON record format. This is the blueprint for a rich set of JSON data that can be submitted by CVE Numbering Authorities (CNAs) and Authorized Data Publishers (ADPs) to describe a CVE record. Some examples of CVE record data include CVE ID number, affected product(s), affected version(s), and public references. While those specific items are required when assigning a CVE, there are many other optional data in the schema that can be used to enrich CVE records for community benefit. Learn more about the CVE program at [the official website](https://cve.mitre.org). This CVE JSON record format is defined using JSON Schema. Learn more about JSON Schema [here](https://json-schema.org/).",
+    "definitions": {
+        "cnaContainer": {
+            "$ref": "https://raw.githubusercontent.com/CVEProject/cve-schema/v5.0.0-rc4/schema/v5.0/CVE_JSON_5.0.schema#/definitions/cnaContainer"
+        }
+    }
+}


### PR DESCRIPTION
# Description of the Change

In the context #510, this PR updates the [OpenAPI YAML](https://github.com/david-waltermire-nist/cve-services/tree/api-v5-update/docs/openapi.yml) for the services for the following endpoints:

- `POST /cve/:id/cna` -> Publish the record, expecting a `cna` container in the JSON body.
- `PUT /cve/:id/cna` -> Update the `cna` container for the record.
- `POST /cve/:id/rejected` -> Reject the CVE. Expects a `descriptions` array with at least one english description and an optional `replacedBy` array to build the new rejected CVE record.

It integrates the CVE Record Format v5 JSON schema through an [integration schema](https://github.com/david-waltermire-nist/cve-services/tree/api-v5-update/docs/service-api-cve-schema.json), which is specific to the service implementation.

This is a work in progress for discussion purposes.
