### PR TITLE
Cdp 576

### DIFF
--- a/src/controller/cve-id.controller/cve-id.middleware.js
+++ b/src/controller/cve-id.controller/cve-id.middleware.js
@@ -17,7 +17,7 @@ function parsePostParams (req, res, next) {
 
 // Sanitizer for dates
 function toDate (val) {
-  let value = val.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)(Z|((-|\s)\d{2}:\d{2}))$/)
+  let value = val.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|((-|\s)\d{2}:\d{2}))$/)
   let result
   if (value) {
     value[0] = value[0].replace(' ', '+') // Re-add literal '+' which was stripped

--- a/src/controller/cve-id.controller/cve-id.middleware.js
+++ b/src/controller/cve-id.controller/cve-id.middleware.js
@@ -17,10 +17,11 @@ function parsePostParams (req, res, next) {
 
 // Sanitizer for dates
 function toDate (val) {
-  let value = val.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/)
+  let value = val.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)(Z|((-|\s)\d{2}:\d{2}))$/)
   let result
   if (value) {
-    result = new Date(`${value[0]}.000+00:00`)
+    value[0] = value[0].replace(' ', '+') // Re-add literal '+' which was stripped
+    result = new Date(value[0])
   } else {
     value = val.match(/^\d{4}-\d{2}-\d{2}$/)
     if (value) {

--- a/src/controller/cve-id.controller/cve-id.middleware.js
+++ b/src/controller/cve-id.controller/cve-id.middleware.js
@@ -17,7 +17,7 @@ function parsePostParams (req, res, next) {
 
 // Sanitizer for dates
 function toDate (val) {
-  let value = val.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|((-|\s)\d{2}:\d{2}))$/)
+  let value = val.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(|Z|((-|\+|\s)\d{2}:\d{2}))$/)
   let result
   if (value) {
     value[0] = value[0].replace(' ', '+') // Re-add literal '+' which was stripped

--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -27,7 +27,7 @@ function parseGetParams (req, res, next) {
 
 // Sanitizer for dates
 function toDate (val) {
-  let value = val.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|((-|\s)\d{2}:\d{2}))$/)
+  let value = val.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(|Z|((-|\+|\s)\d{2}:\d{2}))$/)
   let result
   if (value) {
     value[0] = value[0].replace(' ', '+') // Re-add literal '+' which was stripped

--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -27,7 +27,7 @@ function parseGetParams (req, res, next) {
 
 // Sanitizer for dates
 function toDate (val) {
-  let value = val.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)(Z|((-|\s)\d{2}:\d{2}))$/)
+  let value = val.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|((-|\s)\d{2}:\d{2}))$/)
   let result
   if (value) {
     value[0] = value[0].replace(' ', '+') // Re-add literal '+' which was stripped

--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -27,10 +27,11 @@ function parseGetParams (req, res, next) {
 
 // Sanitizer for dates
 function toDate (val) {
-  let value = val.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/)
+  let value = val.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)(Z|((-|\s)\d{2}:\d{2}))$/)
   let result
   if (value) {
-    result = new Date(`${value[0]}.000+00:00`)
+    value[0] = value[0].replace(' ', '+') // Re-add literal '+' which was stripped
+    result = new Date(value[0])
   } else {
     value = val.match(/^\d{4}-\d{2}-\d{2}$/)
     if (value) {

--- a/test-http/src/test/cve_id_tests/cve_id_as_org_admin.py
+++ b/test-http/src/test/cve_id_tests/cve_id_as_org_admin.py
@@ -317,10 +317,12 @@ def test_get_cve_id_by_time_modified(org_admin_headers):
     n_ids = 10
     time.sleep(1)
     t_before = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
+    t_before_alt = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S+00:00')
     time.sleep(1)
     res_ids = get_reserve_cve_ids(n_ids, utils.CURRENT_YEAR, org_admin_headers['CVE-API-ORG'])
     time.sleep(1)
     t_after = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
+    t_after_alt = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S+00:00')
 
     res_get_ids = requests.get(
         f'{env.AWG_BASE_URL}{CVE_ID_URL}',
@@ -330,8 +332,19 @@ def test_get_cve_id_by_time_modified(org_admin_headers):
             'time_modified.gt': t_before
         }
     )
+    # Test alternate timezone format
+    res_get_ids_alt = requests.get(
+        f'{env.AWG_BASE_URL}{CVE_ID_URL}',
+        headers=utils.BASE_HEADERS,
+        params={
+            'time_modified.lt': t_after_alt,
+            'time_modified.gt': t_before_alt
+        }
+    )
     ok_response_contains(res_get_ids, f'CVE-{utils.CURRENT_YEAR}-')
     assert len(json.loads(res_get_ids.content.decode())['cve_ids']) == n_ids
+    ok_response_contains(res_get_ids_alt, f'CVE-{utils.CURRENT_YEAR}-')
+    assert len(json.loads(res_get_ids_alt.content.decode())['cve_ids']) == n_ids
 
 
 def test_get_cve_id_with_params(org_admin_headers):

--- a/test-http/src/test/cve_tests/cve.py
+++ b/test-http/src/test/cve_tests/cve.py
@@ -36,12 +36,14 @@ def test_get_cve_by_time_modified():
     time.sleep(1)
     post_cve('CVE-2021-0005_published', 'CVE-2021-0005')
     t_before = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
+    t_before_alt = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S+00:00')
     time.sleep(1)
     update_cve('CVE-2021-0004_published', 'CVE-2021-0004')
     time.sleep(1)
     update_cve('CVE-2021-0005_published', 'CVE-2021-0005')
     time.sleep(1)
     t_after = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
+    t_after_alt = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S+00:00')
 
     res = requests.get(
         f'{env.AWG_BASE_URL}{CVE_URL}/',
@@ -51,8 +53,19 @@ def test_get_cve_by_time_modified():
             'time_modified.gt': t_before
         }
     )
+    # Alternat timezone format
+    res_alt = requests.get(
+        f'{env.AWG_BASE_URL}{CVE_URL}/',
+        headers=utils.BASE_HEADERS,
+        params={
+            'time_modified.lt': t_after_alt,
+            'time_modified.gt': t_before_alt
+        }
+    )
     assert res.status_code == utils.HTTP_OK
     assert len(json.loads(res.content.decode())['cveRecords']) >= 2
+    assert res_alt.status_code == utils.HTTP_OK
+    assert len(json.loads(res_alt.content.decode())['cveRecords']) >= 2
 
 
 def test_get_cve_by_count_only_true():


### PR DESCRIPTION
### Identify the Bug

https://github.com/CVEProject/cve-services/issues/576

### Description of the Change

Some of the API calls that use `date-time` now comply to [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6). I have also allowed backwards compatibility for the time formats.

eg. This worked previously and will still work: `2017-07-21T17:32:28`
But now these also work:
```
2017-07-21T17:32:28Z
2017-07-21T17:32:28.59-02:00
2017-07-21T17:32:28-02:30
2017-07-21T17:32:28.59+05:00
```

### Alternate Designs

### Possible Drawbacks
The timezone format can allow a `+` character. This was getting replaced with whitespace when I was testing with `curl`. I made it re-add the `+` back in to the date-time field.

### Verification Process

Added alternate timezone format to the python-http tests.
`test_get_cve_by_time_modified()`
`test_get_cve_id_by_time_modified()`

### Release Notes

Added support for RFC 3339 `date-time` in searches.