### PR TITLE
Adding delete user

### DIFF
--- a/src/controller/org.controller/error.js
+++ b/src/controller/org.controller/error.js
@@ -64,6 +64,13 @@ class OrgControllerError extends idrErr.IDRError {
     err.message = `The organization cannot be renamed as '${shortname}' because this shortname is used by another organization.`
     return err
   }
+
+  userToBeRemovedSameAsRequester (username) { //org
+    const err = {}
+    err.error = 'USER_TO_BE_REMOVED_SAME_AS_REQUESTER'
+    err.message = `The user '${username}' cannot be removed as it is the same user as the requester.`
+    return err
+  }
 }
 
 module.exports = {

--- a/src/controller/org.controller/error.js
+++ b/src/controller/org.controller/error.js
@@ -36,6 +36,14 @@ class OrgControllerError extends idrErr.IDRError {
     return err
   }
 
+  userDoesNotExist (username) { //org
+    const err = {}
+    err.error = 'USER_DOES_NOT_EXIST'
+    err.message = `The user '${username}' does not exist.`
+    return err
+  }
+
+
   uuidProvided () { // org
     const err = {}
     err.error = 'UUID_PROVIDED'

--- a/src/controller/org.controller/error.js
+++ b/src/controller/org.controller/error.js
@@ -36,13 +36,12 @@ class OrgControllerError extends idrErr.IDRError {
     return err
   }
 
-  userDoesNotExist (username) { //org
+  userDoesNotExist (username) { // org
     const err = {}
     err.error = 'USER_DOES_NOT_EXIST'
     err.message = `The user '${username}' does not exist.`
     return err
   }
-
 
   uuidProvided () { // org
     const err = {}
@@ -65,7 +64,7 @@ class OrgControllerError extends idrErr.IDRError {
     return err
   }
 
-  userToBeRemovedSameAsRequester (username) { //org
+  userToBeRemovedSameAsRequester (username) { // org
     const err = {}
     err.error = 'USER_TO_BE_REMOVED_SAME_AS_REQUESTER'
     err.message = `The user '${username}' cannot be removed as it is the same user as the requester.`

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -3,7 +3,7 @@ const router = express.Router()
 const mw = require('../../middleware/middleware')
 const controller = require('./org.controller')
 const { body, param, query } = require('express-validator')
-const { parseGetParams, parsePostParams, parseError, isOrgRole, isUserRole } = require('./org.middleware')
+const { parseGetParams, parseDeleteParams, parsePostParams, parseError, isOrgRole, isUserRole } = require('./org.middleware')
 const CONSTANTS = require('../../../src/constants')
 
 router.get('/org',
@@ -90,6 +90,14 @@ router.put('/org/:shortname/user/:username',
   parseError,
   parsePostParams,
   controller.USER_UPDATE_SINGLE)
+router.delete('/org/:shortname/user/:username',
+  mw.onlySecretariatOrAdmin,
+  mw.validateUser,
+  param(['shortname']).isString().trim().escape().notEmpty(),
+  param(['username']).isString().trim().escape().notEmpty(),
+  parseError,
+  parseDeleteParams,
+  controller.USER_DELETE_SINGLE)
 router.put('/org/:shortname/user/:username/reset_secret',
   mw.validateUser,
   param(['shortname']).isString().trim().escape().notEmpty(),

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -9,6 +9,83 @@ const uuid = require('uuid')
 const errors = require('./error')
 const error = new errors.OrgControllerError()
 
+// Delete user from org
+async function deleteUser (req, res, next) {
+  try {
+    const orgShortName = req.ctx.params.shortname
+    const requesterUsername = req.ctx.user
+    const requesterShortName = req.ctx.org
+    const orgRepo = req.ctx.repositories.getOrgRepository()
+    const userRepo = req.ctx.repositories.getUserRepository()
+    const deleteUser = new User()
+
+    const orgUUID = await orgRepo.getOrgUUID(orgShortName)
+    if (!orgUUID) { // the org can only be non-existent if the requestor is the Secretariat
+      logger.info({ uuid: req.ctx.uuid, message: 'The user could not be deleted because ' + orgShortName + ' organization does not exist.' })
+      return res.status(404).json(error.orgDneParam(orgShortName))
+    }
+
+    Object.keys(req.ctx.body).forEach(k => {
+      const key = k.toLowerCase()
+
+      if (key === 'username') {
+        newUser.username = req.ctx.body.username
+      } else if (key === 'org_uuid') {
+        return res.status(400).json(error.uuidProvided())
+      } else if (key === 'uuid') {
+        return res.status(400).json(error.uuidProvided())
+      }
+    })
+
+    const requesterOrgUUID = await orgRepo.getOrgUUID(requesterShortName)
+    const isSecretariat = await orgRepo.isSecretariatUUID(requesterOrgUUID)
+    const isAdmin = await userRepo.isAdminUUID(requesterUsername, requesterOrgUUID)
+    // check if user is only an Admin (not Secretatiat) and the user does not belong to the same organization as the new user
+    if (!isSecretariat && isAdmin) {
+      if (requesterOrgUUID !== orgUUID) {
+        return res.status(403).json(error.notOrgAdminOrSecretariat()) // The Admin user must belong to the new user's organization
+      }
+    }
+
+    deleteUser.org_UUID = orgUUID
+    deleteUser.UUID = uuid.v4()
+    deleteUser.active = true
+
+    let result = await userRepo.findOneByUserNameAndOrgUUID(deleteUser.username, deleteUser.org_UUID) // Find user in MongoDB
+    if (result) {
+      logger.info({ uuid: req.ctx.uuid, message: deleteUser.username + ' was not deleted because it does not exist.' })
+      return res.status(400).json(error.userDoesNotExist(deleteUser.username))
+    }
+
+    // Parsing all user name fields
+    newUser.name = parseUserName(newUser)
+
+    await userRepo.updateByUserNameAndOrgUUID(newUser.username, newUser.org_UUID, newUser, { upsert: true }) // Create user in MongoDB if it doesn't exist
+    const agt = setAggregateUserObj({ username: newUser.username, org_UUID: newUser.org_UUID })
+    result = await userRepo.aggregate(agt)
+    result = result.length > 0 ? result[0] : null
+
+    result.secret = randomKey
+    const responseMessage = {
+      message: result.username + ' was successfully created.',
+      created: result
+    }
+
+    const payload = {
+      action: 'create_user',
+      change: result.username + ' was successfully created.',
+      req_UUID: req.ctx.uuid,
+      org_UUID: await orgRepo.getOrgUUID(req.ctx.org),
+      user: result
+    }
+    payload.user_UUID = await userRepo.getUserUUID(req.ctx.user, payload.org_UUID)
+    logger.info(JSON.stringify(payload))
+    return res.status(200).json(responseMessage)
+  } catch (err) {
+    next(err)
+  }
+}
+
 // Get the details of all orgs
 async function getOrgs (req, res, next) {
   try {
@@ -424,15 +501,11 @@ async function createUser (req, res, next) {
       return res.status(400).json(error.userExists(newUser.username))
     }
 
-    // Parsing all user name fields
-    newUser.name = parseUserName(newUser)
-
-    await userRepo.updateByUserNameAndOrgUUID(newUser.username, newUser.org_UUID, newUser, { upsert: true }) // Create user in MongoDB if it doesn't exist
+    await userRepo.deleteByUserNameAndOrgUUID(deleteUser.username, deleteUser.org_UUID)
     const agt = setAggregateUserObj({ username: newUser.username, org_UUID: newUser.org_UUID })
     result = await userRepo.aggregate(agt)
     result = result.length > 0 ? result[0] : null
 
-    result.secret = randomKey
     const responseMessage = {
       message: result.username + ' was successfully created.',
       created: result

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -12,75 +12,61 @@ const error = new errors.OrgControllerError()
 // Delete user from org
 async function deleteUser (req, res, next) {
   try {
-    const orgShortName = req.ctx.params.shortname
-    const requesterUsername = req.ctx.user
     const requesterShortName = req.ctx.org
+    const requesterUsername = req.ctx.user
+    const username = req.ctx.params.username
+    const shortName = req.ctx.params.shortname
     const orgRepo = req.ctx.repositories.getOrgRepository()
     const userRepo = req.ctx.repositories.getUserRepository()
-    const deleteUser = new User()
+    const orgUUID = await orgRepo.getOrgUUID(shortName)
+    const isSecretariat = await orgRepo.isSecretariat(shortName)
+    const isAdmin = await userRepo.isAdmin(requesterUsername, shortName)
+    let changesRequirePrivilegedRole
 
-    const orgUUID = await orgRepo.getOrgUUID(orgShortName)
-    if (!orgUUID) { // the org can only be non-existent if the requestor is the Secretariat
-      logger.info({ uuid: req.ctx.uuid, message: 'The user could not be deleted because ' + orgShortName + ' organization does not exist.' })
-      return res.status(404).json(error.orgDneParam(orgShortName))
+    if (!orgUUID) {
+      logger.info({ uuid: req.ctx.uuid, message: 'The user could not be deleted because ' + shortName + ' organization does not exist.' })
+      return res.status(404).json(error.orgDneParam(shortName))
     }
 
-    Object.keys(req.ctx.body).forEach(k => {
-      const key = k.toLowerCase()
+    const user = await userRepo.findOneByUserNameAndOrgUUID(username, orgUUID)
+    if (!user) {
+      logger.info({ uuid: req.ctx.uuid, message: 'The user could not be deleted because ' + username + ' does not exist for ' + shortName + ' organization.' })
+      return res.status(404).json(error.userDne(username))
+    }
 
-      if (key === 'username') {
-        newUser.username = req.ctx.body.username
-      } else if (key === 'org_uuid') {
-        return res.status(400).json(error.uuidProvided())
-      } else if (key === 'uuid') {
-        return res.status(400).json(error.uuidProvided())
-      }
-    })
-
-    const requesterOrgUUID = await orgRepo.getOrgUUID(requesterShortName)
-    const isSecretariat = await orgRepo.isSecretariatUUID(requesterOrgUUID)
-    const isAdmin = await userRepo.isAdminUUID(requesterUsername, requesterOrgUUID)
-    // check if user is only an Admin (not Secretatiat) and the user does not belong to the same organization as the new user
-    if (!isSecretariat && isAdmin) {
-      if (requesterOrgUUID !== orgUUID) {
-        return res.status(403).json(error.notOrgAdminOrSecretariat()) // The Admin user must belong to the new user's organization
+    // TODO: change this so that the user can't delete their own account
+    // check if the user is not the requester or if the requester is not a secretariat
+    if ((shortName !== requesterShortName || username !== requesterUsername) && !isSecretariat) {
+      // check if the requester is not an admin; if admin, the requester must be from the same org as the user
+      if (!isAdmin || (isAdmin && shortName !== requesterShortName)) {
+        logger.info({ uuid: req.ctx.uuid, message: 'The user can only be deleted by the Secretariat, or an Org admin.' })
+        return res.status(403).json(error.notSameUserOrSecretariat())
       }
     }
 
-    deleteUser.org_UUID = orgUUID
-    deleteUser.UUID = uuid.v4()
-    deleteUser.active = true
-
-    let result = await userRepo.findOneByUserNameAndOrgUUID(deleteUser.username, deleteUser.org_UUID) // Find user in MongoDB
-    if (result) {
-      logger.info({ uuid: req.ctx.uuid, message: deleteUser.username + ' was not deleted because it does not exist.' })
-      return res.status(400).json(error.userDoesNotExist(deleteUser.username))
+    if (username === requesterUsername) {
+      logger.info({ uuid: req.ctx.uuid, message: 'The' })
+      return res.status(403).json(error.userToBeRemovedSameAsRequester(username))
     }
 
-    // Parsing all user name fields
-    newUser.name = parseUserName(newUser)
+    // deleting user's is only allowed for secretariats and org admins
+    changesRequirePrivilegedRole = true
+    if (changesRequirePrivilegedRole && !(isAdmin || isSecretariat)) {
+      logger.info({ uuid: req.ctx.uuid, message: 'The user could not be deleted because ' + requesterUsername + ' user is not Org Admin or Secretariat.' })
+      return res.status(403).json(error.notOrgAdminOrSecretariat())
+    }
 
-    await userRepo.updateByUserNameAndOrgUUID(newUser.username, newUser.org_UUID, newUser, { upsert: true }) // Create user in MongoDB if it doesn't exist
-    const agt = setAggregateUserObj({ username: newUser.username, org_UUID: newUser.org_UUID })
-    result = await userRepo.aggregate(agt)
-    result = result.length > 0 ? result[0] : null
+    let result = await userRepo.deleteByUserNameAndOrgUUID(username, orgUUID)
+    if (result.n === 0) {
+      logger.info({ uuid: req.ctx.uuid, message: 'The user could not be deleted because ' + username + 'does not exist for ' + shortName + 'organization.' })
+      return res.status(404).json(error.userDne(username))
+    }
 
-    result.secret = randomKey
     const responseMessage = {
-      message: result.username + ' was successfully created.',
-      created: result
+      message: result.username + ' was successfully deleted.'
     }
 
-    const payload = {
-      action: 'create_user',
-      change: result.username + ' was successfully created.',
-      req_UUID: req.ctx.uuid,
-      org_UUID: await orgRepo.getOrgUUID(req.ctx.org),
-      user: result
-    }
-    payload.user_UUID = await userRepo.getUserUUID(req.ctx.user, payload.org_UUID)
-    logger.info(JSON.stringify(payload))
-    return res.status(200).json(responseMessage)
+    return res.status(204).json(responseMessage)
   } catch (err) {
     next(err)
   }
@@ -501,7 +487,7 @@ async function createUser (req, res, next) {
       return res.status(400).json(error.userExists(newUser.username))
     }
 
-    await userRepo.deleteByUserNameAndOrgUUID(deleteUser.username, deleteUser.org_UUID)
+    await userRepo.updateByUserNameAndOrgUUID(newUser.username, newUser.org_UUID, newUser, { upsert: true }) // Create user in MongoDB if it doesn't exist
     const agt = setAggregateUserObj({ username: newUser.username, org_UUID: newUser.org_UUID })
     result = await userRepo.aggregate(agt)
     result = result.length > 0 ? result[0] : null
@@ -810,6 +796,7 @@ module.exports = {
   ORG_ID_QUOTA: getOrgIdQuota,
   USER_SINGLE: getUser,
   USER_CREATE_SINGLE: createUser,
+  USER_DELETE_SINGLE: deleteUser,
   USER_UPDATE_SINGLE: updateUser,
   USER_RESET_SECRET: resetSecret
 }

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -34,7 +34,6 @@ async function deleteUser (req, res, next) {
       return res.status(404).json(error.userDne(username))
     }
 
-    // TODO: change this so that the user can't delete their own account
     // check if the user is not the requester or if the requester is not a secretariat
     if ((shortName !== requesterShortName || username !== requesterUsername) && !isSecretariat) {
       // check if the requester is not an admin; if admin, the requester must be from the same org as the user

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -21,7 +21,7 @@ async function deleteUser (req, res, next) {
     const orgUUID = await orgRepo.getOrgUUID(shortName)
     const isSecretariat = await orgRepo.isSecretariat(shortName)
     const isAdmin = await userRepo.isAdmin(requesterUsername, shortName)
-    let changesRequirePrivilegedRole
+    const changesRequirePrivilegedRole = true
 
     if (!orgUUID) {
       logger.info({ uuid: req.ctx.uuid, message: 'The user could not be deleted because ' + shortName + ' organization does not exist.' })
@@ -49,13 +49,12 @@ async function deleteUser (req, res, next) {
     }
 
     // deleting user's is only allowed for secretariats and org admins
-    changesRequirePrivilegedRole = true
     if (changesRequirePrivilegedRole && !(isAdmin || isSecretariat)) {
       logger.info({ uuid: req.ctx.uuid, message: 'The user could not be deleted because ' + requesterUsername + ' user is not Org Admin or Secretariat.' })
       return res.status(403).json(error.notOrgAdminOrSecretariat())
     }
 
-    let result = await userRepo.deleteByUserNameAndOrgUUID(username, orgUUID)
+    const result = await userRepo.deleteByUserNameAndOrgUUID(username, orgUUID)
     if (result.n === 0) {
       logger.info({ uuid: req.ctx.uuid, message: 'The user could not be deleted because ' + username + 'does not exist for ' + shortName + 'organization.' })
       return res.status(404).json(error.userDne(username))
@@ -765,25 +764,6 @@ function setAggregateUserObj (query) {
       }
     }
   ]
-}
-
-function parseUserName (newUser) {
-  if (newUser.name) {
-    if (!newUser.name.first) {
-      newUser.name.first = ''
-    }
-    if (!newUser.name.last) {
-      newUser.name.last = ''
-    }
-    if (!newUser.name.middle) {
-      newUser.name.middle = ''
-    }
-    if (!newUser.name.suffix) {
-      newUser.name.suffix = ''
-    }
-  }
-
-  return newUser.name
 }
 
 module.exports = {

--- a/src/controller/org.controller/org.middleware.js
+++ b/src/controller/org.controller/org.middleware.js
@@ -42,6 +42,11 @@ function parseGetParams (req, res, next) {
   next()
 }
 
+function parseDeleteParams (req, res, next) {
+  utils.reqCtxMapping(req, 'params', ['shortname', 'username'])
+  next()
+}
+
 function parseError (req, res, next) {
   const err = validationResult(req).formatWith(({ location, msg, param, value, nestedErrors }) => {
     return { msg: msg, param: param, location: location }
@@ -55,6 +60,7 @@ function parseError (req, res, next) {
 module.exports = {
   parsePostParams,
   parseGetParams,
+  parseDeleteParams,
   parseError,
   isOrgRole,
   isUserRole

--- a/src/repositories/userRepository.js
+++ b/src/repositories/userRepository.js
@@ -7,6 +7,10 @@ class UserRepository extends BaseRepository {
     super(User)
   }
 
+  async deleteByUserNameAndOrgUUID (username, orgUUID) {
+    return this.collection.findOneAndRemove().byUserNameAndOrgUUID(username, orgUUID)
+  }
+
   async getUserUUID (userName, orgUUID) {
     return utils.getUserUUID(userName, orgUUID)
   }

--- a/test/unit-tests/user/userDeleteTest.js
+++ b/test/unit-tests/user/userDeleteTest.js
@@ -1,0 +1,242 @@
+const express = require('express')
+const app = express()
+const chai = require('chai')
+const expect = chai.expect
+chai.use(require('chai-http'))
+
+// Body Parser Middleware
+app.use(express.json())
+app.use(express.urlencoded({ extended: false })) // Allows use to handle url encoded data
+const middleware = require('../../../src/middleware/middleware')
+app.use(middleware.createCtxAndReqUUID)
+
+const CONSTANTS = require('../../../src/constants')
+const errors = require('../../../src/controller/org.controller/error')
+const error = new errors.OrgControllerError()
+
+const userFixtures = require('./mockObjects.user')
+const orgController = require('../../../src/controller/org.controller/org.controller')
+const orgParams = require('../../../src/controller/org.controller/org.middleware')
+const { org } = require('../cve-id/mockObjects.cve-id')
+
+describe('Testing the DELETE /org/:shortname/user/:username endpoint in Org Conttroller', () => {
+  context('Negative Tests', () => {
+    it('User cannot be deleted because org does not exist', (done) => {
+      class OrgUserNotUpdatedOrgDoesntExist {
+        async getOrgUUID () {
+          return null
+        }
+
+        async isSecretariat () {
+          return true
+        }
+      }
+
+      class NullUserRepo {
+        async getUserUUID () {
+          return null
+        }
+
+        async findOneByUserNameAndOrgUUID () {
+          return null
+        }
+
+        async isAdmin () {
+          return null
+        }
+      }
+
+      app.route('/user-not-deleted-org-doesnt-exist/:shortname/:username')
+        .delete((req, res, next) => {
+          const factory = {
+            getOrgRepository: () => { return new OrgUserNotUpdatedOrgDoesntExist() },
+            getUserRepository: () => { return new NullUserRepo() }
+          }
+          req.ctx.repositories = factory
+          next()
+        }, orgParams.parseDeleteParams, orgController.USER_DELETE_SINGLE)
+
+      const shortname = userFixtures.nonExistentOrg.short_name.replace(/\s/g, '')
+      const username = userFixtures.existentUser.username.replace(/\s/g, '')
+      chai.request(app)
+        .delete(`/user-not-deleted-org-doesnt-exist/${shortname}/${username}`)
+        .set(userFixtures.secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          expect(res).to.have.status(404)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          const errObj = error.orgDneParam(userFixtures.nonExistentOrg.short_name)
+          expect(res.body.error).to.equal(errObj.error)
+          expect(res.body.message).to.equal(errObj.message)
+          done()
+        })
+    })
+
+    it('User cannot be deleted because user does not exist', (done) => {
+      class OrgUserNotDeletedOrgDoesntExist {
+        async getOrgUUID () {
+          return userFixtures.existentOrg
+        }
+
+        async isSecretariat () {
+          return true
+        }
+      }
+
+      class UserNotDeletedUserDoesntExist {
+        async findOneByUserNameAndOrgUUID () {
+          return null
+        }
+
+        async isAdmin () {
+          return null
+        }
+      }
+
+      app.route('/user-not-deleted-user-doesnt-exist/:shortname/:username')
+        .delete((req, res, next) => {
+          const factory = {
+            getOrgRepository: () => { return new OrgUserNotDeletedOrgDoesntExist() },
+            getUserRepository: () => { return new UserNotDeletedUserDoesntExist() }
+          }
+          req.ctx.repositories = factory
+          next()
+        }, orgParams.parseDeleteParams, orgController.USER_DELETE_SINGLE)
+
+      const shortname = userFixtures.existentOrg.short_name.replace(/\s/g, '')
+      const username = userFixtures.nonExistentUser.username.replace(/\s/g, '')
+      chai.request(app)
+        .delete(`/user-not-deleted-user-doesnt-exist/${userFixtures.existentOrg.short_name}/${userFixtures.nonExistentUser.username}`)
+        .set(userFixtures.secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          expect(res).to.have.status(404)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          const errObj = error.userDne(userFixtures.nonExistentUser.username)
+          expect(res.body.error).to.equal(errObj.error)
+          expect(res.body.message).to.equal(errObj.message)
+          done()
+        })
+    })
+
+    it('User cannot be deleted because requester is not Org Admin or Secretariat', (done) => {
+      class Org {
+        async getOrgUUID () {
+          return userFixtures.existentOrg.UUID
+        }
+
+        async isSecretariat () {
+          return false
+        }
+      }
+
+      class User {
+        async findOneByUserNameAndOrgUUID () {
+          return userFixtures.existentUser
+        }
+
+        async isAdmin () {
+          return false
+        }
+      }
+
+      app.route('/user-not-deleted-requester-not-admin-secretariat/:shortname/:username')
+        .delete((req, res, next) => {
+          const factory = {
+            getOrgRepository: () => { return new Org() },
+            getUserRepository: () => { return new User() }
+          }
+          req.ctx.repositories = factory
+          next()
+        }, orgParams.parseDeleteParams, orgController.USER_DELETE_SINGLE)
+
+      chai.request(app)
+        .delete(`/user-not-deleted-requester-not-admin-secretariat/${userFixtures.existentOrg.short_name}/${userFixtures.existentUser.username}`)
+        .set(userFixtures.owningOrgHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          expect(res).to.have.status(403)
+          expect(res).to.have.property('body').and.to.be.a('object')
+          const errObj = error.notSameUserOrSecretariat()
+          expect(res.body.error).to.equal(errObj.error)
+          expect(res.body.message).to.equal(errObj.message)
+          done()
+        })
+    })
+  })
+
+  context('Positive Tests', (done) => {
+    it('', (done) => {
+      class Org {
+        async getOrgUUID () {
+          return userFixtures.existentOrgDummy.UUID
+        }
+
+        async isSecretariat () {
+          return false
+        }
+      }
+
+      class User {
+        constructor () {
+          this.testRes1 = JSON.parse(JSON.stringify(userFixtures.userA))
+          this.testRes1.active = false
+        }
+
+        async findOneByUserNameAndOrgUUID () {
+          return userFixtures.userA
+        }
+
+        async isAdmin (username, shortname) {
+          expect(username).to.equal(userFixtures.userDHeader['CVE-API-USER'])
+          expect(shortname).to.equal(userFixtures.existentOrgDummy.short_name)
+          return true
+        }
+
+        async deleteByUserNameAndOrgUUID () {
+          return { n: 1 }
+        }
+
+        async getUserUUID () {
+          return userFixtures.userD.UUID
+        }
+
+        async aggregate () {
+          return [this.testRes1]
+        }
+      }
+
+      app.route('/user-deleted-requester-admin/:shortname/:username')
+        .delete((req, res, next) => {
+          const factory = {
+            getOrgRepository: () => { return new Org() },
+            getUserRepository: () => { return new User() }
+          }
+          req.ctx.repositories = factory
+          next()
+        }, orgParams.parseDeleteParams, orgController.USER_DELETE_SINGLE)
+    })
+
+    chai.request(app)
+      .delete(`/user-deleted-requester-admin/${userFixtures.existentOrgDummy.short_name}/${userFixtures.userA.username}`)
+      .set(userFixtures.userDHeader)
+      .end((err, res) => {
+        if (err) {
+          done(err)
+        }
+
+        console.log(res)
+        expect(res).to.have.status(204)
+        done()
+      })
+  })
+})

--- a/test/unit-tests/user/userDeleteTest.js
+++ b/test/unit-tests/user/userDeleteTest.js
@@ -10,14 +10,12 @@ app.use(express.urlencoded({ extended: false })) // Allows use to handle url enc
 const middleware = require('../../../src/middleware/middleware')
 app.use(middleware.createCtxAndReqUUID)
 
-const CONSTANTS = require('../../../src/constants')
 const errors = require('../../../src/controller/org.controller/error')
 const error = new errors.OrgControllerError()
 
 const userFixtures = require('./mockObjects.user')
 const orgController = require('../../../src/controller/org.controller/org.controller')
 const orgParams = require('../../../src/controller/org.controller/org.middleware')
-const { org } = require('../cve-id/mockObjects.cve-id')
 
 describe('Testing the DELETE /org/:shortname/user/:username endpoint in Org Conttroller', () => {
   context('Negative Tests', () => {
@@ -106,8 +104,6 @@ describe('Testing the DELETE /org/:shortname/user/:username endpoint in Org Cont
           next()
         }, orgParams.parseDeleteParams, orgController.USER_DELETE_SINGLE)
 
-      const shortname = userFixtures.existentOrg.short_name.replace(/\s/g, '')
-      const username = userFixtures.nonExistentUser.username.replace(/\s/g, '')
       chai.request(app)
         .delete(`/user-not-deleted-user-doesnt-exist/${userFixtures.existentOrg.short_name}/${userFixtures.nonExistentUser.username}`)
         .set(userFixtures.secretariatHeader)
@@ -198,7 +194,7 @@ describe('Testing the DELETE /org/:shortname/user/:username endpoint in Org Cont
         }
 
         async deleteByUserNameAndOrgUUID (username, orgUUID) {
-          return userFixtures.userA.username, userFixtures.existentOrg.UUID
+          return (userFixtures.userA.username, userFixtures.existentOrg.UUID)
         }
       }
 
@@ -246,7 +242,7 @@ describe('Testing the DELETE /org/:shortname/user/:username endpoint in Org Cont
         }
 
         async deleteByUserNameAndOrgUUID (username, orgUUID) {
-          return userFixtures.userA.username, userFixtures.existentOrg.UUID
+          return (userFixtures.userA.username, userFixtures.existentOrg.UUID)
         }
       }
 

--- a/test/unit-tests/user/userDeleteTest.js
+++ b/test/unit-tests/user/userDeleteTest.js
@@ -174,8 +174,8 @@ describe('Testing the DELETE /org/:shortname/user/:username endpoint in Org Cont
     })
   })
 
-  context('Positive Tests', (done) => {
-    it('', (done) => {
+  context('Positive Tests', () => {
+    it('User can be deleted because requester is an Org Admin', (done) => {
       class Org {
         async getOrgUUID () {
           return userFixtures.existentOrgDummy.UUID
@@ -187,11 +187,6 @@ describe('Testing the DELETE /org/:shortname/user/:username endpoint in Org Cont
       }
 
       class User {
-        constructor () {
-          this.testRes1 = JSON.parse(JSON.stringify(userFixtures.userA))
-          this.testRes1.active = false
-        }
-
         async findOneByUserNameAndOrgUUID () {
           return userFixtures.userA
         }
@@ -202,16 +197,8 @@ describe('Testing the DELETE /org/:shortname/user/:username endpoint in Org Cont
           return true
         }
 
-        async deleteByUserNameAndOrgUUID () {
-          return { n: 1 }
-        }
-
-        async getUserUUID () {
-          return userFixtures.userD.UUID
-        }
-
-        async aggregate () {
-          return [this.testRes1]
+        async deleteByUserNameAndOrgUUID (username, orgUUID) {
+          return userFixtures.userA.username, userFixtures.existentOrg.UUID
         }
       }
 
@@ -224,19 +211,66 @@ describe('Testing the DELETE /org/:shortname/user/:username endpoint in Org Cont
           req.ctx.repositories = factory
           next()
         }, orgParams.parseDeleteParams, orgController.USER_DELETE_SINGLE)
+
+      chai.request(app)
+        .delete(`/user-deleted-requester-admin/${userFixtures.existentOrgDummy.short_name}/${userFixtures.userA.username}`)
+        .set(userFixtures.userDHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          expect(res).to.have.status(204)
+          done()
+        })
     })
 
-    chai.request(app)
-      .delete(`/user-deleted-requester-admin/${userFixtures.existentOrgDummy.short_name}/${userFixtures.userA.username}`)
-      .set(userFixtures.userDHeader)
-      .end((err, res) => {
-        if (err) {
-          done(err)
+    it('User can be deleted because requester is the Secretariat', (done) => {
+      class Org {
+        async getOrgUUID () {
+          return userFixtures.existentOrgDummy.UUID
         }
 
-        console.log(res)
-        expect(res).to.have.status(204)
-        done()
-      })
+        async isSecretariat () {
+          return true
+        }
+      }
+
+      class User {
+        async findOneByUserNameAndOrgUUID () {
+          return userFixtures.userA
+        }
+
+        async isAdmin () {
+          return false
+        }
+
+        async deleteByUserNameAndOrgUUID (username, orgUUID) {
+          return userFixtures.userA.username, userFixtures.existentOrg.UUID
+        }
+      }
+
+      app.route('/user-deleted-requester-secretariat/:shortname/:username')
+        .delete((req, res, next) => {
+          const factory = {
+            getOrgRepository: () => { return new Org() },
+            getUserRepository: () => { return new User() }
+          }
+          req.ctx.repositories = factory
+          next()
+        }, orgParams.parseDeleteParams, orgController.USER_DELETE_SINGLE)
+
+      chai.request(app)
+        .delete(`/user-deleted-requester-secretariat/${userFixtures.existentOrgDummy.short_name}/${userFixtures.userA.username}`)
+        .set(userFixtures.secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          expect(res).to.have.status(204)
+          done()
+        })
+    })
   })
 })


### PR DESCRIPTION
### Issue

#507 

### Description of the Change

Added an endpoint that supports deleting a user from a CNA organisation. This would allow CNAs to remove users from their CNA organisation who may have left their organisation.

DELETE /org/:shortname/user/:username -> CNA Admin or Secretariat

### Alternate Designs

The alternate design was to keep leveraging the update user endpoint to disable the user account however, this would lead to CNAs having to ensure the users in the CNA organisation are enabled/disabled correctly.

### Possible Drawbacks

None that I think of currently.

### Verification Process

I did manual testing as well as created tests to cover the endpoint.

### Release Notes

Added support for deleting users from a CNA if the requester is a CNA admin or secretariat.
