### PR TITLE
for issue 570, unauthenticated /cve-id/:id GET with partial data

### DIFF
--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -22,18 +22,18 @@ async function getCveId (req, res, next) {
       return res.status(404).json(error.cveIdNotFound(id))
     }
 
-    var logger_uuid;
-    var orgShortName;
-    var orgUUID;
-    var isSecretariat;
+    var loggerUuid
+    var orgShortName
+    var orgUUID
+    var isSecretariat
 
     if (unauth) {
-      logger_uuid = "00000000-0000-4000-9000-000000000000";
-      isSecretariat = false;
-      orgShortName = "";
+      loggerUuid = '00000000-0000-4000-9000-000000000000'
+      isSecretariat = false
+      orgShortName = ''
     } else {
-      logger_uuid = req.ctx.uuid;
-      orgShortName = req.ctx.org;
+      loggerUuid = req.ctx.uuid
+      orgShortName = req.ctx.org
       orgUUID = await orgRepo.getOrgUUID(orgShortName) // orgShortName is not null
       isSecretariat = await orgRepo.isSecretariatUUID(orgUUID)
     }
@@ -42,25 +42,25 @@ async function getCveId (req, res, next) {
     if (orgShortName !== result.owning_cna && !isSecretariat) {
       if (result.state === CONSTANTS.CVE_STATES.RESERVED) {
         result = {
-           cve_id: result.cve_id,
-           cve_year: result.cve_year,
-           state: result.state,
-           owning_cna: "[REDACTED]"
-         }
+          cve_id: result.cve_id,
+          cve_year: result.cve_year,
+          state: result.state,
+          owning_cna: '[REDACTED]'
+        }
       } else {
         result = {
-           dateUpdated: result.time.modified,
-           cve_id: result.cve_id,
-           cve_year: result.cve_year,
-           state: result.state,
-           owning_cna: result.owning_cna
-         }
+          dateUpdated: result.time.modified,
+          cve_id: result.cve_id,
+          cve_year: result.cve_year,
+          state: result.state,
+          owning_cna: result.owning_cna
+        }
       }
 
-      logger.info({ uuid: logger_uuid, message: id + ' record was sent to the user.', cveId: result })
+      logger.info({ uuid: loggerUuid, message: id + ' record was sent to the user.', cveId: result })
       return res.status(200).json(result)
     } else {
-      logger.info({ uuid: logger_uuid, message: id + ' record was sent to the user.', cveId: result })
+      logger.info({ uuid: loggerUuid, message: id + ' record was sent to the user.', cveId: result })
       return res.status(200).json(result)
     }
   } catch (err) {

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -9,8 +9,8 @@ options.sort = { owning_cna: 'asc', cve_id: 'asc' }
 
 async function getCveId (req, res, next) {
   try {
+    const unauth = req.ctx.unauthenticated
     const id = req.ctx.params.id
-    const orgShortName = req.ctx.org
     const cveIdRepo = req.ctx.repositories.getCveIdRepository()
     const orgRepo = req.ctx.repositories.getOrgRepository()
 
@@ -22,27 +22,45 @@ async function getCveId (req, res, next) {
       return res.status(404).json(error.cveIdNotFound(id))
     }
 
-    const orgUUID = await orgRepo.getOrgUUID(orgShortName) // orgShortName is not null
-    const isSecretariat = await orgRepo.isSecretariatUUID(orgUUID)
+    var logger_uuid;
+    var orgShortName;
+    var orgUUID;
+    var isSecretariat;
+
+    if (unauth) {
+      logger_uuid = "00000000-0000-4000-9000-000000000000";
+      isSecretariat = false;
+      orgShortName = "";
+    } else {
+      logger_uuid = req.ctx.uuid;
+      orgShortName = req.ctx.org;
+      orgUUID = await orgRepo.getOrgUUID(orgShortName) // orgShortName is not null
+      isSecretariat = await orgRepo.isSecretariatUUID(orgUUID)
+    }
 
     // the requester is not a user in the organization and is not the secretariat
     if (orgShortName !== result.owning_cna && !isSecretariat) {
       if (result.state === CONSTANTS.CVE_STATES.RESERVED) {
-        logger.info({ uuid: req.ctx.uuid, message: id + ' is ' + result.state + '. A 404 status was sent to the requester.', cveId: result })
-        return res.status(404).json(error.cveIdNotFound(id))
+        result = {
+           cve_id: result.cve_id,
+           cve_year: result.cve_year,
+           state: result.state,
+           owning_cna: "[REDACTED]"
+         }
+      } else {
+        result = {
+           dateUpdated: result.time.modified,
+           cve_id: result.cve_id,
+           cve_year: result.cve_year,
+           state: result.state,
+           owning_cna: result.owning_cna
+         }
       }
 
-      result = {
-        cve_id: result.cve_id,
-        cve_year: result.cve_year,
-        state: result.state,
-        owning_cna: result.owning_cna
-      }
-
-      logger.info({ uuid: req.ctx.uuid, message: id + ' record was sent to the user.', cveId: result })
+      logger.info({ uuid: logger_uuid, message: id + ' record was sent to the user.', cveId: result })
       return res.status(200).json(result)
     } else {
-      logger.info({ uuid: req.ctx.uuid, message: id + ' record was sent to the user.', cveId: result })
+      logger.info({ uuid: logger_uuid, message: id + ' record was sent to the user.', cveId: result })
       return res.status(200).json(result)
     }
   } catch (err) {

--- a/src/controller/cve-id.controller/index.js
+++ b/src/controller/cve-id.controller/index.js
@@ -31,7 +31,7 @@ router.post('/cve-id',
   parsePostParams,
   controller.CVEID_RESERVE)
 router.get('/cve-id/:id',
-  mw.validateUser,
+  mw.optionallyValidateUser,
   param(['id']).isString().matches(/^CVE-[0-9]{4}-[0-9]{4,}$/, 'i'),
   parseError,
   parseGetParams,

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -37,54 +37,54 @@ async function optionallyValidateUser (req, res, next) {
   const key = req.ctx.key
   const userRepo = req.ctx.repositories.getUserRepository()
   const orgRepo = req.ctx.repositories.getOrgRepository()
-  var authfailed = false;
+  var authfailed = false
 
   try {
     if (!org) {
-      authfailed = true;
+      authfailed = true
     }
 
     if (!user) {
-      authfailed = true;
+      authfailed = true
     }
 
     if (!key) {
-      authfailed = true;
+      authfailed = true
     }
 
-    var orgUUID;
-    var result;
+    var orgUUID
+    var result
 
     if (authfailed === false) {
       logger.info({ uuid: req.ctx.uuid, message: 'Authenticating user: ' + user }) // userUUID may be null if user does not exist
       orgUUID = await orgRepo.getOrgUUID(org)
       if (!orgUUID) {
-         authfailed = true;
+        authfailed = true
       }
     }
 
     if (authfailed === false) {
       result = await userRepo.findOneByUserNameAndOrgUUID(user, orgUUID)
       if (!result) {
-        authfailed = true;
+        authfailed = true
       }
     }
 
     if (authfailed === false) {
       if (!result.active) {
-        authfailed = true;
+        authfailed = true
       }
     }
 
     if (authfailed === false) {
       const isPwd = await argon2.verify(result.secret, key)
       if (!isPwd) {
-        authfailed = true;
+        authfailed = true
       }
     }
 
     if (authfailed === false) {
-      req.ctx.unauthenticated = false;
+      req.ctx.unauthenticated = false
       logger.info({ uuid: req.ctx.uuid, message: 'SUCCESSFUL user authentication for ' + user })
     }
 
@@ -193,7 +193,10 @@ async function onlyCnas (req, res, next) {
 
   try {
     const org = await orgRepo.findOneByShortName(shortName) // org exists
-    if (org.authority.active_roles.includes(CONSTANTS.AUTH_ROLE_ENUM.SECRETARIAT)) {
+    if (org === null) {
+      logger.info({ uuid: req.ctx.uuid, message: shortName + ' is NOT a ' + CONSTANTS.AUTH_ROLE_ENUM.CNA })
+      return res.status(404).json(error.cnaDoesNotExist(shortName))
+    } else if (org.authority.active_roles.includes(CONSTANTS.AUTH_ROLE_ENUM.SECRETARIAT)) {
       logger.info({ uuid: req.ctx.uuid, message: org.short_name + ' is a ' + CONSTANTS.AUTH_ROLE_ENUM.SECRETARIAT + ' so until Root organizations are implemented this role is allowed.' })
       next()
     } else if (org.authority.active_roles.includes(CONSTANTS.AUTH_ROLE_ENUM.CNA)) { // the org is a CNA
@@ -269,11 +272,21 @@ function validateCveJsonSchema (req, res, next) {
   }
 }
 
-function largeInputErrorHandler (err, req, res, next) {
+function validateJsonSyntax (err, req, res, next) {
   if (err.status && err.message) {
-    console.warn('Request failed validation because entity too large')
-    console.info((JSON.stringify(err)))
-    return res.status(400).json(error.recordTooLarge(errors))
+    if (err.message.includes('request entity too large')) {
+      console.warn('Request failed validation because entity too large')
+      console.info((JSON.stringify(err)))
+      return res.status(413).json(error.recordTooLarge(errors))
+    } else if (err.status === 400) {
+      console.warn('Request failed validation because JSON syntax is incorrect')
+      console.info((JSON.stringify(err)))
+      return res.status(400).json(error.invalidJsonSyntax(err.message))
+    } else {
+      console.warn('Request failed')
+      console.info((JSON.stringify(err)))
+      return res.status(400).json(error.genericBadRequest(err.message))
+    }
   } else {
     next(err)
   }
@@ -293,6 +306,6 @@ module.exports = {
   cnaMustOwnID,
   createCtxAndReqUUID,
   validateCveJsonSchema,
-  largeInputErrorHandler,
-  errorHandler
+  errorHandler,
+  validateJsonSyntax
 }

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -16,6 +16,7 @@ const RepositoryFactory = require('../repositories/repositoryFactory')
 function createCtxAndReqUUID (req, res, next) {
   try {
     req.ctx = {
+      unauthenticated: true,
       uuid: uuid.v4(),
       org: req.header(CONSTANTS.AUTH_HEADERS.ORG),
       user: req.header(CONSTANTS.AUTH_HEADERS.USER),
@@ -24,6 +25,69 @@ function createCtxAndReqUUID (req, res, next) {
     }
 
     logger.info(JSON.stringify({ uuid: req.ctx.uuid, path: req.path }))
+    next()
+  } catch (err) {
+    next(err)
+  }
+}
+
+async function optionallyValidateUser (req, res, next) {
+  const org = req.ctx.org
+  const user = req.ctx.user
+  const key = req.ctx.key
+  const userRepo = req.ctx.repositories.getUserRepository()
+  const orgRepo = req.ctx.repositories.getOrgRepository()
+  var authfailed = false;
+
+  try {
+    if (!org) {
+      authfailed = true;
+    }
+
+    if (!user) {
+      authfailed = true;
+    }
+
+    if (!key) {
+      authfailed = true;
+    }
+
+    var orgUUID;
+    var result;
+
+    if (authfailed === false) {
+      logger.info({ uuid: req.ctx.uuid, message: 'Authenticating user: ' + user }) // userUUID may be null if user does not exist
+      orgUUID = await orgRepo.getOrgUUID(org)
+      if (!orgUUID) {
+         authfailed = true;
+      }
+    }
+
+    if (authfailed === false) {
+      result = await userRepo.findOneByUserNameAndOrgUUID(user, orgUUID)
+      if (!result) {
+        authfailed = true;
+      }
+    }
+
+    if (authfailed === false) {
+      if (!result.active) {
+        authfailed = true;
+      }
+    }
+
+    if (authfailed === false) {
+      const isPwd = await argon2.verify(result.secret, key)
+      if (!isPwd) {
+        authfailed = true;
+      }
+    }
+
+    if (authfailed === false) {
+      req.ctx.unauthenticated = false;
+      logger.info({ uuid: req.ctx.uuid, message: 'SUCCESSFUL user authentication for ' + user })
+    }
+
     next()
   } catch (err) {
     next(err)
@@ -221,6 +285,7 @@ function errorHandler (err, req, res, next) {
 }
 
 module.exports = {
+  optionallyValidateUser,
   validateUser,
   onlySecretariat,
   onlySecretariatOrAdmin,

--- a/test-http/src/test/cve_id_tests/cve_id.py
+++ b/test-http/src/test/cve_id_tests/cve_id.py
@@ -23,7 +23,7 @@ def test_get_cve_id():
 
 
 def test_get_cve_id_bad_org_header():
-    """ unauthorized users can't get known IDs """
+    """ unauthenticated users can't get full information about IDs """
     uid = str(uuid.uuid4())
     tmp = copy.deepcopy(utils.BASE_HEADERS)
     tmp['CVE-API-ORG'] = uid
@@ -32,9 +32,8 @@ def test_get_cve_id_bad_org_header():
         f'{env.AWG_BASE_URL}{CVE_ID_URL}/{cve_id}',
         headers=tmp
     )
-    assert res.status_code == 401
-    assert res.reason == 'Unauthorized'
-    response_contains_json(res, 'error', 'UNAUTHORIZED')
+    assert res.status_code == 200
+    assert 'requested_by' not in res.content.decode()
 
 
 def test_get_cve_id_id():

--- a/test-http/src/test/cve_id_tests/cve_id_as_general_user.py
+++ b/test-http/src/test/cve_id_tests/cve_id_as_general_user.py
@@ -23,7 +23,7 @@ def test_get_cve_id(reg_user_headers):
 
 
 def test_get_cve_id_bad_org_header(reg_user_headers):
-    """ unauthorized users can't get known IDs """
+    """ unauthenticated users can't get full information about IDs """
     uid = str(uuid.uuid4())
     tmp = copy.deepcopy(reg_user_headers)
     tmp['CVE-API-ORG'] = uid
@@ -32,9 +32,8 @@ def test_get_cve_id_bad_org_header(reg_user_headers):
         f'{env.AWG_BASE_URL}{CVE_ID_URL}/{cve_id}',
         headers=tmp
     )
-    assert res.status_code == 401
-    assert res.reason == 'Unauthorized'
-    response_contains_json(res, 'error', 'UNAUTHORIZED')
+    assert res.status_code == 200
+    assert 'requested_by' not in res.content.decode()
 
 
 def test_get_cve_id_id(reg_user_headers):

--- a/test-http/src/test/cve_id_tests/cve_id_as_org_admin.py
+++ b/test-http/src/test/cve_id_tests/cve_id_as_org_admin.py
@@ -316,10 +316,12 @@ def test_get_cve_id_by_time_modified(org_admin_headers):
     n_ids = 10
     time.sleep(1)
     t_before = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
+    t_before_alt = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S+00:00')
     time.sleep(1)
     res_ids = get_reserve_cve_ids(n_ids, utils.CURRENT_YEAR, org_admin_headers['CVE-API-ORG'])
     time.sleep(1)
     t_after = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
+    t_after_alt = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S+00:00')
 
     res_get_ids = requests.get(
         f'{env.AWG_BASE_URL}{CVE_ID_URL}',
@@ -329,8 +331,19 @@ def test_get_cve_id_by_time_modified(org_admin_headers):
             'time_modified.gt': t_before
         }
     )
+    # Test alternate timezone format
+    res_get_ids_alt = requests.get(
+        f'{env.AWG_BASE_URL}{CVE_ID_URL}',
+        headers=utils.BASE_HEADERS,
+        params={
+            'time_modified.lt': t_after_alt,
+            'time_modified.gt': t_before_alt
+        }
+    )
     ok_response_contains(res_get_ids, f'CVE-{utils.CURRENT_YEAR}-')
     assert len(json.loads(res_get_ids.content.decode())['cve_ids']) == n_ids
+    ok_response_contains(res_get_ids_alt, f'CVE-{utils.CURRENT_YEAR}-')
+    assert len(json.loads(res_get_ids_alt.content.decode())['cve_ids']) == n_ids
 
 
 def test_get_cve_id_with_params(org_admin_headers):

--- a/test-http/src/test/cve_id_tests/cve_id_as_org_admin.py
+++ b/test-http/src/test/cve_id_tests/cve_id_as_org_admin.py
@@ -24,7 +24,7 @@ def test_get_cve_id(org_admin_headers):
 
 
 def test_get_cve_id_bad_org_header(org_admin_headers):
-    """ unauthorized users can't get known IDs """
+    """ unauthenticated users can't get full information about IDs """
     uid = str(uuid.uuid4())
     tmp = copy.deepcopy(org_admin_headers)
     tmp['CVE-API-ORG'] = uid
@@ -33,9 +33,8 @@ def test_get_cve_id_bad_org_header(org_admin_headers):
         f'{env.AWG_BASE_URL}{CVE_ID_URL}/{cve_id}',
         headers=tmp
     )
-    assert res.status_code == 401
-    assert res.reason == 'Unauthorized'
-    response_contains_json(res, 'error', 'UNAUTHORIZED')
+    assert res.status_code == 200
+    assert 'requested_by' not in res.content.decode()
 
 
 def test_get_cve_id_id(org_admin_headers):

--- a/test/unit-tests/cve-id/cveIdGetSingleTest.js
+++ b/test/unit-tests/cve-id/cveIdGetSingleTest.js
@@ -162,11 +162,11 @@ describe('Testing the GET /cve-id/:id endpoint in CveId Controller', () => {
             done(err)
           }
 
-          expect(res).to.have.status(404)
+          expect(res).to.have.status(200)
           expect(res).to.have.property('body').and.to.be.a('object')
-          const errObj = error.cveIdNotFound(cveIdFixtures.cveId)
-          expect(res.body.error).to.equal(errObj.error)
-          expect(res.body.message).to.equal(errObj.message)
+          expect(res.body).to.have.property('cve_id').and.to.equal(cveIdFixtures.cveId)
+          expect(res.body).to.have.property('state').and.to.equal('RESERVED')
+          expect(res.body).to.have.property('owning_cna').and.to.equal('[REDACTED]')
           done()
         })
     })
@@ -265,6 +265,7 @@ describe('Testing the GET /cve-id/:id endpoint in CveId Controller', () => {
             getOrgRepository: () => { return new OrgGetCveIdOwningOrg() }
           }
           req.ctx.repositories = factory
+          req.ctx.unauthenticated = false
           next()
         }, cveIdParams.parseGetParams, cveIdController.CVEID_GET_SINGLE)
 
@@ -331,6 +332,7 @@ describe('Testing the GET /cve-id/:id endpoint in CveId Controller', () => {
             getOrgRepository: () => { return new OrgGetCveIdRequestorSecretariat() }
           }
           req.ctx.repositories = factory
+          req.ctx.unauthenticated = false
           next()
         }, cveIdParams.parseGetParams, cveIdController.CVEID_GET_SINGLE)
 

--- a/test/unit-tests/cve-id/mockObjects.cve-id.js
+++ b/test/unit-tests/cve-id/mockObjects.cve-id.js
@@ -131,6 +131,9 @@ const cveReserved = {
   requested_by: {
     cna: owningOrgUser.org_UUID,
     user: owningOrgUser.UUID
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 
@@ -143,6 +146,9 @@ const cveRejected = {
   requested_by: {
     cna: owningOrgUser.org_UUID,
     user: owningOrgUser.UUID
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 
@@ -155,6 +161,9 @@ const cvePublished = {
   requested_by: {
     cna: owningOrgUser.org_UUID,
     user: owningOrgUser.UUID
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 
@@ -167,6 +176,9 @@ const cveDummy1 = {
   requested_by: {
     cna: secretariatUser.org_UUID,
     user: secretariatUser.UUID
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 
@@ -179,6 +191,9 @@ const cveDummy2 = {
   requested_by: {
     cna: secretariatUser.org_UUID,
     user: secretariatUser.UUID
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 
@@ -191,6 +206,9 @@ const cveDummy3 = {
   requested_by: {
     cna: secretariatUser.org_UUID,
     user: secretariatUser.UUID
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 
@@ -203,6 +221,9 @@ const cveDummy4 = {
   requested_by: {
     cna: secretariatUser.org_UUID,
     user: secretariatUser.UUID
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 
@@ -215,6 +236,9 @@ const cveDummy5 = {
   requested_by: {
     cna: 'N/A',
     user: 'N/A'
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 


### PR DESCRIPTION
## Identify the Bug
https://github.com/CVEProject/cve-services/issues/570

## Description of the Change
If the client doesn't successfully authenticate in middleware.js, then getCveId returns only the information that is supposed to be available to the general public.

## Alternate Designs
There could have been a new endpoint such as /cve-id/:id/public but that would require changes to client code maintained by third parties.

## Possible Drawbacks
Some might not like dateUpdated (compatible with https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json) and would suggest date_updated instead.

## Verification Process
For all https://github.com/CVEProject/cve-services/blob/6b085e481fd3b084a8828ef7489c6b82fa415c92/test-http/README.md tests related to https://github.com/CVEProject/cve-services/tree/6b085e481fd3b084a8828ef7489c6b82fa415c92/test-http/src/test/cve_id_tests to pass, one extra required step is inserting valid credentials into the test-http/docker/.docker-env file. For all 200 of the https://github.com/CVEProject/cve-services/wiki/Tips-for-Developing-in-Docker Mocha tests to pass, one extra required step is adding two missing files to the container, e.g.,
```
/app # mkdir -p test-http/src/test/cve_tests/cve_record_fixtures/
/app # cd test-http/src/test/cve_tests/cve_record_fixtures/
wget https://raw.githubusercontent.com/CVEProject/cve-services/dev/test-http/src/test/cve_tests/cve_record_fixtures/rejectBody.json
wget https://raw.githubusercontent.com/CVEProject/cve-services/dev/test-http/src/test/cve_tests/cve_record_fixtures/rejectBodyMultipleEngDescriptions.json
```
These required testing changes are **not** related to anything introduced by this PR.

## Release Notes
/cve-id/:id provides partial data to clients who aren't entitled to the full data; fixes https://github.com/CVEProject/cve-services/issues/570