### PR TITLE
Issue #569

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ app.use(express.urlencoded({ extended: true })) // Allows us to handle url encod
 app.use('/api/', mw.createCtxAndReqUUID)
 global.mongoose = mongoose // Make mongoose connection available globally
 configureRoutes(app) // Define api routes
-app.use(mw.largeInputErrorHandler) // error handler for large input
+app.use(mw.validateJsonSyntax) // error handler for large input and JSON syntax
 app.use(mw.errorHandler) // error handler middleware
 
 // Handle 404 - Keep this as a last route

--- a/src/middleware/error.js
+++ b/src/middleware/error.js
@@ -47,6 +47,13 @@ class MiddlewareError extends idrErr.IDRError {
     return err
   }
 
+  invalidJsonSyntax (errors) { // mw
+    const err = {}
+    err.error = 'INVALID_JSON_SYNTAX'
+    err.message = errors
+    return err
+  }
+
   recordTooLarge () {
     const err = {}
     err.error = 'RECORD_TOO_LARGE'

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -205,11 +205,17 @@ function validateCveJsonSchema (req, res, next) {
   }
 }
 
-function largeInputErrorHandler (err, req, res, next) {
+function validateJsonSyntax (err, req, res, next) {
   if (err.status && err.message) {
-    console.warn('Request failed validation because entity too large')
-    console.info((JSON.stringify(err)))
-    return res.status(400).json(error.recordTooLarge(errors))
+    if (err.message.includes('Unexpected token')) {
+      console.warn('Request failed validation because JSON syntax is incorrect')
+      console.info((JSON.stringify(err)))
+      return res.status(400).json(error.invalidJsonSyntax(err.message))
+    } else if (err.message.includes('request entity too large')) {
+      console.warn('Request failed validation because entity too large')
+      console.info((JSON.stringify(err)))
+      return res.status(413).json(error.recordTooLarge(errors))
+    }
   } else {
     next(err)
   }
@@ -228,6 +234,6 @@ module.exports = {
   cnaMustOwnID,
   createCtxAndReqUUID,
   validateCveJsonSchema,
-  largeInputErrorHandler,
-  errorHandler
+  errorHandler,
+  validateJsonSyntax
 }

--- a/test-http/src/test/cve_tests/cve.py
+++ b/test-http/src/test/cve_tests/cve.py
@@ -445,7 +445,7 @@ def test_record_submission_too_large():
             headers=utils.BASE_HEADERS,
             json=data
         )
-        assert res.status_code == 400 # payload is too large
+        assert res.status_code == 413 # payload is too large
         response_contains_json(res, 'error', 'RECORD_TOO_LARGE')
 
 
@@ -458,7 +458,7 @@ def test_record_update_too_large():
             headers=utils.BASE_HEADERS,
             json=data
         )
-        assert res.status_code == 400 # payload is too large
+        assert res.status_code == 413 # payload is too large
         response_contains_json(res, 'error', 'RECORD_TOO_LARGE')
 
 

--- a/test-http/src/test/user_tests/user.py
+++ b/test-http/src/test/user_tests/user.py
@@ -13,7 +13,7 @@ def test_get_all_users():
         f'{env.AWG_BASE_URL}/api/users',
         headers=utils.BASE_HEADERS
     )
-    print(res.content)
+
     assert json.loads(res.content.decode())['users'][0]['username'] == 'admin2@mitre.org'
     assert json.loads(res.content.decode())['users'][0]['name']['first'] == 'Sheila'
     assert '"secret"' not in res.content.decode() # check that no secrets are included

--- a/test-http/src/test/user_tests/user.py
+++ b/test-http/src/test/user_tests/user.py
@@ -14,8 +14,8 @@ def test_get_all_users():
         headers=utils.BASE_HEADERS
     )
     print(res.content)
-    assert json.loads(res.content.decode())['users'][0]['username'] == 'cps@mitre.org'
-    assert json.loads(res.content.decode())['users'][0]['name']['first'] == 'Jeremy'
+    assert json.loads(res.content.decode())['users'][0]['username'] == 'admin2@mitre.org'
+    assert json.loads(res.content.decode())['users'][0]['name']['first'] == 'Sheila'
     assert '"secret"' not in res.content.decode() # check that no secrets are included
     assert res.status_code == 200
 

--- a/test-http/src/test/user_tests/user.py
+++ b/test-http/src/test/user_tests/user.py
@@ -15,7 +15,7 @@ def test_get_all_users():
     )
 
     assert json.loads(res.content.decode())['users'][0]['username'] == 'cps@mitre.org'
-    assert json.loads(res.content.decode())['users'][0]['name']['first'] == 'Sheila'
+    assert json.loads(res.content.decode())['users'][0]['name']['first'] == 'Jeremy'
     assert '"secret"' not in res.content.decode() # check that no secrets are included
     assert res.status_code == 200
 

--- a/test-http/src/test/user_tests/user.py
+++ b/test-http/src/test/user_tests/user.py
@@ -13,6 +13,7 @@ def test_get_all_users():
         f'{env.AWG_BASE_URL}/api/users',
         headers=utils.BASE_HEADERS
     )
+    print(res.content)
     assert json.loads(res.content.decode())['users'][0]['username'] == 'cps@mitre.org'
     assert json.loads(res.content.decode())['users'][0]['name']['first'] == 'Jeremy'
     assert '"secret"' not in res.content.decode() # check that no secrets are included

--- a/test-http/src/test/user_tests/user.py
+++ b/test-http/src/test/user_tests/user.py
@@ -14,7 +14,7 @@ def test_get_all_users():
         headers=utils.BASE_HEADERS
     )
 
-    assert json.loads(res.content.decode())['users'][0]['username'] == 'admin2@mitre.org'
+    assert json.loads(res.content.decode())['users'][0]['username'] == 'cps@mitre.org'
     assert json.loads(res.content.decode())['users'][0]['name']['first'] == 'Sheila'
     assert '"secret"' not in res.content.decode() # check that no secrets are included
     assert res.status_code == 200


### PR DESCRIPTION
### Identify the Bug

Link to issue: #569 #509 

### Description of the Change

Updated the functionality of `largeInputErrorHandler` middleware to check for JSON syntax issues and request bodies larger than 16mb. The `largeInputErrorHandler` function has been renamed to `validateJsonSyntax` to align with the dual purposes of the function.

If the body has a JSON syntax error the following error will be returned:

```json
{
    "error": "INVALID_JSON_SYNTAX",
    "message": "Unexpected token , in JSON at position 169"
}
```

If the body is larger than 16mb then the following error will be returned with the HTTP status code of [413](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413):

```json
{
    "error": "RECORD_TOO_LARGE",
    "message": "Records must be less than 16MB."
}
```

Unit tests haven't been created for this piece of middleware as Mocha doesn't handle JSON files that are invalid and for payloads that are too large it fails before returning the correct errors. Appropriate test coverage will have to be handled by the black box testing.

### Alternate Designs

There is another possibility of splitting the middleware functionality into two separate functions however, you essentially end up with the same issue with the first function that is meant to only validate syntax returning an error on the JSON payload exceeding the size limits.

### Possible Drawbacks

There could be other errors that aren't caught in this validator but its unlikely there will be many if any.

### Verification Process

Replicated the PoC provided in the issue and proved that it is no longer valid.

### Release Notes

Fixed a bug where posting a JSON body with a syntax error would return a record too large error.
