### PR TITLE
#763 Update pagination options to not use facet

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -65,7 +65,8 @@ module.exports = {
       docs: 'itemsList',
       limit: 'itemsPerPage',
       page: 'currentPage',
-      totalPages: 'pageCount'
+      totalPages: 'pageCount',
+      useFacet: false
     }
   },
   MAX_SHORTNAME_LENGTH: 32,


### PR DESCRIPTION
The mongoose-aggregate-paginate-v2 v1.0.5 package introduced $facet support enabled by default, but this breaks on DocDB. This disables it in our calls to restore original behavior of the earlier 1.0.42 package.