### PR TITLE
Srl 642

### DIFF
--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -256,9 +256,8 @@ async function rejectCVE (req, res, next) {
     const rejectedCve = Cve.newRejectedCve(cveIdObj, req.ctx.body, owningCnaShortName, providerOrgObj)
     const newCveObj = new Cve({ cve: rejectedCve })
 
-    // Save updated id object
-    cveIdObj.state = CONSTANTS.CVE_STATES.REJECTED
-    result = await cveIdRepo.updateByCveId(id, cveIdObj)
+    // Update state of CVE ID entry
+    result = await cveIdRepo.updateByCveId(id, {state: CONSTANTS.CVE_STATES.REJECTED }) 
     if (!result) {
       return res.status(500).json(error.serverError())
     }
@@ -397,11 +396,7 @@ async function rejectExistingCve (req, res, next) {
     }
 
     // update cveID to rejected
-    const newCveIdObj = JSON.parse(JSON.stringify(cveIdObj)) // clone cve id returned from the db
-    delete newCveIdObj._id
-    delete newCveIdObj.time
-    newCveIdObj.state = CONSTANTS.CVE_STATES.REJECTED
-    result = await cveIdRepo.findOneAndUpdate({ cve_id: id }, newCveIdObj)
+    result = await cveIdRepo.updateByCveId(id, {state: CONSTANTS.CVE_STATES.REJECTED }) 
     if (!result) {
       return res.status(500).json(error.serverError())
     }

--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -257,7 +257,7 @@ async function rejectCVE (req, res, next) {
     const newCveObj = new Cve({ cve: rejectedCve })
 
     // Update state of CVE ID entry
-    result = await cveIdRepo.updateByCveId(id, {state: CONSTANTS.CVE_STATES.REJECTED }) 
+    result = await cveIdRepo.updateByCveId(id, { state: CONSTANTS.CVE_STATES.REJECTED })
     if (!result) {
       return res.status(500).json(error.serverError())
     }
@@ -396,7 +396,7 @@ async function rejectExistingCve (req, res, next) {
     }
 
     // update cveID to rejected
-    result = await cveIdRepo.updateByCveId(id, {state: CONSTANTS.CVE_STATES.REJECTED }) 
+    result = await cveIdRepo.updateByCveId(id, { state: CONSTANTS.CVE_STATES.REJECTED })
     if (!result) {
       return res.status(500).json(error.serverError())
     }


### PR DESCRIPTION
Identify the Bug
Time created overwritten in CVE ID entry when rejectCVE is called.

Description of the Change
Modified call to updateCveById to obtain the correct behavior. Also simplified how the state change is done in rejectExistingCVE
