### PR TITLE
#763 Update mongoose-aggregate-paginate-v2 to 1.0.6.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "JSONStream": "^1.3.5",
                 "kleur": "^4.1.4",
                 "mongoose": "^5.12.3",
-                "mongoose-aggregate-paginate-v2": "^1.0.42",
+                "mongoose-aggregate-paginate-v2": "1.0.6",
                 "morgan": "^1.9.1",
                 "node-dev": "^4.0.0",
                 "prompt-sync": "^4.2.0",
@@ -4774,9 +4774,9 @@
             }
         },
         "node_modules/mongoose-aggregate-paginate-v2": {
-            "version": "1.0.42",
-            "resolved": "https://registry.npmjs.org/mongoose-aggregate-paginate-v2/-/mongoose-aggregate-paginate-v2-1.0.42.tgz",
-            "integrity": "sha512-SOXrztB5DRjwimmxUtg0mVS/IzJEZlWOZ6veU5U1ia0BH7VfCIw+KCvdaiCXXlVAPL75PXroXh0lDcpuxfUVWw==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/mongoose-aggregate-paginate-v2/-/mongoose-aggregate-paginate-v2-1.0.6.tgz",
+            "integrity": "sha512-UuALu+mjhQa1K9lMQvjLL3vm3iALvNw8PQNIh2gp1b+tO5hUa0NC0Wf6/8QrT9PSJVTihXaD8hQVy3J4e0jO0Q==",
             "engines": {
                 "node": ">=4.0.0"
             }
@@ -11780,9 +11780,9 @@
             }
         },
         "mongoose-aggregate-paginate-v2": {
-            "version": "1.0.42",
-            "resolved": "https://registry.npmjs.org/mongoose-aggregate-paginate-v2/-/mongoose-aggregate-paginate-v2-1.0.42.tgz",
-            "integrity": "sha512-SOXrztB5DRjwimmxUtg0mVS/IzJEZlWOZ6veU5U1ia0BH7VfCIw+KCvdaiCXXlVAPL75PXroXh0lDcpuxfUVWw=="
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/mongoose-aggregate-paginate-v2/-/mongoose-aggregate-paginate-v2-1.0.6.tgz",
+            "integrity": "sha512-UuALu+mjhQa1K9lMQvjLL3vm3iALvNw8PQNIh2gp1b+tO5hUa0NC0Wf6/8QrT9PSJVTihXaD8hQVy3J4e0jO0Q=="
         },
         "mongoose-legacy-pluralize": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "JSONStream": "^1.3.5",
         "kleur": "^4.1.4",
         "mongoose": "^5.12.3",
-        "mongoose-aggregate-paginate-v2": "^1.0.42",
+        "mongoose-aggregate-paginate-v2": "1.0.6",
         "morgan": "^1.9.1",
         "node-dev": "^4.0.0",
         "prompt-sync": "^4.2.0",


### PR DESCRIPTION
This package doesn't use semver, so we have to lock the package at this version.
^1.0.6 pulled in 1.0.42 because it looks newer to NPM's resolver.
