### PR TITLE
Srl mp 570

### DIFF
--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -196,11 +196,18 @@ async function reserveCveId (req, res, next) {
   }
 }
 
-// Called by GET /api/cve-id/:id
+/* Expected behavior by role:
+Secretariat: can retrieve all information for all CVE IDs
+Regular, CNA & Admin Users: Retrieve full information for a CVE ID owned by their organization
+Unauthenticated users along with Regular, CNA & Admin users requesting ids not owned by their organization retrieve
+  partial information as follows:
+    requested_by not included for a CVE ID in the “PUBLISHED” or “REJECTED” state
+    owning_org not included for ids in the RESERVED state
+*/
 async function getCveId (req, res, next) {
   try {
+    const auth = req.ctx.authenticated
     const id = req.ctx.params.id
-    const orgShortName = req.ctx.org
     const cveIdRepo = req.ctx.repositories.getCveIdRepository()
     const orgRepo = req.ctx.repositories.getOrgRepository()
 
@@ -212,33 +219,43 @@ async function getCveId (req, res, next) {
       return res.status(404).json(error.cveIdNotFound(id))
     }
 
-    const orgUUID = await orgRepo.getOrgUUID(orgShortName) // orgShortName is not null
-    const isSecretariat = await orgRepo.isSecretariatUUID(orgUUID)
+    var finalResult = {}
+    var loggerUuid = 'unauthenticated-user'
+    var orgShortName = ''
+    var orgUUID = null
+    var isSecretariat = false
 
-    // the requester is not a user in the organization and is not the secretariat
-    if (orgShortName !== result.owning_cna && !isSecretariat) {
-      if (result.state === CONSTANTS.CVE_STATES.RESERVED) {
-        logger.info({ uuid: req.ctx.uuid, message: id + ' is ' + result.state + '. A 404 status was sent to the requester.', cveId: result })
-        return res.status(404).json(error.cveIdNotFound(id))
-      }
+    if (auth) {
+      loggerUuid = req.ctx.uuid
+      orgShortName = req.ctx.org
+      orgUUID = await orgRepo.getOrgUUID(orgShortName) // orgShortName is not null
+      isSecretariat = await orgRepo.isSecretariatUUID(orgUUID)
+    }
 
-      result = {
+    // Secretariat and owning org are allowed to see complete results
+    if (isSecretariat || (orgShortName === result.owning_cna)) {
+      finalResult = result
+    } else { // otherwise, remove Requested by information, and redact owning_cna for RESERVED ids
+      finalResult = {
         cve_id: result.cve_id,
         cve_year: result.cve_year,
-        state: result.state,
-        owning_cna: result.owning_cna
+        state: result.state
       }
-
-      logger.info({ uuid: req.ctx.uuid, message: id + ' record was sent to the user.', cveId: result })
-      return res.status(200).json(result)
-    } else {
-      logger.info({ uuid: req.ctx.uuid, message: id + ' record was sent to the user.', cveId: result })
-      return res.status(200).json(result)
+      if (result.state === CONSTANTS.CVE_STATES.RESERVED) {
+        finalResult.owning_cna = '[REDACTED]'
+      } else {
+        finalResult.owning_cna = result.owning_cna
+        finalResult.dateUpdated = result.time.modified
+      }
     }
+
+    logger.info({ uuid: loggerUuid, message: id + ' record was sent to the user.', cveId: finalResult })
+    return res.status(200).json(finalResult)
   } catch (err) {
     next(err)
   }
 }
+
 
 // Called by PUT /cve-id/:id
 async function modifyCveId (req, res, next) {

--- a/src/controller/cve-id.controller/index.js
+++ b/src/controller/cve-id.controller/index.js
@@ -184,13 +184,15 @@ router.get('/cve-id/:id',
   /*
   #swagger.tags = ['CVE ID']
   #swagger.operationId = 'cveIdGetSingle'
-  #swagger.summary = "Retrieves a CVE ID entry for the specified id (acessible to all registered users)"
+  #swagger.summary = "Retrieves a CVE ID entry for the specified id (acessible to all users)"
   #swagger.description = "
         <h2>Access Control</h2>
-        <p>All registered users can access this endpoint</p>
+        <p>Endpoint is accessible to all</p>
         <h2>Expected Behavior</h2>
-        <p><b>Regular, CNA & Admin Users: </b>Retrieves full information for a CVE ID owned by their organization; partial information for a CVE ID in the “PUBLISHED” or “REJECTED” state owned by other organizations</p>
+        <p><b>Regular, CNA & Admin Users: </b>Retrieves full information for a CVE ID owned by their organization; partial information for a CVE ID owned by other organizations</p>
+        <p><b>Unauthenticated Users: Retrieves partial information for a CVE ID</b>
         <p><b>Secretariat: </b>Retrieves full information for a CVE ID owned by any organization</p>
+        <p><i><b>Note - </b>The owning organization of RESERVED CVE IDs is redacted for all users other than those in the owning organization or Secretariat</i></p>
   #swagger.parameters['id'] = { description: 'The id of CVE ID entry to retrieve' }
   #swagger.parameters['$ref'] = [
     '#/components/parameters/apiEntityHeader',

--- a/src/controller/cve-id.controller/index.js
+++ b/src/controller/cve-id.controller/index.js
@@ -246,7 +246,7 @@ router.get('/cve-id/:id',
     }
   }
   */
-  mw.validateUser,
+  mw.optionallyValidateUser,
   param(['id']).isString().matches(/^CVE-[0-9]{4}-[0-9]{4,}$/, 'i'),
   parseError,
   parseGetParams,

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -16,6 +16,7 @@ const RepositoryFactory = require('../repositories/repositoryFactory')
 function createCtxAndReqUUID (req, res, next) {
   try {
     req.ctx = {
+      authenticated: false,
       uuid: uuid.v4(),
       org: req.header(CONSTANTS.AUTH_HEADERS.ORG),
       user: req.header(CONSTANTS.AUTH_HEADERS.USER),
@@ -24,6 +25,50 @@ function createCtxAndReqUUID (req, res, next) {
     }
 
     logger.info(JSON.stringify({ uuid: req.ctx.uuid, path: req.path }))
+    next()
+  } catch (err) {
+    next(err)
+  }
+}
+
+// Sets parameter indicating whether user is authenticated
+async function optionallyValidateUser (req, res, next) {
+  const org = req.ctx.org
+  const user = req.ctx.user
+  const key = req.ctx.key
+  const userRepo = req.ctx.repositories.getUserRepository()
+  const orgRepo = req.ctx.repositories.getOrgRepository()
+  var authenticated = true
+
+  try {
+    if (!org || !user || !key) {
+      authenticated = false
+    } else {
+      var orgUUID = null
+      var result = null
+
+      logger.info({ uuid: req.ctx.uuid, message: 'Authenticating user: ' + user }) // userUUID may be null if user does not exist
+      orgUUID = await orgRepo.getOrgUUID(org)
+      if (!orgUUID) {
+        authenticated = false
+      } else {
+        result = await userRepo.findOneByUserNameAndOrgUUID(user, orgUUID)
+        if (!result || !result.active) {
+          authenticated = false
+        } else {
+          const isPwd = await argon2.verify(result.secret, key)
+          if (!isPwd) {
+            authenticated = false
+          }
+        }
+      }
+    }
+
+    req.ctx.authenticated = authenticated
+    if (authenticated) {
+      logger.info({ uuid: req.ctx.uuid, message: 'SUCCESSFUL user authentication for ' + user })
+    }
+
     next()
   } catch (err) {
     next(err)
@@ -234,6 +279,7 @@ function errorHandler (err, req, res, next) {
 }
 
 module.exports = {
+  optionallyValidateUser,
   validateUser,
   onlySecretariat,
   onlySecretariatOrAdmin,

--- a/test-http/src/test/cve_id_tests/cve_id.py
+++ b/test-http/src/test/cve_id_tests/cve_id.py
@@ -23,7 +23,7 @@ def test_get_cve_id():
 
 
 def test_get_cve_id_bad_org_header():
-    """ unauthorized users can't get known IDs """
+    """ unauthenticated users can't get full information about IDs """
     uid = str(uuid.uuid4())
     tmp = copy.deepcopy(utils.BASE_HEADERS)
     tmp['CVE-API-ORG'] = uid
@@ -32,9 +32,8 @@ def test_get_cve_id_bad_org_header():
         f'{env.AWG_BASE_URL}{CVE_ID_URL}/{cve_id}',
         headers=tmp
     )
-    assert res.status_code == 401
-    assert res.reason == 'Unauthorized'
-    response_contains_json(res, 'error', 'UNAUTHORIZED')
+    assert res.status_code == 200
+    assert 'requested_by' not in res.content.decode()
 
 
 def test_get_cve_id_id():

--- a/test-http/src/test/cve_id_tests/cve_id_as_general_user.py
+++ b/test-http/src/test/cve_id_tests/cve_id_as_general_user.py
@@ -23,7 +23,7 @@ def test_get_cve_id(reg_user_headers):
 
 
 def test_get_cve_id_bad_org_header(reg_user_headers):
-    """ unauthorized users can't get known IDs """
+    """ unauthenticated users can't get full information about IDs """
     uid = str(uuid.uuid4())
     tmp = copy.deepcopy(reg_user_headers)
     tmp['CVE-API-ORG'] = uid
@@ -32,9 +32,8 @@ def test_get_cve_id_bad_org_header(reg_user_headers):
         f'{env.AWG_BASE_URL}{CVE_ID_URL}/{cve_id}',
         headers=tmp
     )
-    assert res.status_code == 401
-    assert res.reason == 'Unauthorized'
-    response_contains_json(res, 'error', 'UNAUTHORIZED')
+    assert res.status_code == 200
+    assert 'requested_by' not in res.content.decode()
 
 
 def test_get_cve_id_id(reg_user_headers):

--- a/test-http/src/test/cve_id_tests/cve_id_as_org_admin.py
+++ b/test-http/src/test/cve_id_tests/cve_id_as_org_admin.py
@@ -24,7 +24,7 @@ def test_get_cve_id(org_admin_headers):
 
 
 def test_get_cve_id_bad_org_header(org_admin_headers):
-    """ unauthorized users can't get known IDs """
+    """ unauthenticated users can't get full information about IDs """
     uid = str(uuid.uuid4())
     tmp = copy.deepcopy(org_admin_headers)
     tmp['CVE-API-ORG'] = uid
@@ -33,9 +33,8 @@ def test_get_cve_id_bad_org_header(org_admin_headers):
         f'{env.AWG_BASE_URL}{CVE_ID_URL}/{cve_id}',
         headers=tmp
     )
-    assert res.status_code == 401
-    assert res.reason == 'Unauthorized'
-    response_contains_json(res, 'error', 'UNAUTHORIZED')
+    assert res.status_code == 200
+    assert 'requested_by' not in res.content.decode()
 
 
 def test_get_cve_id_id(org_admin_headers):

--- a/test/unit-tests/cve-id/cveIdGetSingleTest.js
+++ b/test/unit-tests/cve-id/cveIdGetSingleTest.js
@@ -162,11 +162,11 @@ describe('Testing the GET /cve-id/:id endpoint in CveId Controller', () => {
             done(err)
           }
 
-          expect(res).to.have.status(404)
+          expect(res).to.have.status(200)
           expect(res).to.have.property('body').and.to.be.a('object')
-          const errObj = error.cveIdNotFound(cveIdFixtures.cveId)
-          expect(res.body.error).to.equal(errObj.error)
-          expect(res.body.message).to.equal(errObj.message)
+          expect(res.body).to.have.property('cve_id').and.to.equal(cveIdFixtures.cveId)
+          expect(res.body).to.have.property('state').and.to.equal('RESERVED')
+          expect(res.body).to.have.property('owning_cna').and.to.equal('[REDACTED]')
           done()
         })
     })
@@ -265,6 +265,7 @@ describe('Testing the GET /cve-id/:id endpoint in CveId Controller', () => {
             getOrgRepository: () => { return new OrgGetCveIdOwningOrg() }
           }
           req.ctx.repositories = factory
+          req.ctx.authenticated = true
           next()
         }, cveIdParams.parseGetParams, cveIdController.CVEID_GET_SINGLE)
 
@@ -331,6 +332,7 @@ describe('Testing the GET /cve-id/:id endpoint in CveId Controller', () => {
             getOrgRepository: () => { return new OrgGetCveIdRequestorSecretariat() }
           }
           req.ctx.repositories = factory
+          req.ctx.authenticated = true
           next()
         }, cveIdParams.parseGetParams, cveIdController.CVEID_GET_SINGLE)
 

--- a/test/unit-tests/cve-id/mockObjects.cve-id.js
+++ b/test/unit-tests/cve-id/mockObjects.cve-id.js
@@ -131,6 +131,9 @@ const cveReserved = {
   requested_by: {
     cna: owningOrgUser.org_UUID,
     user: owningOrgUser.UUID
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 
@@ -143,6 +146,9 @@ const cveRejected = {
   requested_by: {
     cna: owningOrgUser.org_UUID,
     user: owningOrgUser.UUID
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 
@@ -155,6 +161,9 @@ const cvePublished = {
   requested_by: {
     cna: owningOrgUser.org_UUID,
     user: owningOrgUser.UUID
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 
@@ -167,6 +176,9 @@ const cveDummy1 = {
   requested_by: {
     cna: secretariatUser.org_UUID,
     user: secretariatUser.UUID
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 
@@ -179,6 +191,9 @@ const cveDummy2 = {
   requested_by: {
     cna: secretariatUser.org_UUID,
     user: secretariatUser.UUID
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 
@@ -191,6 +206,9 @@ const cveDummy3 = {
   requested_by: {
     cna: secretariatUser.org_UUID,
     user: secretariatUser.UUID
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 
@@ -203,6 +221,9 @@ const cveDummy4 = {
   requested_by: {
     cna: secretariatUser.org_UUID,
     user: secretariatUser.UUID
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 
@@ -215,6 +236,9 @@ const cveDummy5 = {
   requested_by: {
     cna: 'N/A',
     user: 'N/A'
+  },
+  time: {
+    modified: '2012-03-04T12:34:56.789Z'
   }
 }
 


### PR DESCRIPTION
Identify the Bug
#570 allow unauthenticated users to access partial information about CVE ID entries; owning org of RESERVED CVE IDs is redacted unless user belongs to Secretariat or the owning org; only partial information is returned for ids in any state unless the user belongs to Secretariat or the owning org

Description of the Change
Code based on changes submitted in PR #597. For readability, flipped the implementation to be based on whether the user is authenticated rather than unauthenticated as implemented in that PR. Code relies on addition of optionallyValidateUser, which sets a flag in the request header to indicate whether or not the user is authenticated

Verification Process
Manual testing using Compass and Postman

Release Notes
