### PR TITLE
Stop populating CVE records

### DIFF
--- a/src/scripts/populate.js
+++ b/src/scripts/populate.js
@@ -104,10 +104,12 @@ db.once('open', async () => {
       ))
 
       // CVE
-      populatePromises.push(dataUtils.populateCollection(
-        './datadump/pre-population/cves.json',
-        Cve, dataUtils.newCveTransform
-      ))
+      if (process.env.NODE_ENV === 'development') {
+        populatePromises.push(dataUtils.populateCollection(
+          './datadump/pre-population/cves.json',
+          Cve, dataUtils.newCveTransform
+        ))
+      }
 
       // CVE ID, depends on User and Org
       populatePromises.push(dataUtils.populateCollection(


### PR DESCRIPTION
Only populate fake CVE records when the populate script is ran with a dev environment.