### PR TITLE
Resolves #710 replacedBy doesn't match schema

### DIFF
--- a/src/model/cve.js
+++ b/src/model/cve.js
@@ -64,12 +64,12 @@ CveSchema.statics.newPublishedCve = function (id, assignerOrgId, cnaContainer, s
   return baseRecord
 }
 
-function createCnaRejectContainer (providerMetadata, rejectedReasons, replacedBy = {}) {
+function createCnaRejectContainer (providerMetadata, rejectedReasons, replacedBy = []) {
   const cnaContainer = {
     providerMetadata: providerMetadata,
     rejectedReasons: rejectedReasons
   }
-  if (replacedBy !== {}) {
+  if (replacedBy !== []) {
     cnaContainer.replacedBy = replacedBy
   }
   return cnaContainer


### PR DESCRIPTION
## Summary

Resolves #710 

In `createCnaRejectContainer` in `cve.js`, `replacedBy` was being set to `{}` when the schema has it as `[]`. Updated this to correctly match the schema.

When POSTing a new rejectedCna container with an empty `replacedBy` field, the response will now include `replacedBy` as `[]`.