### PR TITLE
Fix Flaky Black Box Test for test_get_all_users

### DIFF
--- a/datadump/pre-population/users.json
+++ b/datadump/pre-population/users.json
@@ -745,7 +745,7 @@
         }
     },
     {
-        "username": "cps@mitre.org",
+        "username": "cps2@mitre.org",
         "cna_short_name": "mitre",
         "active": true,
         "name": {

--- a/test-http/src/test/user_tests/user.py
+++ b/test-http/src/test/user_tests/user.py
@@ -13,8 +13,12 @@ def test_get_all_users():
         f'{env.AWG_BASE_URL}/api/users',
         headers=utils.BASE_HEADERS
     )
-    assert json.loads(res.content.decode())['users'][0]['username'] == 'cps@mitre.org'
-    assert json.loads(res.content.decode())['users'][0]['name']['first'] == 'Jeremy'
+    test_user={}
+    for user in json.loads(res.content.decode())['users']:
+        if user['username'] == 'cps@mitre.org':
+            test_user = user
+    assert test_user['username'] == 'cps@mitre.org'
+    assert test_user['name']['first'] == 'Jeremy'
     assert '"secret"' not in res.content.decode() # check that no secrets are included
     assert res.status_code == 200
 

--- a/test-http/src/test/user_tests/user.py
+++ b/test-http/src/test/user_tests/user.py
@@ -17,6 +17,7 @@ def test_get_all_users():
     for user in json.loads(res.content.decode())['users']:
         if user['username'] == 'cps@mitre.org':
             test_user = user
+            break
     assert test_user['username'] == 'cps@mitre.org'
     assert test_user['name']['first'] == 'Jeremy'
     assert '"secret"' not in res.content.decode() # check that no secrets are included


### PR DESCRIPTION
### Identify the Bug
https://github.com/CVEProject/cve-services/issues/582

### Description of the Change
The `test_get_all_users` test was checking the first element of the json array for all users. As json does not ensure ordering this test would sometimes fail.

This now loops over users and properly selects the user to always verify the correct user.

There was also an issue where there was a duplicate user in `datadump/pre-population/users.json`. There was a second user with the same username `cps@mitre.org`.

### Alternate Designs
Could remove this test but I think with this fix it still provides value.

### Possible Drawbacks
The test doesn't exhaustively check every single user in the response.

### Verification Process
I tested running the tests manually.

### Release Notes
N/A