### PR TITLE
#689 throw an error if a bad query parameter name is sent

### DIFF
--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -5,7 +5,6 @@ const controller = require('./org.controller')
 const { body, param, query } = require('express-validator')
 const { parseGetParams, parsePostParams, parseError, isOrgRole, isUserRole, isValidUsername } = require('./org.middleware')
 const CONSTANTS = require('../../../src/constants')
-const ERRORS = require('../../middleware/error')
 
 router.get('/org',
   /*
@@ -74,7 +73,7 @@ router.get('/org',
   */
   mw.validateUser,
   mw.onlySecretariat,
-  query().custom((query) => {return mw.validateQueryParameterNames(query, ['page'])}),
+  query().custom((query) => { return mw.validateQueryParameterNames(query, ['page']) }),
   query(['page']).optional().isInt({ min: CONSTANTS.PAGINATOR_PAGE }),
   parseError,
   parseGetParams,
@@ -306,7 +305,7 @@ router.put('/org/:shortname',
   */
   mw.validateUser,
   mw.onlySecretariat,
-  query().custom((query) => {return mw.validateQueryParameterNames(query, ['new_short_name', 'id_quota', 'name', 'active_roles.add', 'active_roles.remove'])}),
+  query().custom((query) => { return mw.validateQueryParameterNames(query, ['new_short_name', 'id_quota', 'name', 'active_roles.add', 'active_roles.remove']) }),
   param(['shortname']).isString().trim().escape().isLength({ min: CONSTANTS.MIN_SHORTNAME_LENGTH, max: CONSTANTS.MAX_SHORTNAME_LENGTH }),
   query(['new_short_name']).optional().isString().trim().escape().notEmpty().isLength({ min: CONSTANTS.MIN_SHORTNAME_LENGTH, max: CONSTANTS.MAX_SHORTNAME_LENGTH }),
   query(['id_quota']).optional().not().isArray().isInt({ min: CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_min, max: CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_max }).withMessage('The id_quota does not comply with CVE id quota limitations'),
@@ -702,8 +701,10 @@ router.put('/org/:shortname/user/:username',
   */
   mw.validateUser,
   mw.onlyOrgWithRole,
-  query().custom((query) => {return mw.validateQueryParameterNames(query, ['active', 'new_username', 'org_short_name', 'name.first', 'name.last', 'name.middle',
-    'name.suffix', 'active_roles.add', 'active_roles.remove'])}),
+  query().custom((query) => {
+    return mw.validateQueryParameterNames(query, ['active', 'new_username', 'org_short_name', 'name.first', 'name.last', 'name.middle',
+      'name.suffix', 'active_roles.add', 'active_roles.remove'])
+  }),
   param(['shortname']).isString().trim().escape().notEmpty().isLength({ min: CONSTANTS.MIN_SHORTNAME_LENGTH, max: CONSTANTS.MAX_SHORTNAME_LENGTH }),
   param(['username']).isString().trim().escape().notEmpty().custom(val => { return isValidUsername(val) }),
   query(['active']).optional().isString().trim().escape().isIn(['true', 'false']),

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -5,6 +5,7 @@ const controller = require('./org.controller')
 const { body, param, query } = require('express-validator')
 const { parseGetParams, parsePostParams, parseError, isOrgRole, isUserRole, isValidUsername } = require('./org.middleware')
 const CONSTANTS = require('../../../src/constants')
+const ERRORS = require('../../middleware/error')
 
 router.get('/org',
   /*
@@ -73,6 +74,7 @@ router.get('/org',
   */
   mw.validateUser,
   mw.onlySecretariat,
+  query().custom((query) => {return mw.validateQueryParameterNames(query, ['page'])}),
   query(['page']).optional().isInt({ min: CONSTANTS.PAGINATOR_PAGE }),
   parseError,
   parseGetParams,
@@ -304,6 +306,7 @@ router.put('/org/:shortname',
   */
   mw.validateUser,
   mw.onlySecretariat,
+  query().custom((query) => {return mw.validateQueryParameterNames(query, ['new_short_name', 'id_quota', 'name', 'active_roles.add', 'active_roles.remove'])}),
   param(['shortname']).isString().trim().escape().isLength({ min: CONSTANTS.MIN_SHORTNAME_LENGTH, max: CONSTANTS.MAX_SHORTNAME_LENGTH }),
   query(['new_short_name']).optional().isString().trim().escape().notEmpty().isLength({ min: CONSTANTS.MIN_SHORTNAME_LENGTH, max: CONSTANTS.MAX_SHORTNAME_LENGTH }),
   query(['id_quota']).optional().not().isArray().isInt({ min: CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_min, max: CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_max }).withMessage('The id_quota does not comply with CVE id quota limitations'),
@@ -699,6 +702,8 @@ router.put('/org/:shortname/user/:username',
   */
   mw.validateUser,
   mw.onlyOrgWithRole,
+  query().custom((query) => {return mw.validateQueryParameterNames(query, ['active', 'new_username', 'org_short_name', 'name.first', 'name.last', 'name.middle',
+    'name.suffix', 'active_roles.add', 'active_roles.remove'])}),
   param(['shortname']).isString().trim().escape().notEmpty().isLength({ min: CONSTANTS.MIN_SHORTNAME_LENGTH, max: CONSTANTS.MAX_SHORTNAME_LENGTH }),
   param(['username']).isString().trim().escape().notEmpty().custom(val => { return isValidUsername(val) }),
   query(['active']).optional().isString().trim().escape().isIn(['true', 'false']),

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -12,7 +12,6 @@ const uuid = require('uuid')
 const errors = require('./error')
 const error = new errors.MiddlewareError()
 const RepositoryFactory = require('../repositories/repositoryFactory')
-const { async } = require('crypto-random-string')
 
 function setCacheControl (req, res, next) {
   res.set('Cache-Control', 'no-store')
@@ -220,9 +219,9 @@ async function onlyOrgWithRole (req, res, next) {
   }
 }
 
-async function validateQueryParameterNames(queryParamNames, validNames) {
+function validateQueryParameterNames (queryParamNames, validNames) {
   Object.keys(queryParamNames).forEach(k => {
-  if (!validNames.includes(k)) {
+    if (!validNames.includes(k)) {
       throw new Error(`'${k}' is not a valid parameter name.`)
     }
   })

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -12,6 +12,7 @@ const uuid = require('uuid')
 const errors = require('./error')
 const error = new errors.MiddlewareError()
 const RepositoryFactory = require('../repositories/repositoryFactory')
+const { async } = require('crypto-random-string')
 
 function setCacheControl (req, res, next) {
   res.set('Cache-Control', 'no-store')
@@ -219,6 +220,15 @@ async function onlyOrgWithRole (req, res, next) {
   }
 }
 
+async function validateQueryParameterNames(queryParamNames, validNames) {
+  Object.keys(queryParamNames).forEach(k => {
+  if (!validNames.includes(k)) {
+      throw new Error(`'${k}' is not a valid parameter name.`)
+    }
+  })
+  return true
+}
+
 async function cnaMustOwnID (req, res, next) {
   try {
     const requestingOrg = req.ctx.org
@@ -313,6 +323,7 @@ module.exports = {
   onlySecretariatOrAdmin,
   onlyCnas,
   onlyOrgWithRole,
+  validateQueryParameterNames,
   cnaMustOwnID,
   createCtxAndReqUUID,
   validateCveJsonSchema,


### PR DESCRIPTION
Adds middleware that can be used in all controllers. Function takes a list of valid query parameter names and compares it to those in the call to the endpoint. An error is thrown if a query parameter name is not valid.
