### PR TITLE
Draft: Jd 703

### DIFF
--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -283,7 +283,7 @@ async function submitCna (req, res, next) {
     const cveRecord = Cve.newPublishedCve(id, cveId.owning_cna, cnaContainer, additionalCveMetadataFields, providerMetadata)
     const cveModel = new Cve({ cve: cveRecord })
 
-    result = Cve.validateCveRecord(cveModel.cve)
+    result = Cve.validateCna(cveModel.cve)
 
     if (!result) {
       return res.status(500).json(error.serverError())
@@ -347,6 +347,11 @@ async function updateCna (req, res, next) {
     const cveRecord = result.cve
     const cnaContainer = req.ctx.body.cnaContainer
     const dateUpdated = (new Date()).toISOString()
+
+    if (cveRecord.cveMetadata.state === CONSTANTS.CVE_STATES.REJECTED) {
+      delete cveRecord.cveMetadata.dateRejected
+    }
+
     cveRecord.cveMetadata.dateUpdated = dateUpdated
     if (cveRecord.cveMetadata.state !== CONSTANTS.CVE_STATES.PUBLISHED) {
       cveRecord.cveMetadata.state = CONSTANTS.CVE_STATES.PUBLISHED
@@ -355,8 +360,10 @@ async function updateCna (req, res, next) {
     const providerMetadata = createProviderMetadata(orgUuid, req.ctx.org, dateUpdated)
     cnaContainer.providerMetadata = providerMetadata
     cveRecord.containers.cna = cnaContainer
+
     const cveModel = new Cve({ cve: cveRecord })
-    result = Cve.validateCveRecord(cveModel.cve)
+    result = Cve.validateCna(cveModel.cve)
+
     if (!result) {
       return res.status(500).json(error.serverError())
     }
@@ -457,6 +464,7 @@ async function rejectCVE (req, res, next) {
 
 // Called by PUT /cve/:id/reject
 async function rejectExistingCve (req, res, next) {
+  // A cnaContainer is passed in, not a complete CVE record
   try {
     const id = req.ctx.params.id
     const cveIdRepo = req.ctx.repositories.getCveIdRepository()
@@ -481,7 +489,8 @@ async function rejectExistingCve (req, res, next) {
     // update CVE record to rejected
     const updatedRecord = Cve.updateCveToRejected(id, providerMetadata, result.cve, req.ctx.body)
     const updatedCve = new Cve({ cve: updatedRecord })
-    result = Cve.validateRejected(updatedCve)
+
+    result = Cve.validateCna(updatedCve)
     if (!result) {
       return res.status(500).json(error.serverError())
     }

--- a/src/model/cve.js
+++ b/src/model/cve.js
@@ -6,9 +6,9 @@ const Ajv = require('ajv')
 const addFormats = require('ajv-formats')
 const ajv = new Ajv({ allErrors: true })
 addFormats(ajv)
-const validate = ajv.compile(cveSchemaV5)
-const rejectedContainerSchema = JSON.parse(fs.readFileSync('src/middleware/schemas/cnaContainer.json'))
-const validateCnaRejectedContainer = ajv.compile(rejectedContainerSchema)
+const validateCveRecord = ajv.compile(cveSchemaV5)
+const cnaContainerSchema = JSON.parse(fs.readFileSync('src/middleware/schemas/cnaContainer.json'))
+const validateCna = ajv.compile(cnaContainerSchema)
 const CONSTANTS = require('../constants')
 
 const schema = {
@@ -27,11 +27,12 @@ CveSchema.query.byCveId = function (id) {
 }
 
 CveSchema.statics.validateCveRecord = function (record) {
-  const result = validate(record)
-  if (result) {
-    return true
+  const result = validateCveRecord(record)
+
+  if (!result) {
+    console.error('Validation Failed: ', validateCveRecord.errors)
   }
-  return false
+  return result
 }
 
 function createBaseCveMetadata (id, assignerOrgId, state) {
@@ -93,12 +94,13 @@ CveSchema.statics.newRejectedCve = function (cveIdObj, reqBody, owningCnaShortNa
   return rejectedRecord
 }
 
-CveSchema.statics.validateRejected = function (record) {
-  const result = validateCnaRejectedContainer(record)
-  if (result) {
-    return true
+CveSchema.statics.validateCna = function (record) {
+  const result = validateCna(record)
+
+  if (!result) {
+    console.error('Validation Failed: ', validateCna.errors)
   }
-  return false
+  return result
 }
 
 CveSchema.statics.updateCveToRejected = function (id, providerMetadata, record, newCnaContainer) {

--- a/src/model/cve.js
+++ b/src/model/cve.js
@@ -1,12 +1,10 @@
 const mongoose = require('mongoose')
 const aggregatePaginate = require('mongoose-aggregate-paginate-v2')
 const fs = require('fs')
-const cveSchemaV5 = JSON.parse(fs.readFileSync('src/middleware/5.0_bundled_schema.json'))
 const Ajv = require('ajv')
 const addFormats = require('ajv-formats')
 const ajv = new Ajv({ allErrors: true })
 addFormats(ajv)
-const validateCveRecord = ajv.compile(cveSchemaV5)
 const cnaContainerSchema = JSON.parse(fs.readFileSync('src/middleware/schemas/cnaContainer.json'))
 const validateCna = ajv.compile(cnaContainerSchema)
 const CONSTANTS = require('../constants')
@@ -24,15 +22,6 @@ const CveSchema = new mongoose.Schema(schema, { collection: 'Cve', timestamps: {
 
 CveSchema.query.byCveId = function (id) {
   return this.where({ 'cve.cveMetadata.cveId': id })
-}
-
-CveSchema.statics.validateCveRecord = function (record) {
-  const result = validateCveRecord(record)
-
-  if (!result) {
-    console.error('Validation Failed: ', validateCveRecord.errors)
-  }
-  return result
 }
 
 function createBaseCveMetadata (id, assignerOrgId, state) {


### PR DESCRIPTION
## Summary

Resolves #703 . Updated cve.js validation function to validate the correct cnaContainer schema and updated all instances of validation in cve.controller.js to use this validator. Also added logic to delete `dateRejected` field when publishing a previously rejected cnaContainer record.