### PR TITLE
Issue #605

### DIFF
--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -207,14 +207,14 @@ function validateCveJsonSchema (req, res, next) {
 
 function validateJsonSyntax (err, req, res, next) {
   if (err.status && err.message) {
-    if (err.message.includes('Unexpected token')) {
-      console.warn('Request failed validation because JSON syntax is incorrect')
-      console.info((JSON.stringify(err)))
-      return res.status(400).json(error.invalidJsonSyntax(err.message))
-    } else if (err.message.includes('request entity too large')) {
+    if (err.message.includes('request entity too large')) {
       console.warn('Request failed validation because entity too large')
       console.info((JSON.stringify(err)))
       return res.status(413).json(error.recordTooLarge(errors))
+    } else if (err.status === 400) {
+      console.warn('Request failed validation because JSON syntax is incorrect')
+      console.info((JSON.stringify(err)))
+      return res.status(400).json(error.invalidJsonSyntax(err.message))
     }
   } else {
     next(err)


### PR DESCRIPTION
### Identify the Bug

closes #605 

### Description of the Change

Updated `validateJsonSyntax` to remove the code that looked for `Unexpected token` in the `err.message` and instead ensured the `request entity too large` check was validated first and then a catch all at the end for a `err.status` of 400 returning the error which covers the possible combinations of JSON error responses.

![image](https://user-images.githubusercontent.com/58360154/159858700-cb0e66ee-ca9c-4ee2-807a-98a5f40a76f9.png)

![image](https://user-images.githubusercontent.com/58360154/159858769-90954c75-6139-444e-a3b9-e47752fa6074.png)

As mentioned in #580 unit tests can't be created for this middleware as Mocha doesn't handle JSON files that are invalid and for payloads that are too large it fails before returning the correct errors. Appropriate test coverage will have to be handled by the black box testing.

### Alternate Designs

You could update the if/else statement to include different types of error messages but it will will end up with a large code block trying to guess possible error combinations.

### Possible Drawbacks

Potential for some errors to be caught that may not be specifically a JSON syntax issue.

### Verification Process

Tested with a combination of incorrect JSON payloads.

### Release Notes

Fixed a bug where certain JSON payloads with incorrect syntax would cause the API to hang.
