### PR TITLE
#771 rejectExistingCve now correctly updates dateRejected

### DIFF
--- a/src/model/cve.js
+++ b/src/model/cve.js
@@ -106,8 +106,12 @@ CveSchema.statics.updateCveToRejected = function (id, providerMetadata, record, 
   record.cveMetadata.dateUpdated = providerMetadata.dateUpdated
   record.containers.cna.providerMetadata = providerMetadata
 
-  // if record is in a PUBLISHED state, transition to a REJECTED state
-  record.cveMetadata.state = CONSTANTS.CVE_STATES.REJECTED // update state
+  // If record is not already rejected, update state and dateRejected
+  if (record.cveMetadata.state !== CONSTANTS.CVE_STATES.REJECTED) {
+    record.cveMetadata.state = CONSTANTS.CVE_STATES.REJECTED // update state
+    record.cveMetadata.dateRejected = providerMetadata.dateUpdated // update dateRejected to dateUpdated, since they're both the same
+  }
+
   if (record.containers.adp) { // check if adp field exists
     delete record.containers.adp
   }


### PR DESCRIPTION
## Summary
#711 
Fixed `rejectExistingCve` endpoint to correctly update dateRejected.

### Significant Changes
`cve.controller.js`
- Updated rejectExistingCve() function to check if the record is not currently rejected, then updates the status and dateRejected fields. Otherwise, these fields remain unchanged.