### PR TITLE
feature: Add CVE_PREFLIGHT build args to dockerfiles.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,11 @@ LABEL \
     mitre.project=cveawg \
     mitre.maintainer=mbianchi@mitre.org
 
+# Run an optional pre-flight script for host-dependent reqs such as CA certs
+# Use --build-arg:
+# docker compose --build-arg CVE_PREFLIGHT="wget -q -O - --no-check-certificate http://pki.local/install_certs.sh | sh"
+ARG CVE_PREFLIGHT
+RUN sh -c "${CVE_PREFLIGHT:-exit 0}"
 
 # Install python/pip (required for argon2 build from source)
 ENV PYTHONUNBUFFERED=1

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -8,6 +8,12 @@ LABEL \
     mitre.project=cveawg \
     mitre.maintainer=mbianchi@mitre.org
 
+# Run an optional pre-flight script for host-dependent reqs such as CA certs
+# Use --build-arg:
+# docker compose --build-arg CVE_PREFLIGHT="wget -q -O - --no-check-certificate http://pki.local/install_certs.sh | sh"
+ARG CVE_PREFLIGHT
+RUN sh -c "${CVE_PREFLIGHT:-exit 0}"
+
 # Install python/pip (required for argon2 build from source)
 ENV PYTHONUNBUFFERED=1
 RUN apk add --update --no-cache python3

--- a/docker/README.md
+++ b/docker/README.md
@@ -64,6 +64,16 @@ cveawg  | 2022-06-07 19:29:11 [info]: "Successfully connected to database!"
 cveawg  | 2022-06-07 19:29:11 [info]: "Serving on port 3000"
 ```
 
+#### The Docker CVE_PREFLIGHT argument
+
+The Docker build process fetches resources on the public internet. Some corporate environments require specific configuration to enable communication with public networks (e.g., corporate proxies or custom CA certificates). The included Dockerfiles expose an optional build argument, `CVE_PREFLIGHT`, that allows a script to run before any network traffic is attempted. For example, to fetch and run a script that installs corporate CA certificates:
+
+```
+docker compose build --no-cache --build-arg CVE_PREFLIGHT="wget -q -O - --no-check-certificate https://pki.intranet/install_certs.sh | sh"
+```
+
+If you do not require special configuration to access the internet, you can safely omit the build argument.
+
 ### Pre-load Data
 
 Populate mongoDB with test data included in `datadump/pre-population/`


### PR DESCRIPTION
This exposes a build arg in the Dockerfiles to allow an optional preflight script to configure CA certs or proxies before internet access while building containers.