### PR TITLE
Require upper case CVE in controllers

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,3 +1,6 @@
+const fs = require('fs')
+const cveSchemaV5 = JSON.parse(fs.readFileSync('src/middleware/5.0_bundled_schema.json'))
+
 module.exports = {
   MONGOOSE_VALIDATION: {
     Org_policies_id_quota_min: 0,
@@ -71,5 +74,9 @@ module.exports = {
     }
   },
   MAX_SHORTNAME_LENGTH: 32,
-  MIN_SHORTNAME_LENGTH: 2
+  MIN_SHORTNAME_LENGTH: 2,
+  CVE_ID_PATTERN: cveSchemaV5.definitions.cveId.pattern,
+  // Ajv's pattern validation uses the "u" (unicode) flag:
+  // https://ajv.js.org/json-schema.html#pattern
+  CVE_ID_REGEX: new RegExp(cveSchemaV5.definitions.cveId.pattern, 'u')
 }

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -3,7 +3,7 @@ module.exports = {
     Org_policies_id_quota_min: 0,
     Org_policies_id_quota_min_message: 'Org.policies.id_quota cannot be a negative number.',
     Org_policies_id_quota_max: 100000,
-    Org_policies_id_quota_max_message: 'Org.polocies.id_quota cannot exceed maximum threshold.'
+    Org_policies_id_quota_max_message: 'Org.policies.id_quota cannot exceed maximum threshold.'
   },
   DEFAULT_ID_QUOTA: 1000,
   DEFAULT_AVAILABLE_POOL: 100,

--- a/src/controller/cve-id.controller/index.js
+++ b/src/controller/cve-id.controller/index.js
@@ -251,7 +251,7 @@ router.get('/cve-id/:id',
   }
   */
   mw.optionallyValidateUser,
-  param(['id']).isString().matches(/^CVE-[0-9]{4}-[0-9]{4,}$/, 'i'),
+  param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parseGetParams,
   controller.CVEID_GET_SINGLE)
@@ -326,7 +326,7 @@ router.put('/cve-id/:id',
   */
   mw.validateUser,
   mw.onlyCnas,
-  param(['id']).isString().matches(/^CVE-[0-9]{4}-[0-9]{4,}$/, 'i'),
+  param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   query().custom((query) => { return mw.validateQueryParameterNames(query, ['state', 'org']) }),
   query(['state']).optional().isString().trim().escape().customSanitizer(val => { return val.toUpperCase() }).isIn(MODIFYTARGETS),
   query(['org']).optional().isString().trim().escape(),

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -69,7 +69,7 @@ router.get('/cve/:id',
     }
   }
   */
-  param(['id']).isString().matches(/^CVE-[0-9]{4}-[0-9]{4,}$/i),
+  param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parseGetParams,
   controller.CVE_GET_SINGLE)
@@ -228,7 +228,7 @@ router.post('/cve/:id',
   mw.validateUser,
   mw.onlySecretariat,
   mw.validateCveJsonSchema,
-  param(['id']).isString().matches(/^CVE-[0-9]{4}-[0-9]{4,}$/i),
+  param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
   controller.CVE_SUBMIT)
@@ -309,7 +309,7 @@ router.put('/cve/:id',
   mw.validateUser,
   mw.onlySecretariat,
   mw.validateCveJsonSchema,
-  param(['id']).isString().matches(/^CVE-[0-9]{4}-[0-9]{4,}$/i),
+  param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
   controller.CVE_UPDATE_SINGLE)
@@ -391,7 +391,7 @@ router.post('/cve/:id/cna',
   mw.validateUser,
   mw.onlyCnas,
   validateCveCnaContainerJsonSchema,
-  param(['id']).isString().matches(/^CVE-[0-9]{4}-[0-9]{4,}$/i),
+  param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
   mw.cnaMustOwnID,
@@ -474,7 +474,7 @@ router.put('/cve/:id/cna',
   mw.validateUser,
   mw.onlyCnas,
   validateCveCnaContainerJsonSchema,
-  param(['id']).isString().matches(/^CVE-[0-9]{4}-[0-9]{4,}$/i),
+  param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
   mw.cnaMustOwnID,
@@ -557,7 +557,7 @@ router.post('/cve/:id/reject',
   mw.validateUser,
   mw.onlyCnas,
   validateRejectBody,
-  param(['id']).isString().matches(/^CVE-[0-9]{4}-[0-9]{4,}$/i),
+  param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   body(['cnaContainer.rejectedReasons']).isArray().custom((arr) => {
     if (!uniqueEnglishDescription(arr)) {
       throw new Error(400, 'Bad request, more than one English description found')
@@ -647,7 +647,7 @@ router.put('/cve/:id/reject',
   mw.validateUser,
   mw.onlyCnas,
   validateRejectBody,
-  param(['id']).isString().matches(/^CVE-[0-9]{4}-[0-9]{4,}$/i),
+  param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   body(['cnaContainer.rejectedReasons']).isArray().custom((arr) => {
     if (!uniqueEnglishDescription(arr)) {
       throw new Error(400, 'Bad request, more than one English description found')

--- a/test/README.md
+++ b/test/README.md
@@ -1,7 +1,7 @@
 
 
 # CVE-API-Unit-Tests
-In order to Run Tests, make sure you configure a DB connection in the config/config.json under the `test` enviorment.
+In order to Run Tests, make sure you configure a DB connection in the config/config.json under the `test` environment.
 
 ## Dependencies
 
@@ -23,5 +23,5 @@ npm run start:test
 
 ## Notes
 
-Please note, test will run on every attempted `git push` command. Pushing into a repo will only be succesfull if and only if tests succesfully pass.
+Please note, test will run on every attempted `git push` command. Pushing into a repo will only be successful if and only if tests successfully pass.
 

--- a/test/unit-tests/cve-id/cveIdRegex.js
+++ b/test/unit-tests/cve-id/cveIdRegex.js
@@ -1,0 +1,49 @@
+const chai = require('chai')
+const expect = chai.expect
+
+const constants = require('../../../src/constants')
+
+// #789 - don't allow lowercase CVE
+describe('CVE IDs should be well formed', () => {
+  context('Negative tests', () => {
+    it('should not match lowercase', () => {
+      expect('cve-2022-1234567890').to.not.match(constants.CVE_ID_REGEX)
+    })
+    it('should not match invalid prefix', () => {
+      expect('abc-2022-1234567890').to.not.match(constants.CVE_ID_REGEX)
+    })
+    it('should not match non-digit year', () => {
+      expect('CVE-abcd-1234567890').to.not.match(constants.CVE_ID_REGEX)
+    })
+    it('should not match non-digit ID', () => {
+      expect('CVE-2022-abcdefghij').to.not.match(constants.CVE_ID_REGEX)
+    })
+    it("should not match years that aren't exactly 4 digits", () => {
+      expect('CVE-22-1234567890').to.not.match(constants.CVE_ID_REGEX)
+      expect('CVE-20222-1234567890').to.not.match(constants.CVE_ID_REGEX)
+    })
+    it("should not match IDs that aren't 4-19 digits", () => {
+      expect('CVE-2022-123').to.not.match(constants.CVE_ID_REGEX)
+      expect('CVE-2022-12345678901234567890').to.not.match(constants.CVE_ID_REGEX)
+    })
+    it('should not match without dashes', () => {
+      expect('CVE20221234567890').to.not.match(constants.CVE_ID_REGEX)
+    })
+  })
+
+  context('Positive tests', () => {
+    it('should match uppercase', () => {
+      expect('CVE-2022-1234567890').to.match(constants.CVE_ID_REGEX)
+    })
+    it('should match IDs that are 4-19 digits', () => {
+      const cveId = 'CVE-2022-'
+
+      // build strings for the ID part
+      for (let i = 4; i < 20; i++) {
+        // pad the end with a random number up to i
+        const fullId = cveId.padEnd(cveId.length + i, Math.floor(Math.random() * 9))
+        expect(fullId).to.match(constants.CVE_ID_REGEX, `Failed with ${fullId}`)
+      }
+    })
+  })
+})


### PR DESCRIPTION
This uses the bundled 5.0 schema's regex to validate CVE id formats. Tests added.