### PR TITLE
Update the Python test docker container to use a smaller image

### DIFF
--- a/.github/workflows/test-http.yml
+++ b/.github/workflows/test-http.yml
@@ -40,7 +40,7 @@ jobs:
         path: test-http/src/testOutput.txt
         retention-days: 1
     - name: Extract Tests Results
-      run: docker exec demon /bin/sh src/parse_tests_output.sh | (read foo; echo "##[set-output name=result;]$(echo $foo)")
+      run: docker exec demon /bin/bash src/parse_tests_output.sh | (read foo; echo "##[set-output name=result;]$(echo $foo)")
       id: tests_result
     - name: Evaluate Tests Results
       if: ${{ steps.tests_result.outputs.result == 'Tests failed' }}

--- a/.github/workflows/test-http.yml
+++ b/.github/workflows/test-http.yml
@@ -40,7 +40,7 @@ jobs:
         path: test-http/src/testOutput.txt
         retention-days: 1
     - name: Extract Tests Results
-      run: docker exec demon /bin/bash src/parse_tests_output.sh | (read foo; echo "##[set-output name=result;]$(echo $foo)")
+      run: docker exec demon /bin/sh src/parse_tests_output.sh | (read foo; echo "##[set-output name=result;]$(echo $foo)")
       id: tests_result
     - name: Evaluate Tests Results
       if: ${{ steps.tests_result.outputs.result == 'Tests failed' }}

--- a/test-http/README.md
+++ b/test-http/README.md
@@ -1,6 +1,6 @@
 # CVE Services Endpoint Testing
 
-**Warning**: do not point these tests at production.
+**Warning**: do not point these tests at production!!!
 
 This portion of the repository contains HTTP tests written using Python `requests`, and `pytest`. They can be run against any instantiation of the REST API by updating `test-http/docker/.docker-env` accordingly. The REST API must have a backing MongoDb database. Tests should not be run against production, since they do update and delete data. Some tests assume that the MITRE organization exists and is the secretariat.
 
@@ -11,16 +11,15 @@ The following will run tests against an existing instance of the CPS and service
 ```sh
 cd test-http
 
-# update empty credentials in docker env file
+# Copy default credentials
+# Edit these to point at the desired endpoint
 cp docker/.docker-env.example docker/.docker-env
 
-# optional but recommended: use the project's shared testing bash aliases
-source config/.bashrc
-demon-build  # docker-compose --file docker/docker-compose.yml up
+# Run the testing container
+docker-compose --file docker/docker-compose.yml up --build
 
-# in a separate bash shell from the `cve-services/test-http/` folder
-source config/.bashrc
-demon pytest src/  # docker exec -it demon pytest src/
+# Run the tests
+docker exec -it demon pytest src/
 ```
 
 ## External Documentation

--- a/test-http/config/.bashrc
+++ b/test-http/config/.bashrc
@@ -1,7 +1,9 @@
 # Testing Aliases
-# - source this file for useful bash commands
+#
+# Source this file for useful shell aliases
+
 alias demon='docker exec -it demon'
-alias demon-bash='demon /bin/bash'
+alias demon-sh='demon /bin/sh'
 alias demon-run='\
     docker-compose \
         --file docker/docker-compose.yml \

--- a/test-http/config/.bashrc
+++ b/test-http/config/.bashrc
@@ -3,7 +3,7 @@
 # Source this file for useful shell aliases
 
 alias demon='docker exec -it demon'
-alias demon-sh='demon /bin/sh'
+alias demon-bash='demon /bin/bash'
 alias demon-run='\
     docker-compose \
         --file docker/docker-compose.yml \

--- a/test-http/docker/Dockerfile
+++ b/test-http/docker/Dockerfile
@@ -1,33 +1,14 @@
-FROM debian:stable
+FROM python:3.9-slim-buster
 
-LABEL \
-    name="Dockerized Endpoint Testing", \
-    maintainer="Colin Payne-Rogers" \
-    email="cpaynerogers@mitre.org"
+LABEL name="Dockerized Endpoint Testing"
 
 WORKDIR /app
-
-# install python, build prerequisites, MITRE certificates
-RUN apt-get update \
-    && apt-get install -y \
-        ca-certificates \
-        curl \
-        python3 \
-        python3-pip \
-        vim \
-    && curl -skL 'https://bitbucket.ecis.mitre.org/projects/DOCKER/repos/docker/browse/install/install_mitre_certificates.sh?&raw' | bash \
-# prerequisites smoke tests
-    && curl --version \
-    && pip3 --version \
-    && python3 --version
-
-# install required Python packages
-# this also points the requests package at the MITRE certificate chain
 COPY docker/reqs.txt ./
-RUN pip3 install -r reqs.txt \
-    && curl -sf http://pki.mitre.org/MITRE-chain.txt -o MITRE-chain.txt \
-    && cat MITRE-chain.txt >> "$(python3 -c 'import requests; print(requests.certs.where())')"
-
 COPY src ./src
 COPY docker/entrypoint.sh ./
+
+RUN pip3 --version
+RUN python3 --version
+RUN pip3 install -r reqs.txt
+
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/test-http/docker/entrypoint.sh
+++ b/test-http/docker/entrypoint.sh
@@ -1,9 +1,8 @@
-#!/bin/bash
+#!/bin/sh
+# Do not exit the container
+# - Instead, wait to run tests using `docker exec -it`
+# - This enables capturing of Python's debugger and re-running tests
+#   without restarting the container
 
-# do not exit the container
-# - instead, wait to run tests using `docker exec -it`
-# - this enables capturing of Python's debugger, and re-running tests without
-#   restarting the container
-# - a separate entrypoint will be useful to deploy this to GitHub Actions
 echo "Waiting."
 sleep 99999

--- a/test-http/docker/entrypoint.sh
+++ b/test-http/docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Do not exit the container
 # - Instead, wait to run tests using `docker exec -it`
 # - This enables capturing of Python's debugger and re-running tests


### PR DESCRIPTION
https://github.com/CVEProject/cve-services/issues/543

### Description of the Change

Use the `slim-buster` Python image over the stable `debian` image.

### Quantitative Performance Benefits

This wasn't measured but should be easy to see from the diff

### Possible Drawbacks

I don't see any

### Verification Process

The HTTP tests GitHub Action still needs to pass

### Applicable Issues

NA

### Release Notes

Slim down Python docker testing image
