### PR TITLE
Issue 675

### DIFF
--- a/src/controller/org.controller/error.js
+++ b/src/controller/org.controller/error.js
@@ -63,6 +63,13 @@ class OrgControllerError extends idrErr.IDRError {
     err.message = `The organization cannot be renamed as '${shortname}' because this shortname is used by another organization.`
     return err
   }
+
+  notAllowedToModifyUser (username) {
+    const err = {}
+    err.error = 'NOT_AUTHORISED_TO_MODIFY_USER'
+    err.message = `The user '${username}' can only be modified by the Secretariat or an Org admin.`
+    return err
+  }
 }
 
 module.exports = {

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -626,7 +626,7 @@ router.put('/org/:shortname/user/:username',
   #swagger.summary = "Updates a user entry for the specified username and organization shortname (accessible to Admins and Secretariats)"
   #swagger.description = "
         <h2>Access Control</h2>
-        <p>All registered users can access this endpoint</p>
+        <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>
         <h2>Expected Behavior</h2>
         <p><b>Admin User:</b> Updates a user entry for users in the Admin's organization. Allowed to change all fields except org_shortname. </p>
         <p><b>Secretariat:</b> Updates a user entry in any organization. Allowed to change all fields.</p>"
@@ -719,7 +719,7 @@ router.put('/org/:shortname/user/:username/reset_secret',
   #swagger.summary = "Reset the API key for a user (accessible to Admins and Secretariats)"
   #swagger.description = "
         <h2>Access Control</h2>
-        <p>All registered users can access this endpoint</p>
+        <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>
         <h2>Expected Behavior</h2>
         <p><b>Admin User:</b> Resets any user's API secret in the Admin's organization</p>
         <p><b>Secretariat:</b> Resets any user's API secret</p>"

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -628,7 +628,6 @@ router.put('/org/:shortname/user/:username',
         <h2>Access Control</h2>
         <p>All registered users can access this endpoint</p>
         <h2>Expected Behavior</h2>
-        <p><b>Regular User:</b> Updates a user's own user entry. Allowed to change name fields.</p>
         <p><b>Admin User:</b> Updates a user entry for users in the Admin's organization. Allowed to change all fields except org_shortname. </p>
         <p><b>Secretariat:</b> Updates a user entry in any organization. Allowed to change all fields.</p>"
   #swagger.parameters['shortname'] = { description: 'The shortname of the organization' }
@@ -722,7 +721,6 @@ router.put('/org/:shortname/user/:username/reset_secret',
         <h2>Access Control</h2>
         <p>All registered users can access this endpoint</p>
         <h2>Expected Behavior</h2>
-        <p><b>Regular User:</b> Resets user's own API secret</p>
         <p><b>Admin User:</b> Resets any user's API secret in the Admin's organization</p>
         <p><b>Secretariat:</b> Resets any user's API secret</p>"
   #swagger.parameters['shortname'] = { description: 'The shortname of the organization' }

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -623,7 +623,7 @@ router.put('/org/:shortname/user/:username',
   /*
   #swagger.tags = ['Users']
    #swagger.operationId = 'userUpdateSingle'
-  #swagger.summary = "Updates a user entry for the specified username and organization shortname (accessible to all registered users)"
+  #swagger.summary = "Updates a user entry for the specified username and organization shortname (accessible to Admins and Secretariats)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>All registered users can access this endpoint</p>
@@ -716,7 +716,7 @@ router.put('/org/:shortname/user/:username/reset_secret',
   /*
   #swagger.tags = ['Users']
   #swagger.operationId = 'userResetSecret'
-  #swagger.summary = "Reset the API key for a user (accessible to all registered users)"
+  #swagger.summary = "Reset the API key for a user (accessible to Admins and Secretariats)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>All registered users can access this endpoint</p>

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -528,13 +528,10 @@ async function updateUser (req, res, next) {
       return res.status(404).json(error.userDne(username))
     }
 
-    // check if the user is not the requester or if the requester is not a secretariat
-    if ((shortName !== requesterShortName || username !== requesterUsername) && !isSecretariat) {
-      // check if the requester is not and admin; if admin, the requester must be from the same org as the user
-      if (!isAdmin || (isAdmin && shortName !== requesterShortName)) {
-        logger.info({ uuid: req.ctx.uuid, message: 'The user can only be updated by the Secretariat, an Org admin or if the requester is the user.' })
-        return res.status(403).json(error.notSameUserOrSecretariat())
-      }
+    // Check if the user is a secretariat or admin
+    if (!isSecretariat && !isAdmin) {
+      logger.info({ uuid: req.ctx.uuid, message: 'The user could not be updated because ' + requesterUsername + ' is not the Secretariat or Org admin.' })
+      return res.status(403).json(error.notAllowedToModifyUser(username))
     }
 
     // Sets the name values to what currently exists in the database, this ensures data is retained during partial name updates
@@ -703,14 +700,11 @@ async function resetSecret (req, res, next) {
       return res.status(404).json(error.userDne(username))
     }
 
+    // Check if the user is a secretariat or admin
     const isAdmin = await userRepo.isAdmin(requesterUsername, requesterShortName)
-    // check if the user is not the requester or if the requester is not a secretariat
-    if ((orgShortName !== requesterShortName || username !== requesterUsername) && !isSecretariat) {
-      // check if the requester is not and admin; if admin, the requester must be from the same org as the user
-      if (!isAdmin || (isAdmin && orgShortName !== requesterShortName)) {
-        logger.info({ uuid: req.ctx.uuid, message: 'The api secret can only be reset by the Secretariat, an Org admin or if the requester is the user.' })
-        return res.status(403).json(error.notSameUserOrSecretariat())
-      }
+    if (!isSecretariat && !isAdmin) {
+      logger.info({ uuid: req.ctx.uuid, message: 'The api secret can only be reset by the Secretariat or an Org admin.' })
+      return res.status(403).json(error.notAllowedToModifyUser(username))
     }
 
     const randomKey = cryptoRandomString({ length: CONSTANTS.CRYPTO_RANDOM_STRING_LENGTH })

--- a/test-http/src/test/org_user_tests/org_as_org_admin.py
+++ b/test-http/src/test/org_user_tests/org_as_org_admin.py
@@ -406,7 +406,7 @@ def test_org_admin_update_own_user_roles_name(org_admin_headers):
         headers=org_admin_headers
     )
     assert res.status_code == 403
-    response_contains_json(res, 'error', 'NOT_ORG_ADMIN_OR_SECRETARIAT') # cannot add role because org admin doesn't have "ADMIN" role anymore
+    response_contains_json(res, 'error', 'NOT_AUTHORISED_TO_MODIFY_USER') # cannot add role because org admin doesn't have "ADMIN" role anymore
     res = requests.put(
         f'{env.AWG_BASE_URL}{ORG_URL}/{org}/user/{user}?active_roles.add=admin', # adding "ADMIN" role back to org admin user
         headers=utils.BASE_HEADERS

--- a/test-http/src/test/org_user_tests/regular_users.py
+++ b/test-http/src/test/org_user_tests/regular_users.py
@@ -16,7 +16,7 @@ from src.utils import (assert_contains, ok_response_contains,
 
 #### PUT /org/:shortname/user/:username ####
 def test_regular_user_update_name_and_username(reg_user_headers):
-    """  regular users can update their name & username """
+    """  regular users cannot update their name & username """
     org = reg_user_headers['CVE-API-ORG']
     user = reg_user_headers['CVE-API-USER']
     new_username = str(uuid.uuid4()) # used in query
@@ -24,17 +24,14 @@ def test_regular_user_update_name_and_username(reg_user_headers):
         f'{env.AWG_BASE_URL}{ORG_URL}/{org}/user/{user}?name.first=aaa&name.last=bbb&name.middle=ccc&name.suffix=ddd',
         headers=reg_user_headers
     )
-    assert res.status_code == 200
-    assert json.loads(res.content.decode())['updated']['name']['first'] == 'aaa'
-    assert json.loads(res.content.decode())['updated']['name']['last'] == 'bbb'
-    assert json.loads(res.content.decode())['updated']['name']['middle'] == 'ccc'
-    assert json.loads(res.content.decode())['updated']['name']['suffix'] == 'ddd'
+    assert res.status_code == 403
+    response_contains_json(res, 'error', 'NOT_AUTHORISED_TO_MODIFY_USER')
     res = requests.put(
         f'{env.AWG_BASE_URL}{ORG_URL}/{org}/user/{user}?new_username={new_username}', 
         headers=reg_user_headers
     )
     assert res.status_code == 403
-    response_contains_json(res, 'error', 'NOT_ORG_ADMIN_OR_SECRETARIAT')
+    response_contains_json(res, 'error', 'NOT_AUTHORISED_TO_MODIFY_USER')
 
 
 def test_regular_user_cannot_update_for_another_user(reg_user_headers):
@@ -50,7 +47,7 @@ def test_regular_user_cannot_update_for_another_user(reg_user_headers):
         headers=reg_user_headers
     )
     assert res.status_code == 403
-    response_contains_json(res, 'error', 'NOT_SAME_USER_OR_SECRETARIAT')
+    response_contains_json(res, 'error', 'NOT_AUTHORISED_TO_MODIFY_USER')
 
 
 def test_regular_user_cannot_update_duplicate_user_with_new_username(reg_user_headers):
@@ -65,7 +62,7 @@ def test_regular_user_cannot_update_duplicate_user_with_new_username(reg_user_he
         headers=reg_user_headers
     )
     assert res.status_code == 403
-    response_contains_json(res, 'error', 'NOT_ORG_ADMIN_OR_SECRETARIAT')
+    response_contains_json(res, 'error', 'NOT_AUTHORISED_TO_MODIFY_USER')
 
 
 def test_regular_user_cannot_update_organization_with_new_shortname(reg_user_headers):
@@ -78,7 +75,7 @@ def test_regular_user_cannot_update_organization_with_new_shortname(reg_user_hea
         headers=reg_user_headers
     )
     assert res.status_code == 403
-    response_contains_json(res, 'error', 'NOT_ALLOWED_TO_CHANGE_ORGANIZATION')
+    response_contains_json(res, 'error', 'NOT_AUTHORISED_TO_MODIFY_USER')
 
 
 def test_regular_user_cannot_update_active_state(reg_user_headers):
@@ -90,7 +87,7 @@ def test_regular_user_cannot_update_active_state(reg_user_headers):
         headers=reg_user_headers
     )
     assert res.status_code == 403
-    response_contains_json(res, 'error', 'NOT_ORG_ADMIN_OR_SECRETARIAT')
+    response_contains_json(res, 'error', 'NOT_AUTHORISED_TO_MODIFY_USER')
 
 
 def test_regular_user_cannot_add_role(reg_user_headers):
@@ -102,7 +99,7 @@ def test_regular_user_cannot_add_role(reg_user_headers):
         headers=reg_user_headers
     )
     assert res.status_code == 403
-    response_contains_json(res, 'error', 'NOT_ORG_ADMIN_OR_SECRETARIAT')
+    response_contains_json(res, 'error', 'NOT_AUTHORISED_TO_MODIFY_USER')
 
 
 def test_regular_user_cannot_remove_role(reg_user_headers):
@@ -114,7 +111,7 @@ def test_regular_user_cannot_remove_role(reg_user_headers):
         headers=reg_user_headers
     )
     assert res.status_code == 403
-    response_contains_json(res, 'error', 'NOT_ORG_ADMIN_OR_SECRETARIAT')
+    response_contains_json(res, 'error', 'NOT_AUTHORISED_TO_MODIFY_USER')
 
 
 def test_regular_user_cannot_update_user_org_dne(reg_user_headers):
@@ -301,14 +298,15 @@ def test_reg_user_cannot_get_another_org_id_quota(reg_user_headers):
 
 #### PUT /org/:shortname/user/:username/reset_secret ####
 def test_regular_user_reset_secret(reg_user_headers):
-    """ regular users can update their secret """
+    """ regular users cannot update their secret """
     org = reg_user_headers['CVE-API-ORG']
     user = reg_user_headers['CVE-API-USER']
     res = requests.put(
         f'{env.AWG_BASE_URL}{ORG_URL}/{org}/user/{user}/reset_secret',
         headers=reg_user_headers
     )
-    ok_response_contains(res, 'API-secret')
+    asset res.status_code == 403
+    response_contains_json(res, 'error', 'NOT_AUTHORISED_TO_MODIFY_USER')
 
 
 def test_regular_user_cannot_reset_secret_of_another_user(reg_user_headers):
@@ -322,7 +320,7 @@ def test_regular_user_cannot_reset_secret_of_another_user(reg_user_headers):
         headers=reg_user_headers
     )
     assert res.status_code == 403
-    response_contains_json(res, 'error', 'NOT_SAME_USER_OR_SECRETARIAT')
+    response_contains_json(res, 'error', 'NOT_AUTHORISED_TO_MODIFY_USER')
 
 
 def test_regular_user_cannot_reset_secret_user_org_dne(reg_user_headers):
@@ -360,7 +358,7 @@ def test_regular_user_cannot_reset_admin_user_secret(reg_user_headers, org_admin
         headers=reg_user_headers
     )
     assert res.status_code == 403
-    response_contains_json(res, 'error', 'NOT_SAME_USER_OR_SECRETARIAT')
+    response_contains_json(res, 'error', 'NOT_AUTHORISED_TO_MODIFY_USER')
     # Check that user's admin role is preserved
     admin_org = org_admin_headers['CVE-API-ORG']
     res2 = requests.get(

--- a/test/unit-tests/user/userResetSecretTest.js
+++ b/test/unit-tests/user/userResetSecretTest.js
@@ -222,9 +222,9 @@ describe('Testing the PUT /org/:shortname/user/:username/reset_secret endpoint i
         })
     })
 
-    // requester is not the same user (same org but different username)
-    it('Requester is from same org but has different username: User secret is not reset because requester is not the same user or is the secretariat or org admin', (done) => {
-      app.route('/user-secret-reset-sameOrg/:shortname/:username')
+    // requester is the same user but not an admin
+    it('Requester is the user: User secret is not reset because requester is not the secretariat or org admin', (done) => {
+      app.route('/user-secret-reset-same-user/:shortname/:username')
         .put((req, res, next) => {
           const factory = {
             getOrgRepository: () => { return new OrgUserSecretResetNotSecretariat() },
@@ -235,7 +235,7 @@ describe('Testing the PUT /org/:shortname/user/:username/reset_secret endpoint i
         }, orgParams.parsePostParams, orgController.USER_RESET_SECRET)
 
       chai.request(app)
-        .put(`/user-secret-reset-sameOrg/${userFixtures.existentOrgDummy.short_name}/${userFixtures.userC.username}`) // requester has same org as user but different username
+        .put(`/user-secret-reset-same-user/${userFixtures.existentOrgDummy.short_name}/${userFixtures.userC.username}`) // requester has same org as user but different username
         .set(userFixtures.userAHeader)
         .end((err, res) => {
           if (err) {
@@ -244,36 +244,7 @@ describe('Testing the PUT /org/:shortname/user/:username/reset_secret endpoint i
 
           expect(res).to.have.status(403)
           expect(res).to.have.property('body').and.to.be.a('object')
-          const errObj = error.notSameUserOrSecretariat()
-          expect(res.body.error).to.equal(errObj.error)
-          expect(res.body.message).to.equal(errObj.message)
-          done()
-        })
-    })
-
-    // requester is not the same user (same username but different org)
-    it('Requester has same username but is from different org: User secret is not reset because requester is not the same user or is the secretariat or org admin', (done) => {
-      app.route('/user-secret-reset-sameUsername/:shortname/:username')
-        .put((req, res, next) => {
-          const factory = {
-            getOrgRepository: () => { return new OrgUserSecretResetNotSecretariat() },
-            getUserRepository: () => { return new UserSecretReset() }
-          }
-          req.ctx.repositories = factory
-          next()
-        }, orgParams.parsePostParams, orgController.USER_RESET_SECRET)
-
-      chai.request(app)
-        .put(`/user-secret-reset-sameUsername/${userFixtures.owningOrg.short_name}/${userFixtures.userB.username}`) // requester has same username as user but different org
-        .set(userFixtures.userAHeader)
-        .end((err, res) => {
-          if (err) {
-            done(err)
-          }
-
-          expect(res).to.have.status(403)
-          expect(res).to.have.property('body').and.to.be.a('object')
-          const errObj = error.notSameOrgOrSecretariat()
+          const errObj = error.notAllowedToModifyUser(userFixtures.userC.username)
           expect(res.body.error).to.equal(errObj.error)
           expect(res.body.message).to.equal(errObj.message)
           done()

--- a/test/unit-tests/user/userUpdateTest.js
+++ b/test/unit-tests/user/userUpdateTest.js
@@ -418,7 +418,7 @@ describe('Testing the PUT /org/:shortname/user/:username endpoint in Org Control
 
           expect(res).to.have.status(403)
           expect(res).to.have.property('body').and.to.be.a('object')
-          const errObj = error.notOrgAdminOrSecretariat()
+          const errObj = error.notAllowedToModifyUser(userFixtures.userA.username)
           expect(res.body.error).to.equal(errObj.error)
           expect(res.body.message).to.equal(errObj.message)
           done()


### PR DESCRIPTION
### Identify the Bug

close #675 

### Description of the Change

Updated the `updateUser` and `resetSecret` functions to prevent users modify their own accounts. This change means only org admins and the secretariat are able to modify accounts under these endpoints.

Issue #675 mentions that POST /org/{shortname}/user also needs to be updated however, non admin users can't create users as it stands.

### Alternate Designs

Restricting the endpoints to just the Secretariat would go against the goal of pushing more responsibility to program partners.

### Possible Drawbacks

None that I can think of

### Verification Process

Unit tests and black box tests were updated with the new code logic and manual testing was completed.

### Release Notes

Updated the updateUser and resetSecret endpoints to restrict access to org admins and the secretariat.
