### PR TITLE
Issue #574

### DIFF
--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -485,6 +485,11 @@ async function updateUser (req, res, next) {
       return res.status(404).json(error.orgDneParam(shortName))
     }
 
+    if (shortName !== requesterShortName && !isSecretariat) {
+      logger.info({ uuid: req.ctx.uuid, message: shortName + ' organization can only be viewed by the users of the same organization or the Secretariat.' })
+      return res.status(403).json(error.notSameOrgOrSecretariat())
+    }
+
     const user = await userRepo.findOneByUserNameAndOrgUUID(username, orgUUID)
     if (!user) {
       logger.info({ uuid: req.ctx.uuid, message: 'The user could not be updated because ' + username + ' does not exist for ' + shortName + ' organization.' })

--- a/test/unit-tests/user/userUpdateTest.js
+++ b/test/unit-tests/user/userUpdateTest.js
@@ -42,7 +42,7 @@ class OrgUserUpdatedAddingRole {
 }
 
 class UserUpdatedAddingRole {
-  constructor () {
+  constructor() {
     this.user = {
       org_UUID: userFixtures.existentUserDummy.org_UUID,
       username: userFixtures.existentUserDummy.username,
@@ -270,7 +270,7 @@ describe('Testing the PUT /org/:shortname/user/:username endpoint in Org Control
 
           expect(res).to.have.status(403)
           expect(res).to.have.property('body').and.to.be.a('object')
-          const errObj = error.notSameUserOrSecretariat()
+          const errObj = error.notSameOrgOrSecretariat()
           expect(res.body.error).to.equal(errObj.error)
           expect(res.body.message).to.equal(errObj.message)
           done()
@@ -320,7 +320,7 @@ describe('Testing the PUT /org/:shortname/user/:username endpoint in Org Control
 
           expect(res).to.have.status(403)
           expect(res).to.have.property('body').and.to.be.a('object')
-          const errObj = error.notSameUserOrSecretariat()
+          const errObj = error.notSameOrgOrSecretariat()
           expect(res.body.error).to.equal(errObj.error)
           expect(res.body.message).to.equal(errObj.message)
           done()
@@ -423,7 +423,7 @@ describe('Testing the PUT /org/:shortname/user/:username endpoint in Org Control
 
     it('User is unchanged: Adding a user role that the user already have', (done) => {
       class UserUpdatedAddingRoleAlreadyExists {
-        constructor () {
+        constructor() {
           this.user = {
             org_UUID: userFixtures.existentUserDummy.org_UUID,
             username: userFixtures.existentUserDummy.username,
@@ -508,7 +508,7 @@ describe('Testing the PUT /org/:shortname/user/:username endpoint in Org Control
 
     it('User is updated: Removing a user role', (done) => {
       class UserUpdatedRemovingRole {
-        constructor () {
+        constructor() {
           this.user = {
             org_UUID: userFixtures.existentUserDummy.org_UUID,
             username: userFixtures.existentUserDummy.username,
@@ -593,7 +593,7 @@ describe('Testing the PUT /org/:shortname/user/:username endpoint in Org Control
 
     it('User is unchanged: Removing a user role that the user does not have', (done) => {
       class UserUpdatedRemovingRoleAlreadyRemoved {
-        constructor () {
+        constructor() {
           this.user = {
             org_UUID: userFixtures.existentUserDummy.org_UUID,
             username: userFixtures.existentUserDummy.username,
@@ -677,7 +677,7 @@ describe('Testing the PUT /org/:shortname/user/:username endpoint in Org Control
       }
 
       class User {
-        constructor () {
+        constructor() {
           this.testRes1 = JSON.parse(JSON.stringify(userFixtures.userA))
           this.testRes1.active = false
         }
@@ -743,7 +743,7 @@ describe('Testing the PUT /org/:shortname/user/:username endpoint in Org Control
       }
 
       class User {
-        constructor () {
+        constructor() {
           this.testRes1 = JSON.parse(JSON.stringify(userFixtures.userA))
           this.testRes1.username = 'TESTER'
         }


### PR DESCRIPTION
### Identify the Bug

Link to issue: #574  

### Description of the Change

Added a check to see if the org name used to authenticate is the same as the short name provided in the parameters. This means that if someone tries to enumerate users across CNAs they will get a 403 and the following error:

```json
{
    "error": "NOT_SAME_ORG_OR_SECRETARIAT",
    "message": "This information can only be viewed by the users of the same organization or the Secretariat."
}
```
The unit tests have been updated with this change.

### Alternate Designs

Doesn't really appear to any other designs as this pattern has been used on other /org/{shortname}/user endpoints.

### Possible Drawbacks

Can't really think of any as you wouldn't want user enumeration across CNAs.

### Verification Process

Replicated the PoC provided in the issue and proved that it is no longer valid. Also tested using a secretariat account and that works as expected.

Unit tests have been updated and are all 🟢 

### Release Notes

Fixed a bug in the UpdateUser API endpoint that could lead to user enumeration across CNAs.
