### PR TITLE
Issue #607

### DIFF
--- a/src/middleware/error.js
+++ b/src/middleware/error.js
@@ -54,7 +54,14 @@ class MiddlewareError extends idrErr.IDRError {
     return err
   }
 
-  recordTooLarge () {
+  genericBadRequest (errors) { // mw
+    const err = {}
+    err.error = 'BAD_REQUEST'
+    err.message = errors
+    return err
+  }
+
+  recordTooLarge () { // mw
     const err = {}
     err.error = 'RECORD_TOO_LARGE'
     err.message = 'Records must be less than 16MB.'

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -215,6 +215,10 @@ function validateJsonSyntax (err, req, res, next) {
       console.warn('Request failed validation because entity too large')
       console.info((JSON.stringify(err)))
       return res.status(413).json(error.recordTooLarge(errors))
+    } else {
+      console.warn('Request failed')
+      console.info((JSON.stringify(err)))
+      return res.status(400).json(error.genericBadRequest(err.message))
     }
   } else {
     next(err)


### PR DESCRIPTION
### Identify the Bug

close #607 

### Description of the Change

Updated the `validateJsonSyntax` function to include a catch all error handler to prevent hanging API requests. 

If an non specific validation error comes up then the default will be return a `400` status with an error message such as: 

```json
{
  "error": "BAD_REQUEST",
  "message": "too many parameters"
}
```

### Alternate Designs

This should hopefully catch all the edge cases however, I am not sure if there is anything this is missing.

### Possible Drawbacks

Non that I am aware of as hanging API requests isn't good.

### Verification Process

Multiple test cases run through including those provided by in the issue.

### Release Notes

Implemented a catch all error handling when validating JSON syntax.
