### PR TITLE
Fixed org_quota documentation

### DIFF
--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -790,11 +790,5 @@ router.put('/org/:shortname/user/:username/reset_secret',
   parseError,
   parsePostParams,
   controller.USER_RESET_SECRET)
-router.get('/org/:shortname/id_quota',
-  mw.validateUser,
-  param(['shortname']).isString().trim().escape().notEmpty().isLength({ min: CONSTANTS.MIN_SHORTNAME_LENGTH, max: CONSTANTS.MAX_SHORTNAME_LENGTH }),
-  parseError,
-  parseGetParams,
-  controller.ORG_ID_QUOTA)
 
 module.exports = router


### PR DESCRIPTION
The endpoint `/org/:shortname/id_quota` was duplicated in `/org.controller/index.js` causing the Swagger docs to incorrectly render the documentation for the endpoint.
