### PR TITLE
#675 added middleware check to ensure org has role for creating or up…

### DIFF
--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -533,6 +533,7 @@ router.post('/org/:shortname/user',
   }
   */
   mw.onlySecretariatOrAdmin,
+  mw.onlyOrgWithRole,
   mw.validateUser,
   param(['shortname']).isString().trim().escape().notEmpty(),
   body(['username']).isString().trim().escape().notEmpty().custom(val => { return isValidUsername(val) }),
@@ -696,6 +697,7 @@ router.put('/org/:shortname/user/:username',
     }
   }
   */
+  mw.onlyOrgWithRole,
   mw.validateUser,
   param(['shortname']).isString().trim().escape().notEmpty(),
   param(['username']).isString().trim().escape().notEmpty().custom(val => { return isValidUsername(val) }),
@@ -781,6 +783,7 @@ router.put('/org/:shortname/user/:username/reset_secret',
     }
   }
   */
+  mw.onlyOrgWithRole,
   mw.validateUser,
   param(['shortname']).isString().trim().escape().notEmpty(),
   param(['username']).isString().trim().escape().notEmpty(),

--- a/src/middleware/error.js
+++ b/src/middleware/error.js
@@ -35,6 +35,20 @@ class MiddlewareError extends idrErr.IDRError {
     return err
   }
 
+  orgDoesNotExist (shortname) { // mw
+    const err = {}
+    err.error = 'ORG_DOES_NOT_EXIST'
+    err.message = `The '${shortname}' organization designated by the shortname parameter does not exist.`
+    return err
+  }
+
+  orgHasNoRole (shortname) { // mw
+    const err = {}
+    err.error = 'ORG_HAS_NO_ROLE'
+    err.message = `The '${shortname}' organization designated by the shortname parameter does not have any roles.`
+    return err
+  }
+
   orgDoesNotOwnId (org, id) {
     const err = {
       error: 'ORG_DOES_NOT_OWN_ID',

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -192,6 +192,28 @@ async function onlyCnas (req, res, next) {
   }
 }
 
+// Checks that an org has a role or any sort
+async function onlyOrgWithRole (req, res, next) {
+  const shortName = req.ctx.org
+  const orgRepo = req.ctx.repositories.getOrgRepository()
+
+  try {
+    const org = await orgRepo.findOneByShortName(shortName)
+    if (org === null) {
+      logger.info({ uuid: req.ctx.uuid, message: shortName + ' does NOT exist ' })
+      return res.status(404).json(error.orgDoesNotExist(shortName))
+    } else if (org.authority.active_roles.length > 0) {
+      logger.info({ uuid: req.ctx.uuid, message: org.short_name + ' has a role ' })
+      next()
+    } else {
+      logger.info({ uuid: req.ctx.uuid, message: org.short_name + ' does NOT have a role ' })
+      return res.status(403).json(error.orgHasNoRole(shortName))
+    }
+  } catch (err) {
+    next(err)
+  }
+}
+
 async function cnaMustOwnID (req, res, next) {
   try {
     const requestingOrg = req.ctx.org
@@ -284,6 +306,7 @@ module.exports = {
   onlySecretariat,
   onlySecretariatOrAdmin,
   onlyCnas,
+  onlyOrgWithRole,
   cnaMustOwnID,
   createCtxAndReqUUID,
   validateCveJsonSchema,


### PR DESCRIPTION
Issue Endorsed by Maintainers
#675 approved by AWG

Description of the Change
Restrict creation of new users and updating user information, including secret, to organizations that have a role. Normally, all orgs have roles - the Secretariat will remove roles from an org in the event of a rogue user or admin

Verification Process
Manual testing