### PR TITLE
Issue 631

### DIFF
--- a/test/unit-tests/cve/cveRecordRejectionTest.js
+++ b/test/unit-tests/cve/cveRecordRejectionTest.js
@@ -17,7 +17,6 @@ const cveController = require('../../../src/controller/cve.controller/cve.contro
 const cveMiddleware = require('../../../src/controller/cve.controller/cve.middleware')
 
 const rejectedBody = require('../../../test-http/src/test/cve_tests/cve_record_fixtures/rejectBody.json')
-const multipleEngDescriptions = require('../../../test-http/src/test/cve_tests/cve_record_fixtures/rejectBodyMultipleSameEngValues.json')
 const nonExistentId = 'CVE-1800-0001'
 const cveIdReserved = 'CVE-2019-1421'
 
@@ -125,25 +124,6 @@ describe('Testing the POST /cve/:id/reject endpoint in Cve Controller', () => {
         .post(`/cve-reject-negative-tests/${nonExistentId}`)
         .set(cveFixtures.secretariatHeader)
         .send(rejectedBody)
-        .end((err, res) => {
-          if (err) {
-            done(err)
-          }
-
-          expect(res).to.have.status(400)
-          expect(res).to.have.property('body').and.to.be.a('object')
-          const errObj = error.cveDne()
-          expect(res.body.error).to.equal(errObj.error)
-          expect(res.body.message).to.equal(errObj.message)
-          done()
-        })
-    })
-
-    it('Submit a reject request for with multiple English descriptions, returns 400', (done) => {
-      chai.request(app)
-        .post(`/cve-reject-negative-tests/${cveIdReserved}`)
-        .set(cveFixtures.secretariatHeader)
-        .send(multipleEngDescriptions)
         .end((err, res) => {
           if (err) {
             done(err)

--- a/test/unit-tests/cve/cveUniqueEnglishDescriptionTest.js
+++ b/test/unit-tests/cve/cveUniqueEnglishDescriptionTest.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-expressions */
+// https://github.com/standard/standard/issues/690#issuecomment-278533482
 const chai = require('chai')
 const expect = chai.expect
 
@@ -6,19 +8,17 @@ const rejectedBody = require('../../../test-http/src/test/cve_tests/cve_record_f
 const multipleEngDescriptions = require('../../../test-http/src/test/cve_tests/cve_record_fixtures/rejectBodyMultipleSameEngValues.json')
 
 describe('Testing the uniqueEnglishDescription middleware', () => {
-  context('Negative Tests', function () {
-    it('Submit a reject request with multiple English descriptions', function (done) {
+  context('Negative Tests', () => {
+    it('Submit a reject request with multiple English descriptions', () => {
       const result = cveMiddleware.uniqueEnglishDescription(multipleEngDescriptions.cnaContainer.rejectedReasons)
       expect(result).to.be.false
-      done()
     })
   })
 
   context('Positive Tests', () => {
-    it('Submit a reject request with single English descriptions', function (done) {
+    it('Submit a reject request with single English descriptions', () => {
       const result = cveMiddleware.uniqueEnglishDescription(rejectedBody.cnaContainer.rejectedReasons)
       expect(result).to.be.true
-      done()
     })
   })
 })

--- a/test/unit-tests/cve/cveUniqueEnglishDescriptionTest.js
+++ b/test/unit-tests/cve/cveUniqueEnglishDescriptionTest.js
@@ -1,0 +1,33 @@
+const express = require('express')
+const app = express()
+const chai = require('chai')
+const expect = chai.expect
+chai.use(require('chai-http'))
+
+// Body Parser Middleware
+app.use(express.json()) // Allows us to handle raw JSON data
+app.use(express.urlencoded({ extended: false })) // Allows us to handle url encoded data
+const middleware = require('../../../src/middleware/middleware')
+const cveMiddleware = require('../../../src/controller/cve.controller/cve.middleware')
+app.use(middleware.createCtxAndReqUUID)
+
+const rejectedBody = require('../../../test-http/src/test/cve_tests/cve_record_fixtures/rejectBody.json')
+const multipleEngDescriptions = require('../../../test-http/src/test/cve_tests/cve_record_fixtures/rejectBodyMultipleSameEngValues.json')
+
+describe('Testing the uniqueEnglishDescription middleware', () => {
+  context('Negative Tests', function () {
+    it('Submit a reject request with multiple English descriptions', function (done) {
+      const result = cveMiddleware.uniqueEnglishDescription(multipleEngDescriptions.cnaContainer.rejectedReasons)
+      expect(result).to.be.false
+      done()
+    })
+  })
+
+  context('Positive Tests', () => {
+    it('Submit a reject request with single English descriptions', function (done) {
+      const result = cveMiddleware.uniqueEnglishDescription(rejectedBody.cnaContainer.rejectedReasons)
+      expect(result).to.be.true
+      done()
+    })
+  })
+})

--- a/test/unit-tests/cve/cveUniqueEnglishDescriptionTest.js
+++ b/test/unit-tests/cve/cveUniqueEnglishDescriptionTest.js
@@ -1,16 +1,7 @@
-const express = require('express')
-const app = express()
 const chai = require('chai')
 const expect = chai.expect
-chai.use(require('chai-http'))
 
-// Body Parser Middleware
-app.use(express.json()) // Allows us to handle raw JSON data
-app.use(express.urlencoded({ extended: false })) // Allows us to handle url encoded data
-const middleware = require('../../../src/middleware/middleware')
 const cveMiddleware = require('../../../src/controller/cve.controller/cve.middleware')
-app.use(middleware.createCtxAndReqUUID)
-
 const rejectedBody = require('../../../test-http/src/test/cve_tests/cve_record_fixtures/rejectBody.json')
 const multipleEngDescriptions = require('../../../test-http/src/test/cve_tests/cve_record_fixtures/rejectBodyMultipleSameEngValues.json')
 


### PR DESCRIPTION
### Identify the Bug

Close #631 

### Description of the Change

Added new tests to correctly test the `uniqueEnglishDescription` middleware for the `cve.controller`.

### Alternate Designs

Tests could be removed and not re-implemented for the `uniqueEnglishDescription` function.

### Possible Drawbacks

None that I can think of.

### Verification Process

Ensured tests provided the expected output:

<img width="556" alt="image" src="https://user-images.githubusercontent.com/58360154/169792265-f01329ec-0581-4721-9aed-7d9c63753b03.png">


### Release Notes

N/A
