### PR TITLE
Add page query parameter validation to additional endpoints

### DIFF
--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -457,6 +457,7 @@ router.get('/org/:shortname/users',
   */
   mw.validateUser,
   param(['shortname']).isString().trim().escape().notEmpty().isLength({ min: CONSTANTS.MIN_SHORTNAME_LENGTH, max: CONSTANTS.MAX_SHORTNAME_LENGTH }),
+  query(['page']).optional().isInt({ min: CONSTANTS.PAGINATOR_PAGE }),
   parseError,
   parseGetParams,
   controller.USER_ALL)

--- a/src/controller/user.controller/index.js
+++ b/src/controller/user.controller/index.js
@@ -1,8 +1,10 @@
 const express = require('express')
 const router = express.Router()
 const mw = require('../../middleware/middleware')
+const { query } = require('express-validator')
 const controller = require('./user.controller')
 const { parseGetParams, parseError } = require('./user.middleware')
+const CONSTANTS = require('../../constants')
 
 router.get('/users',
   /*
@@ -72,6 +74,7 @@ router.get('/users',
   */
   mw.validateUser,
   mw.onlySecretariat,
+  query(['page']).optional().isInt({ min: CONSTANTS.PAGINATOR_PAGE }),
   parseError,
   parseGetParams,
   controller.ALL_USERS)

--- a/test-http/src/test/cve_tests/cve.py
+++ b/test-http/src/test/cve_tests/cve.py
@@ -623,3 +623,43 @@ def post_cve(filename, cveid):
             headers=utils.BASE_HEADERS,
             json=data
         )
+
+
+def test_cve_get_page():
+    """ page must be a positive int """
+    res = requests.get(
+        f'{env.AWG_BASE_URL}{CVE_URL}',
+        headers=utils.BASE_HEADERS,
+        params={
+            'page': '1',
+        }
+    )
+    assert res.status_code == 200
+
+
+def test_cve_get_bad_page():
+    """ page must be a positive int """
+
+    # test negative
+    res = requests.get(
+        f'{env.AWG_BASE_URL}{CVE_URL}',
+        headers=utils.BASE_HEADERS,
+        params={
+            'page': -1,
+        }
+    )
+    assert res.status_code == 400
+    response_contains_json(res, 'error', 'BAD_INPUT')
+    response_contains_json(res, 'details', utils.BAD_PAGE_ERROR_DETAILS)
+
+    # test strings
+    res = requests.get(
+        f'{env.AWG_BASE_URL}{CVE_URL}',
+        headers=utils.BASE_HEADERS,
+        params={
+            'page': 'abc',
+        }
+    )
+    assert res.status_code == 400
+    response_contains_json(res, 'error', 'BAD_INPUT')
+    response_contains_json(res, 'details', utils.BAD_PAGE_ERROR_DETAILS)

--- a/test-http/src/test/org_user_tests/org_as_org_admin.py
+++ b/test-http/src/test/org_user_tests/org_as_org_admin.py
@@ -167,6 +167,47 @@ def test_org_admin_get_own_users_info(org_admin_headers):
     response_contains(res, user)
 
 
+def test_org_get_user_page(org_admin_headers):
+    """ page must be a positive int """
+    org = org_admin_headers["CVE-API-ORG"][:MAX_SHORTNAME_LENGTH]
+    res = requests.get(
+        f'{env.AWG_BASE_URL}{ORG_URL}/{org}/users',
+        headers=org_admin_headers,
+        params={
+            'page': '1',
+        }
+    )
+    assert res.status_code == 200
+
+
+def test_org_get_bad_user_page(org_admin_headers):
+    """ page must be a positive int """
+
+    # test negative
+    org = org_admin_headers["CVE-API-ORG"][:MAX_SHORTNAME_LENGTH]
+    res = requests.get(
+        f'{env.AWG_BASE_URL}{ORG_URL}/{org}/users',
+        headers=org_admin_headers,
+        params={
+            'page': -1,
+        }
+    )
+    assert res.status_code == 400
+    response_contains_json(res, 'error', 'BAD_INPUT')
+    response_contains_json(res, 'details', utils.BAD_PAGE_ERROR_DETAILS)
+
+    # test strings
+    res = requests.get(
+        f'{env.AWG_BASE_URL}{ORG_URL}/{org}/users',
+        headers=org_admin_headers,
+        params={
+            'page': 'abc',
+        }
+    )
+    assert res.status_code == 400
+    response_contains_json(res, 'error', 'BAD_INPUT')
+    response_contains_json(res, 'details', utils.BAD_PAGE_ERROR_DETAILS)
+
 #### POST /org ####
 def test_org_admin_cannot_create_another_org(org_admin_headers):
     """ services api does not allow org admins to create other orgs """

--- a/test-http/src/test/user_tests/user.py
+++ b/test-http/src/test/user_tests/user.py
@@ -44,3 +44,43 @@ def test_org_admins_cannot_get_all_users(org_admin_headers):
     )
     assert res.status_code == 403
     response_contains_json(res, 'error', 'SECRETARIAT_ONLY')
+
+
+def test_get_user_page():
+    """ page must be a positive int """
+    res = requests.get(
+        f'{env.AWG_BASE_URL}/api/users',
+        headers=utils.BASE_HEADERS,
+        params={
+            'page': '1',
+        }
+    )
+    assert res.status_code == 200
+
+
+def test_get_bad_user_page():
+    """ page must be a positive int """
+
+    # test negative
+    res = requests.get(
+        f'{env.AWG_BASE_URL}/api/users',
+        headers=utils.BASE_HEADERS,
+        params={
+            'page': '-1',
+        }
+    )
+    assert res.status_code == 400
+    response_contains_json(res, 'error', 'BAD_INPUT')
+    response_contains_json(res, 'details', utils.BAD_PAGE_ERROR_DETAILS)
+
+    # test strings
+    res = requests.get(
+        f'{env.AWG_BASE_URL}/api/users',
+        headers=utils.BASE_HEADERS,
+        params={
+            'page': 'abc',
+        }
+    )
+    assert res.status_code == 400
+    response_contains_json(res, 'error', 'BAD_INPUT')
+    response_contains_json(res, 'details', utils.BAD_PAGE_ERROR_DETAILS)

--- a/test-http/src/utils.py
+++ b/test-http/src/utils.py
@@ -19,6 +19,12 @@ BASE_HEADERS = {
     'CVE-API-USER': env.AWG_USER_NAME
 }
 
+# used to check invalid pagination errors
+BAD_PAGE_ERROR_DETAILS = [{
+    "msg": "Invalid value",
+    "param": "page",
+    "location": "query"
+}]
 
 def assert_contains(response, has_this, count=1):
     if count == 1:


### PR DESCRIPTION
Refs #738 

Validation was missing for:
* /users
* /org/shortname/users

Tests were added for:
* /cve
* /org/shortname/users
* /users
