### PR TITLE
#556 Corrected update to rejected for CVE Records and ids

### DIFF
--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -369,10 +369,12 @@ async function rejectExistingCve (req, res, next) {
     const id = req.ctx.params.id
     const cveIdRepo = req.ctx.repositories.getCveIdRepository()
     const cveRepo = req.ctx.repositories.getCveRepository()
+    const orgRepo = req.ctx.repositories.getOrgRepository()
+    const providerOrgObj = await orgRepo.findOneByShortName(req.ctx.org)
 
     // check that cve id exists
-    const cveId = await cveIdRepo.findOneByCveId(id)
-    if (!cveId || cveId.state === CONSTANTS.CVE_STATES.AVAILABLE) {
+    const cveIdObj = await cveIdRepo.findOneByCveId(id)
+    if (!cveIdObj || cveIdObj.state === CONSTANTS.CVE_STATES.AVAILABLE) {
       return res.status(400).json(error.cveDne())
     }
 
@@ -382,29 +384,38 @@ async function rejectExistingCve (req, res, next) {
       return res.status(400).json(error.cveRecordExists())
     }
 
-    const updatedRecord = Cve.updateCveToRejected(id, result.cve, req.ctx.body)
+    // update CVE record to rejected
+    const updatedRecord = Cve.updateCveToRejected(id, providerOrgObj.UUID, result.cve, req.ctx.body)
     const updatedCve = new Cve({ cve: updatedRecord })
     result = Cve.validateRejected(updatedCve)
     if (!result) {
       return res.status(500).json(error.serverError())
     }
-
     result = await cveRepo.updateByCveId(id, updatedCve)
     if (!result) {
       return res.status(500).json(error.unableToUpdateByCveID())
     }
 
+    // update cveID to rejected
+    const newCveIdObj = JSON.parse(JSON.stringify(cveIdObj)) // clone cve id returned from the db
+    delete newCveIdObj._id
+    delete newCveIdObj.time
+    newCveIdObj.state = CONSTANTS.CVE_STATES.REJECTED
+    result = await cveIdRepo.findOneAndUpdate({ cve_id: id }, newCveIdObj)
+    if (!result) {
+      return res.status(500).json(error.serverError())
+    }
+
     const responseMessage = {
-      message: cveId + ' record was successfully submitted.',
+      message: id + ' record was successfully submitted.',
       created: updatedCve.cve
     }
 
-    const orgRepo = req.ctx.repositories.getOrgRepository()
     const payload = {
       action: 'update_rejected_cve_record',
       change: id + ' record was successfully submitted.',
       req_UUID: req.ctx.uuid,
-      org_UUID: await orgRepo.getOrgUUID(req.ctx.org),
+      org_UUID: providerOrgObj.UUID,
       cve: id
     }
     const userRepo = req.ctx.repositories.getUserRepository()
@@ -473,7 +484,7 @@ async function updateCna (req, res, next) {
 
     const responseMessage = {
       message: id + ' record was successfully updated.',
-      created: cveModel.cve
+      updated: cveModel.cve
     }
 
     const payload = {

--- a/src/model/cve.js
+++ b/src/model/cve.js
@@ -110,18 +110,19 @@ CveSchema.statics.validateRejected = function (record) {
   return false
 }
 
-CveSchema.statics.updateCveToRejected = function (id, record, newCnaContainer) {
-  record.containers = newCnaContainer // replace cna field on existing record
-  const timeStamp = (new Date()).toISOString()
-  record.cveMetadata.dateUpdated = timeStamp
-  record.containers.cnaContainer.providerMetadata.dateUpdated = timeStamp
+CveSchema.statics.updateCveToRejected = function (id, providerOrgId, record, newCnaContainer) {
+  record.containers.cna = newCnaContainer.cnaContainer // replace cna field on existing record
+  const updateDate = (new Date()).toISOString()
+  record.cveMetadata.dateUpdated = updateDate
+  if (!record.containers.cna.providerMetadata) {
+    record.containers.cna.providerMetadata = {"orgId": providerOrgId}
+  }
+  record.containers.cna.providerMetadata.dateUpdated = updateDate
+
   // if record is in a PUBLISHED state, transition to a REJECTED state
-  if (record.cveMetadata.state === CONSTANTS.CVE_STATES.PUBLISHED) {
-    record.cveMetadata.cveId = id // update cveId
-    record.cveMetadata.state = CONSTANTS.CVE_STATES.REJECTED // update state
-    if (record.containers.adp) { // check if adp field exists
-      delete record.containers.adp
-    }
+  record.cveMetadata.state = CONSTANTS.CVE_STATES.REJECTED // update state
+  if (record.containers.adp) { // check if adp field exists
+    delete record.containers.adp
   }
   return record
 }


### PR DESCRIPTION
Identify the Bug
#556 

Description of the Change
Modified controller and model to create correct JSON for updating a published CVE Record and id to be REJECTED, explicitly setting the providerMetaData if it has not been passed in as part of the request body

Alternate Designs
Possible Drawbacks

Verification Process
Manually verified using Postman and Compass

Release Notes