### PR TITLE
Issue 663 and 667

### DIFF
--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -537,6 +537,12 @@ async function updateUser (req, res, next) {
       }
     }
 
+    // Sets the name values to what currently exists in the database, this ensures data is retained during partial name updates
+    newUser.name.first = user.name.first
+    newUser.name.last = user.name.last
+    newUser.name.middle = user.name.middle
+    newUser.name.suffix = user.name.suffix
+
     Object.keys(req.ctx.query).forEach(k => {
       const key = k.toLowerCase()
 


### PR DESCRIPTION
### Identify the Bug

close #663 
close #667 

### Description of the Change

Updated the `updateUser` function to set the name values of the `newUser` variable with data from the database prior to values being updated by the query parameters.

This means that if there are partial name updates the non-updated fields are preserved.

### Alternate Designs

This was the simplest design I could think of.

### Possible Drawbacks

None that I can think of.

### Verification Process

Tested updating users with different name values and there is no loss of data.

Screenshot to show a valid test:

<img width="799" alt="image" src="https://user-images.githubusercontent.com/58360154/169532181-ef1307f2-b472-433c-80ef-eceadb679b75.png">


### Release Notes

Fixed a bug where if the name values of a user were partially updated the non-updated fields would be deleted.
