### PR TITLE
#782 fix typo in .docker-env filename

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -112,7 +112,7 @@ Display the key with:
 
 #### Development
 
-In `development` environments, the API is the value of the `LOCAL_KEY` variable in the `docker.env` file.
+In `development` environments, the API is the value of the `LOCAL_KEY` variable in the `.docker-env` file.
 
 You can view the value for the running container with:
 


### PR DESCRIPTION
Corrected name of .docker-env file in README
