### PR TITLE
#717 Check for unique English language entries for descriptions field in /api/cve/:id/cna endpoints

### DIFF
--- a/datadump/pre-population/cves.json
+++ b/datadump/pre-population/cves.json
@@ -235,7 +235,7 @@
         "cveId": "CVE-1999-0006",
         "assignerShortName": "mitre",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -271,7 +271,7 @@
         "cveId": "CVE-1999-0008",
         "assignerShortName": "mitre",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -370,7 +370,7 @@
         "cveId": "CVE-1999-0009",
         "assignerShortName": "mitre",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -434,7 +434,7 @@
         "cveId": "CVE-1999-0010",
         "assignerShortName": "window_1",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -471,7 +471,7 @@
         "cveId": "CVE-2000-0002",
         "assignerShortName": "window_1",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -545,7 +545,7 @@
         "cveId": "CVE-2000-0004",
         "assignerShortName": "window_1",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -582,7 +582,7 @@
         "cveId": "CVE-2000-0005",
         "assignerShortName": "window_1",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -671,7 +671,7 @@
         "cveId": "CVE-2000-0008",
         "assignerShortName": "window_1",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -708,7 +708,7 @@
         "cveId": "CVE-2000-0010",
         "assignerShortName": "church_2",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -745,7 +745,7 @@
         "cveId": "CVE-2001-0001",
         "assignerShortName": "church_2",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -834,7 +834,7 @@
         "cveId": "CVE-2001-0002",
         "assignerShortName": "church_2",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -923,7 +923,7 @@
         "cveId": "CVE-2001-0004",
         "assignerShortName": "church_2",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -960,7 +960,7 @@
         "cveId": "CVE-2001-0005",
         "assignerShortName": "church_2",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -997,7 +997,7 @@
         "cveId": "CVE-2001-0009",
         "assignerShortName": "officer_3",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -1034,7 +1034,7 @@
         "cveId": "CVE-2001-0010",
         "assignerShortName": "officer_3",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -1143,7 +1143,7 @@
         "cveId": "CVE-2002-0003",
         "assignerShortName": "officer_3",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -1252,7 +1252,7 @@
         "cveId": "CVE-2002-0006",
         "assignerShortName": "officer_3",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -1289,7 +1289,7 @@
         "cveId": "CVE-2002-0007",
         "assignerShortName": "officer_3",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -1383,7 +1383,7 @@
         "cveId": "CVE-2002-0008",
         "assignerShortName": "range_4",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -1420,7 +1420,7 @@
         "cveId": "CVE-2002-0009",
         "assignerShortName": "range_4",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -1457,7 +1457,7 @@
         "cveId": "CVE-2003-0002",
         "assignerShortName": "range_4",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -1494,7 +1494,7 @@
         "cveId": "CVE-2004-0001",
         "assignerShortName": "range_4",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -1583,7 +1583,7 @@
         "cveId": "CVE-2004-0003",
         "assignerShortName": "range_4",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -1692,7 +1692,7 @@
         "cveId": "CVE-2004-0007",
         "assignerShortName": "win_5",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -1729,7 +1729,7 @@
         "cveId": "CVE-2004-0009",
         "assignerShortName": "win_5",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -1838,7 +1838,7 @@
         "cveId": "CVE-2004-0010",
         "assignerShortName": "win_5",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -1875,7 +1875,7 @@
         "cveId": "CVE-2005-0001",
         "assignerShortName": "win_5",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -1912,7 +1912,7 @@
         "cveId": "CVE-2005-0005",
         "assignerShortName": "win_5",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2016,7 +2016,7 @@
         "cveId": "CVE-2005-0009",
         "assignerShortName": "activity_6",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2105,7 +2105,7 @@
         "cveId": "CVE-2006-0005",
         "assignerShortName": "activity_6",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2189,7 +2189,7 @@
         "cveId": "CVE-2006-0006",
         "assignerShortName": "activity_6",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2278,7 +2278,7 @@
         "cveId": "CVE-2006-0008",
         "assignerShortName": "activity_6",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2347,7 +2347,7 @@
         "cveId": "CVE-2006-0009",
         "assignerShortName": "activity_6",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2421,7 +2421,7 @@
         "cveId": "CVE-2006-0010",
         "assignerShortName": "seem_7",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2458,7 +2458,7 @@
         "cveId": "CVE-2007-0006",
         "assignerShortName": "seem_7",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2537,7 +2537,7 @@
         "cveId": "CVE-2007-0009",
         "assignerShortName": "seem_7",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2621,7 +2621,7 @@
         "cveId": "CVE-2008-0002",
         "assignerShortName": "seem_7",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2730,7 +2730,7 @@
         "cveId": "CVE-2008-0003",
         "assignerShortName": "seem_7",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2767,7 +2767,7 @@
         "cveId": "CVE-2008-0004",
         "assignerShortName": "cause_8",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2841,7 +2841,7 @@
         "cveId": "CVE-2008-0008",
         "assignerShortName": "cause_8",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2878,7 +2878,7 @@
         "cveId": "CVE-2008-0009",
         "assignerShortName": "cause_8",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2915,7 +2915,7 @@
         "cveId": "CVE-2009-0001",
         "assignerShortName": "cause_8",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -2952,7 +2952,7 @@
         "cveId": "CVE-2009-0002",
         "assignerShortName": "cause_8",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3031,7 +3031,7 @@
         "cveId": "CVE-2009-0004",
         "assignerShortName": "admit_9",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3068,7 +3068,7 @@
         "cveId": "CVE-2009-0008",
         "assignerShortName": "admit_9",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3127,7 +3127,7 @@
         "cveId": "CVE-2009-0010",
         "assignerShortName": "admit_9",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3164,7 +3164,7 @@
         "cveId": "CVE-2010-0003",
         "assignerShortName": "admit_9",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3201,7 +3201,7 @@
         "cveId": "CVE-2010-0005",
         "assignerShortName": "admit_9",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3238,7 +3238,7 @@
         "cveId": "CVE-2010-0006",
         "assignerShortName": "beat_10",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3275,7 +3275,7 @@
         "cveId": "CVE-2010-0008",
         "assignerShortName": "beat_10",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3312,7 +3312,7 @@
         "cveId": "CVE-2011-0002",
         "assignerShortName": "beat_10",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3376,7 +3376,7 @@
         "cveId": "CVE-2011-0004",
         "assignerShortName": "beat_10",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3470,7 +3470,7 @@
         "cveId": "CVE-2011-0005",
         "assignerShortName": "beat_10",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3579,7 +3579,7 @@
         "cveId": "CVE-2011-0006",
         "assignerShortName": "tax_11",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3616,7 +3616,7 @@
         "cveId": "CVE-2011-0007",
         "assignerShortName": "tax_11",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3653,7 +3653,7 @@
         "cveId": "CVE-2011-0008",
         "assignerShortName": "tax_11",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3712,7 +3712,7 @@
         "cveId": "CVE-2011-0009",
         "assignerShortName": "tax_11",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3806,7 +3806,7 @@
         "cveId": "CVE-2012-0001",
         "assignerShortName": "tax_11",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3843,7 +3843,7 @@
         "cveId": "CVE-2012-0002",
         "assignerShortName": "face_12",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3880,7 +3880,7 @@
         "cveId": "CVE-2012-0003",
         "assignerShortName": "face_12",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3939,7 +3939,7 @@
         "cveId": "CVE-2012-0004",
         "assignerShortName": "face_12",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -3976,7 +3976,7 @@
         "cveId": "CVE-2012-0005",
         "assignerShortName": "face_12",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4070,7 +4070,7 @@
         "cveId": "CVE-2012-0007",
         "assignerShortName": "face_12",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4174,7 +4174,7 @@
         "cveId": "CVE-2012-0009",
         "assignerShortName": "deal_13",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4211,7 +4211,7 @@
         "cveId": "CVE-2013-0001",
         "assignerShortName": "deal_13",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4305,7 +4305,7 @@
         "cveId": "CVE-2013-0002",
         "assignerShortName": "deal_13",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4374,7 +4374,7 @@
         "cveId": "CVE-2013-0003",
         "assignerShortName": "deal_13",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4411,7 +4411,7 @@
         "cveId": "CVE-2013-0004",
         "assignerShortName": "deal_13",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4448,7 +4448,7 @@
         "cveId": "CVE-2013-0005",
         "assignerShortName": "environmental_14",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4512,7 +4512,7 @@
         "cveId": "CVE-2013-0006",
         "assignerShortName": "environmental_14",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4549,7 +4549,7 @@
         "cveId": "CVE-2013-0010",
         "assignerShortName": "environmental_14",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4633,7 +4633,7 @@
         "cveId": "CVE-2014-0001",
         "assignerShortName": "environmental_14",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4670,7 +4670,7 @@
         "cveId": "CVE-2014-0002",
         "assignerShortName": "environmental_14",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4759,7 +4759,7 @@
         "cveId": "CVE-2014-0003",
         "assignerShortName": "evidence_15",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4848,7 +4848,7 @@
         "cveId": "CVE-2014-0006",
         "assignerShortName": "evidence_15",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4885,7 +4885,7 @@
         "cveId": "CVE-2014-0007",
         "assignerShortName": "evidence_15",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -4974,7 +4974,7 @@
         "cveId": "CVE-2014-0009",
         "assignerShortName": "evidence_15",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5011,7 +5011,7 @@
         "cveId": "CVE-2014-0010",
         "assignerShortName": "evidence_15",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5048,7 +5048,7 @@
         "cveId": "CVE-2015-0007",
         "assignerShortName": "response_16",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5107,7 +5107,7 @@
         "cveId": "CVE-2015-0008",
         "assignerShortName": "response_16",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5144,7 +5144,7 @@
         "cveId": "CVE-2015-0009",
         "assignerShortName": "response_16",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5181,7 +5181,7 @@
         "cveId": "CVE-2015-0010",
         "assignerShortName": "response_16",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5218,7 +5218,7 @@
         "cveId": "CVE-2016-0001",
         "assignerShortName": "response_16",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5255,7 +5255,7 @@
         "cveId": "CVE-2016-0002",
         "assignerShortName": "if_17",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5339,7 +5339,7 @@
         "cveId": "CVE-2016-0005",
         "assignerShortName": "if_17",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5403,7 +5403,7 @@
         "cveId": "CVE-2016-0006",
         "assignerShortName": "if_17",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5507,7 +5507,7 @@
         "cveId": "CVE-2016-0008",
         "assignerShortName": "if_17",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5611,7 +5611,7 @@
         "cveId": "CVE-2016-0009",
         "assignerShortName": "if_17",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5648,7 +5648,7 @@
         "cveId": "CVE-2017-0001",
         "assignerShortName": "if_17",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5752,7 +5752,7 @@
         "cveId": "CVE-2017-0002",
         "assignerShortName": "most_18",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5836,7 +5836,7 @@
         "cveId": "CVE-2017-0003",
         "assignerShortName": "most_18",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -5925,7 +5925,7 @@
         "cveId": "CVE-2017-0004",
         "assignerShortName": "most_18",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -6019,7 +6019,7 @@
         "cveId": "CVE-2017-0009",
         "assignerShortName": "most_18",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -6108,7 +6108,7 @@
         "cveId": "CVE-2017-0010",
         "assignerShortName": "most_18",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -6217,7 +6217,7 @@
         "cveId": "CVE-2018-0001",
         "assignerShortName": "interesting_19",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -6254,7 +6254,7 @@
         "cveId": "CVE-2018-0002",
         "assignerShortName": "interesting_19",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -6291,7 +6291,7 @@
         "cveId": "CVE-2018-0004",
         "assignerShortName": "interesting_19",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -6328,7 +6328,7 @@
         "cveId": "CVE-2018-0007",
         "assignerShortName": "interesting_19",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -6437,7 +6437,7 @@
         "cveId": "CVE-2018-0009",
         "assignerShortName": "interesting_19",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -6551,7 +6551,7 @@
         "cveId": "CVE-2019-0002",
         "assignerShortName": "sister_20",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -6630,7 +6630,7 @@
         "cveId": "CVE-2019-0003",
         "assignerShortName": "sister_20",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -6719,7 +6719,7 @@
         "cveId": "CVE-2019-0007",
         "assignerShortName": "sister_20",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -6756,7 +6756,7 @@
         "cveId": "CVE-2019-0010",
         "assignerShortName": "sister_20",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -6845,7 +6845,7 @@
         "cveId": "CVE-2020-0001",
         "assignerShortName": "sister_20",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -6882,7 +6882,7 @@
         "cveId": "CVE-2020-0002",
         "assignerShortName": "sister_20",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -6976,7 +6976,7 @@
         "cveId": "CVE-2020-0005",
         "assignerShortName": "sister_20",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -7045,7 +7045,7 @@
         "cveId": "CVE-2020-0006",
         "assignerShortName": "mitre",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -7082,7 +7082,7 @@
         "cveId": "CVE-2020-0008",
         "assignerShortName": "mitre",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -7146,7 +7146,7 @@
         "cveId": "CVE-2021-0004",
         "assignerShortName": "mitre",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -7220,7 +7220,7 @@
         "cveId": "CVE-2021-0005",
         "assignerShortName": "mitre",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -7257,7 +7257,7 @@
         "cveId": "CVE-2021-0008",
         "assignerShortName": "mitre",
         "state": "REJECTED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"
@@ -7316,7 +7316,7 @@
         "cveId": "CVE-2021-0009",
         "assignerShortName": "mitre",
         "state": "PUBLISHED",
-        "updated": "2021-09-08"
+        "dateUpdated": "2021-09-08"
       },
       "dataType": "CVE_RECORD",
       "dataVersion": "5.0"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
         "populate-cve:stage": "NODE_ENV=staging node src/scripts/populate-cve.js",
         "populate-cve:int": "NODE_ENV=integration node src/scripts/populate-cve.js",
         "populate-cve:prd": "NODE_ENV=production node src/scripts/populate-cve.js",
-        "start:dev": "node src/swagger.js && NODE_ENV=development node src/scripts/updateOpenapiHost.js && NODE_ENV=development node-dev src/index.js",
+        "start:dev": "node src/swagger.js && TZ=utc NODE_ENV=development node src/scripts/updateOpenapiHost.js && TZ=utc NODE_ENV=development node-dev src/index.js",
         "start:stage": "node src/swagger.js && NODE_ENV=staging node src/scripts/updateOpenapiHost.js && NODE_ENV=staging node src/index.js",
         "start:int": "node src/swagger.js && NODE_ENV=integration node src/scripts/updateOpenapiHost.js && NODE_ENV=integration node src/index.js",
         "start:prd": "node src/swagger.js && NODE_ENV=production node src/scripts/updateOpenapiHost.js && NODE_ENV=production node src/index.js",

--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -1,4 +1,4 @@
-const { validationResult } = require('express-validator')
+const { body, validationResult } = require('express-validator')
 const errors = require('./error')
 const error = new errors.CveControllerError()
 const utils = require('../../utils/utils')
@@ -53,19 +53,41 @@ function parseError (req, res, next) {
   next()
 }
 
-function uniqueEnglishDescription (rejectedReasonsArr) {
-  const langArray = rejectedReasonsArr.map(function (reason) { return reason.lang.toLowerCase() })// create arr of lowercase lang values
-  const foundValues = new Set() // set to hold languages found
-  // loop through the lang array and find duplicates
-  for (var i = 0; i < langArray.length; i++) {
-    if (langArray[i].startsWith('en')) { // check case only if lang starts with "en"
-      if (foundValues.has(langArray[i])) {
-        return false // duplicate found so return false
+/**
+ * Custom body validation to check that the array index passed contains
+ * only 1 unique English language code entry. (Schema validation checks
+ * a unique combination of lang + text value, so we don't here.)
+ *
+ *  - Pass: Duplicate non-English codes (fr and fr)
+ *  - Pass: > 1 different English codes (en and en-ca)
+ *  - Fail: > 1 same English codes (en & en, en-gb & en-gb)
+ *
+ * @param {String} langsIndex
+ * @returns Result
+ */
+function validateUniqueEnglishEntry (langsIndex) {
+  return body(langsIndex).isArray().custom((langsArr, { req }) => {
+    const foundValues = new Set()
+
+    for (const entry of langsArr) {
+      const lang = entry.lang.toLowerCase()
+
+      // ignore non-English
+      if (!lang.startsWith('en')) {
+        continue
       }
-      foundValues.add(langArray[i]) // add each unique value to set
+
+      if (foundValues.has(lang)) {
+        // duplicate found so send error
+        // provide error message details in same format as Ajv
+        throw new Error(`Cannot have more one English language entry '${lang}'`)
+      }
+      // add each unique value to set
+      foundValues.add(lang)
     }
-  }
-  return true // if no duplicate found, then all lang values were unique
+
+    return true
+  })
 }
 
 function validateRejectBody (req, res, next) {
@@ -109,6 +131,6 @@ module.exports = {
   parseError,
   toDate,
   validateCveCnaContainerJsonSchema,
-  uniqueEnglishDescription,
+  validateUniqueEnglishEntry,
   validateRejectBody
 }

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -3,7 +3,7 @@ const router = express.Router()
 const mw = require('../../middleware/middleware')
 const controller = require('./cve.controller')
 const { body, param, query } = require('express-validator')
-const { parseGetParams, parsePostParams, parseError, toDate, validateCveCnaContainerJsonSchema, validateRejectBody, uniqueEnglishDescription } = require('./cve.middleware')
+const { parseGetParams, parsePostParams, parseError, toDate, validateCveCnaContainerJsonSchema, validateRejectBody, validateUniqueEnglishEntry } = require('./cve.middleware')
 const CONSTANTS = require('../../constants')
 const CHOICES = [CONSTANTS.CVE_STATES.REJECTED, CONSTANTS.CVE_STATES.PUBLISHED]
 
@@ -228,6 +228,7 @@ router.post('/cve/:id',
   mw.validateUser,
   mw.onlySecretariat,
   mw.validateCveJsonSchema,
+  validateUniqueEnglishEntry('containers.cna.descriptions'),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
@@ -391,6 +392,7 @@ router.post('/cve/:id/cna',
   mw.validateUser,
   mw.onlyCnas,
   validateCveCnaContainerJsonSchema,
+  validateUniqueEnglishEntry('cnaContainer.descriptions'),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
@@ -474,6 +476,7 @@ router.put('/cve/:id/cna',
   mw.validateUser,
   mw.onlyCnas,
   validateCveCnaContainerJsonSchema,
+  validateUniqueEnglishEntry('cnaContainer.descriptions'),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
@@ -557,13 +560,8 @@ router.post('/cve/:id/reject',
   mw.validateUser,
   mw.onlyCnas,
   validateRejectBody,
+  validateUniqueEnglishEntry(['cnaContainer.rejectedReasons']),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
-  body(['cnaContainer.rejectedReasons']).isArray().custom((arr) => {
-    if (!uniqueEnglishDescription(arr)) {
-      throw new Error(400, 'Bad request, more than one English description found')
-    }
-    return true
-  }),
   body(['cnaContainer.replacedBy']).optional().isArray(),
   parseError,
   parsePostParams,
@@ -647,13 +645,8 @@ router.put('/cve/:id/reject',
   mw.validateUser,
   mw.onlyCnas,
   validateRejectBody,
+  validateUniqueEnglishEntry('cnaContainer.rejectedReasons'),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
-  body(['cnaContainer.rejectedReasons']).isArray().custom((arr) => {
-    if (!uniqueEnglishDescription(arr)) {
-      throw new Error(400, 'Bad request, more than one English description found')
-    }
-    return true
-  }),
   body(['cnaContainer.replacedBy']).optional().isArray(),
   parseError,
   parsePostParams,

--- a/test-http/src/test/cve_tests/cve.py
+++ b/test-http/src/test/cve_tests/cve.py
@@ -4,6 +4,7 @@ import json
 import requests
 import time
 import uuid
+from pathlib import Path
 
 from requests.models import Response
 from src import env, utils
@@ -334,8 +335,10 @@ def test_create_existent_cve():
         assert res.status_code == 400
         response_contains_json(res, 'error', 'CVE_RECORD_EXISTS')
 
-#### POST /cve/:id/reject ####
 
+
+
+#### POST /cve/:id/reject ####
 
 def test_submit_record_rejection():
     """ submit a reject request with a descriptions and replacedBy arrays """
@@ -419,8 +422,11 @@ def test_submit_record_rejection_multiple_non_English_values():
         assert res.status_code == 400  # lang values aren't unique
 
 
-def test_submit_record_rejection_multiple_same_English_values():
-    """ submit a reject request with descriptions array that has multiple same English values (ex: "en-Gb" and "en-Gb") """
+def test_submit_record_rejection_multiple_same_lang_values():
+    """ 
+    submit a reject request with descriptions array that has multiple 
+    identical lang and value entries.
+    """
     res = requests.post(
         f'{env.AWG_BASE_URL}/api/cve-id/',
         headers=utils.BASE_HEADERS,
@@ -430,8 +436,7 @@ def test_submit_record_rejection_multiple_same_English_values():
             'short_name': 'mitre'
         }
     )
-    id_num = json.loads(res.content.decode())[
-        'cve_ids'][0]['cve_id']  # obtain id number
+    id_num = json.loads(res.content.decode())['cve_ids'][0]['cve_id']
     with open('./src/test/cve_tests/cve_record_fixtures/rejectBodyMultipleSameEngValues.json') as json_file:
         data = json.load(json_file)
         res = requests.post(
@@ -439,7 +444,131 @@ def test_submit_record_rejection_multiple_same_English_values():
             headers=utils.BASE_HEADERS,
             json=data
         )
-        assert res.status_code == 400  # lang values are not unique
+
+        res_json = json.loads(res.content.decode())
+
+        assert res.status_code == 400
+
+        response_contains_json(res, 'error', 'INVALID_JSON_SCHEMA')
+        assert res_json['details']['errors'][0]['instancePath'] == '/cnaContainer/rejectedReasons'
+        assert res_json['details']['errors'][0]['schemaPath'] == '#/uniqueItems'
+
+
+def test_update_record_rejection_multiple_same_English_values():
+    """ 
+    update a reject request with descriptions array that has multiple 
+    identical English lang and value entries.
+    """
+    res = requests.post(
+        f'{env.AWG_BASE_URL}/api/cve-id/',
+        headers=utils.BASE_HEADERS,
+        params={
+            'amount': 1,
+            'cve_year': 2000,
+            'short_name': 'mitre'
+        }
+    )
+    id_num = json.loads(res.content.decode())['cve_ids'][0]['cve_id']
+    with open('./src/test/cve_tests/cve_record_fixtures/rejectBody.json') as json_file:
+        data = json.load(json_file)
+        res = requests.post(
+            f'{env.AWG_BASE_URL}{CVE_URL}/{id_num}/reject',
+            headers=utils.BASE_HEADERS,
+            json=data
+        )
+
+        assert res.status_code == 200
+
+    with open('./src/test/cve_tests/cve_record_fixtures/rejectBodyMultipleSameEngValues.json') as json_file:
+        data = json.load(json_file)
+        res = requests.put(
+            f'{env.AWG_BASE_URL}{CVE_URL}/{id_num}/reject',
+            headers=utils.BASE_HEADERS,
+            json=data
+        )
+
+        res_json = json.loads(res.content.decode())
+        
+        assert res.status_code == 400
+
+        response_contains_json(res, 'error', 'INVALID_JSON_SCHEMA')
+        assert res_json['details']['errors'][0]['instancePath'] == '/cnaContainer/rejectedReasons'
+        assert res_json['details']['errors'][0]['schemaPath'] == '#/uniqueItems'
+
+
+def test_submit_record_rejection_multiple_English_lang_entries():
+    """ submit a reject request with descriptions array that contains multiple English lang entries """
+    res = requests.post(
+        f'{env.AWG_BASE_URL}/api/cve-id/',
+        headers=utils.BASE_HEADERS,
+        params={
+            'amount': 1,
+            'cve_year': 2000,
+            'short_name': 'mitre'
+        }
+    )
+    id_num = json.loads(res.content.decode())['cve_ids'][0]['cve_id']
+    with open('./src/test/cve_tests/cve_record_fixtures/rejectBodyMultipleEngLangs.json') as json_file:
+        data = json.load(json_file)
+        res = requests.post(
+            f'{env.AWG_BASE_URL}{CVE_URL}/{id_num}/reject',
+            headers=utils.BASE_HEADERS,
+            json=data
+        )
+
+        res_json = json.loads(res.content.decode())
+
+        assert res.status_code == 400
+
+        # example of how to validate when eventually using Avj extensions
+        # response_contains_json(res, 'error', 'INVALID_JSON_SCHEMA')
+        # assert res_json['details']['errors'][0]['instancePath'] == '/cnaContainer/rejectedReasons'
+        # assert res_json['details']['errors'][0]['message'] == 'Cannot have more one English language entry: en-gb.'
+        response_contains_json(res, 'error', 'BAD_INPUT')
+        assert res_json['details'][0]['param'] == "cnaContainer.rejectedReasons"
+        assert res_json['details'][0]['msg'] == "Cannot have more one English language entry 'en-gb'"
+
+
+def test_update_record_rejection_multiple_English_lang_entries():
+    """ 
+    update a reject request with descriptions array that has multiple 
+    identical English lang entries.
+    """
+    res = requests.post(
+        f'{env.AWG_BASE_URL}/api/cve-id/',
+        headers=utils.BASE_HEADERS,
+        params={
+            'amount': 1,
+            'cve_year': 2000,
+            'short_name': 'mitre'
+        }
+    )
+    id_num = json.loads(res.content.decode())['cve_ids'][0]['cve_id']
+    with open('./src/test/cve_tests/cve_record_fixtures/rejectBody.json') as json_file:
+        data = json.load(json_file)
+        res = requests.post(
+            f'{env.AWG_BASE_URL}{CVE_URL}/{id_num}/reject',
+            headers=utils.BASE_HEADERS,
+            json=data
+        )
+
+        assert res.status_code == 200
+
+    with open('./src/test/cve_tests/cve_record_fixtures/rejectBodyMultipleEngLangs.json') as json_file:
+        data = json.load(json_file)
+        res = requests.put(
+            f'{env.AWG_BASE_URL}{CVE_URL}/{id_num}/reject',
+            headers=utils.BASE_HEADERS,
+            json=data
+        )
+
+        res_json = json.loads(res.content.decode())
+        
+        assert res.status_code == 400
+
+        response_contains_json(res, 'error', 'BAD_INPUT')
+        assert res_json['details'][0]['param'] == "cnaContainer.rejectedReasons"
+        assert res_json['details'][0]['msg'] == "Cannot have more one English language entry 'en-gb'"
 
 
 #### PUT /cve/:id ####
@@ -551,6 +680,72 @@ def test_post_cna_container():
             response_contains_json(res, 'error', 'CVE_RECORD_EXISTS')
 
 
+def test_post_cna_container_langs():
+    """ 
+    tests all permutations of the language fields for cna containers 
+    
+    NB: This currently checks only the cna.descriptions field and not 
+    cna.problemTypes.descriptions because it's unclear if it has the same restrictions
+
+    """
+
+    pos = [
+        "cna_descriptions-multipleEnLangsDifferentLocale.json",
+        "cna_descriptions-multipleSameLangs.json",
+        # "cna_problemTypes_descriptions-multipleEnLangsDifferentLocale.json",
+        # "cna_problemTypes_descriptions-multipleSameLangs.json",
+    ]
+
+    neg = [
+        "cna_descriptions-multipleEnLangs.json",
+        "cna_descriptions-multipleIdenticalEntries.json",
+        # "cna_problemTypes_descriptions-multipleEnLangs.json",
+        # "cna_problemTypes_descriptions-multipleIdenticalEntries.json",
+    ]
+
+    def get_res(test_filename):
+        test_path = Path(
+            './src/test/cve_tests/cve_record_fixtures',
+            'CVE-2000-0008_published_langs',
+            test_filename
+        )
+
+        with open(test_path) as json_file:
+            data = json.load(json_file)
+            data = {'cnaContainer': data['containers']['cna']}
+            return requests.post(
+                f'{env.AWG_BASE_URL}{CVE_URL}/CVE-2021-0004/cna',
+                headers=utils.BASE_HEADERS,
+                json=data
+            )
+
+    for test_filename in pos:
+        res = get_res(test_filename)
+
+        # these records already exist and it's outside scope to create new ones here.
+        # we only want to test that validation passes for the language fields,
+        # so the expected error should be a duplicate entry, NOT language related
+        assert res.status_code == 403, test_filename
+        response_contains_json(res, 'error', 'CVE_RECORD_EXISTS')
+
+    for test_filename in neg :
+        res = get_res(test_filename)
+        res_json = json.loads(res.content.decode())
+        
+        assert res.status_code == 400, test_filename
+
+        # temp fix for a special case because language validation happens
+        # separately from schema validation, and these are caught
+        # by the avj schema validation
+        if test_filename.endswith('multipleIdenticalEntries.json'):
+            response_contains_json(res, 'error', 'INVALID_JSON_SCHEMA', test_filename)
+        else:
+            response_contains_json(res, 'error', 'BAD_INPUT', test_filename)
+            assert res_json['details'][0]['param'] == "cnaContainer.descriptions"
+            assert res_json['details'][0]['msg'] == "Cannot have more one English language entry 'en'"
+
+
+
 def test_put_cna_container():
     """ the cve record is updated from provided cna container """
     with open('./src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published.json') as json_file:
@@ -562,6 +757,67 @@ def test_put_cna_container():
             json=data
         )
         assert res.status_code == 200
+
+
+def test_put_cna_container_langs():
+    """ 
+    tests all permutations of the language fields for put cna containers 
+    
+    NB: This currently checks only the cna.descriptions field and not 
+    cna.problemTypes.descriptions because it's unclear if it has the same restrictions
+
+    """
+
+    pos = [
+        "cna_descriptions-multipleEnLangsDifferentLocale.json",
+        "cna_descriptions-multipleSameLangs.json",
+        # "cna_problemTypes_descriptions-multipleEnLangsDifferentLocale.json",
+        # "cna_problemTypes_descriptions-multipleSameLangs.json",
+    ]
+
+    neg = [
+        "cna_descriptions-multipleEnLangs.json",
+        "cna_descriptions-multipleIdenticalEntries.json",
+        # "cna_problemTypes_descriptions-multipleEnLangs.json",
+        # "cna_problemTypes_descriptions-multipleIdenticalEntries.json",
+    ]
+
+    def get_res(test_filename):
+        test_path = Path(
+            './src/test/cve_tests/cve_record_fixtures',
+            'CVE-2000-0008_published_langs',
+            test_filename
+        )
+
+        with open(test_path) as json_file:
+            data = json.load(json_file)
+            data = {'cnaContainer': data['containers']['cna']}
+            return requests.put(
+                f'{env.AWG_BASE_URL}{CVE_URL}/CVE-2021-0004/cna',
+                headers=utils.BASE_HEADERS,
+                json=data
+            )
+
+    for test_filename in pos:
+        res = get_res(test_filename)
+        assert res.status_code == 200, test_filename
+
+    for test_filename in neg :
+        res = get_res(test_filename)
+        res_json = json.loads(res.content.decode())
+        
+        assert res.status_code == 400, test_filename
+
+        # temp fix for a special case because language validation happens
+        # separately from schema validation, and these are caught
+        # by the avj schema validation
+        if test_filename.endswith('multipleIdenticalEntries.json'):
+            response_contains_json(res, 'error', 'INVALID_JSON_SCHEMA', test_filename)
+        else:
+            response_contains_json(res, 'error', 'BAD_INPUT', test_filename)
+            assert res_json['details'][0]['param'] == "cnaContainer.descriptions"
+            assert res_json['details'][0]['msg'] == "Cannot have more one English language entry 'en'"
+
 
 
 # PUT cve/:id/reject ###

--- a/test-http/src/test/cve_tests/cve.py
+++ b/test-http/src/test/cve_tests/cve.py
@@ -35,44 +35,62 @@ def test_get_all_cves():
 
 
 def test_get_cve_by_time_modified():
-    post_cve('CVE-2021-0004_published', 'CVE-2021-0004')
-    time.sleep(1)
-    post_cve('CVE-2021-0005_published', 'CVE-2021-0005')
-    t_before = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
-    t_before_alt = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S+00:00')
-    time.sleep(1)
-    update_cve('CVE-2021-0004_published', 'CVE-2021-0004')
-    time.sleep(1)
-    update_cve('CVE-2021-0005_published', 'CVE-2021-0005')
-    time.sleep(1)
-    t_after = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
-    t_after_alt = dt.datetime.now().strftime('%Y-%m-%dT%H:%M:%S+00:00')
+    # @todo - These records are created by the populate scripts on the node side
+    # Creating them again here throws 400 errors, which are ignored in this test
 
+    # create CVE records if they don't exist
+    post_cve('CVE-2021-0004_published', 'CVE-2021-0004')
+    post_cve('CVE-2021-0005_published', 'CVE-2021-0005')
+    
+    # grab current timestamp for gt value, then sleep long enough 
+    # for imprecise second resolution and update the CVE records
+    dt_before_update = dt.datetime.now(tz=dt.timezone.utc)
+    time.sleep(3)
+
+    update_cve('CVE-2021-0004_published', 'CVE-2021-0004')
+    update_cve('CVE-2021-0005_published', 'CVE-2021-0005')
+
+    # wait again, then grab after timestamp for lt value
+    time.sleep(3)
+    dt_after_update = dt.datetime.now(tz=dt.timezone.utc)
+
+    # check for ISO dates with and without timezone offsets
+    date_fmt = '%Y-%m-%dT%H:%M:%S'
+    date_fmt_tz = '%Y-%m-%dT%H:%M:%S+00:00'
+
+    # without tz
     res = requests.get(
         f'{env.AWG_BASE_URL}{CVE_URL}/',
         headers=utils.BASE_HEADERS,
         params={
-            'time_modified.lt': t_after,
-            'time_modified.gt': t_before
+            'time_modified.lt': dt_after_update.strftime(date_fmt),
+            'time_modified.gt': dt_before_update.strftime(date_fmt)
         }
     )
-    # Alternat timezone format
+
+    assert res.status_code == utils.HTTP_OK
+    assert len(json.loads(res.content.decode())['cveRecords']) == 2
+
+    # with tz
     res_alt = requests.get(
         f'{env.AWG_BASE_URL}{CVE_URL}/',
         headers=utils.BASE_HEADERS,
         params={
-            'time_modified.lt': t_after_alt,
-            'time_modified.gt': t_before_alt
+            'time_modified.lt': dt_after_update.strftime(date_fmt_tz),
+            'time_modified.gt': dt_before_update.strftime(date_fmt_tz)
         }
     )
-    assert res.status_code == utils.HTTP_OK
-    assert len(json.loads(res.content.decode())['cveRecords']) >= 2
+
     assert res_alt.status_code == utils.HTTP_OK
-    assert len(json.loads(res_alt.content.decode())['cveRecords']) >= 2
+    assert len(json.loads(res_alt.content.decode())['cveRecords']) == 2
 
 
 def test_get_cve_by_count_only_true():
-    """ count_only set to True using number 1 """
+    """ 
+    count_only set to True using number 1 
+    
+    WARNING: Requires pristine database
+    """
     res = requests.get(
         f'{env.AWG_BASE_URL}{CVE_URL}/',
         headers=utils.BASE_HEADERS,
@@ -87,7 +105,11 @@ def test_get_cve_by_count_only_true():
 
 
 def test_get_cve_by_count_only_false():
-    """ count_only set to False using number 0, returns all records"""
+    """ 
+    count_only set to False using number 0, returns all records
+    
+    WARNING: Requires pristine database
+    """
     res = requests.get(
         f'{env.AWG_BASE_URL}{CVE_URL}/',
         headers=utils.BASE_HEADERS,
@@ -778,6 +800,10 @@ def test_put_cna_container_langs():
     neg = [
         "cna_descriptions-multipleEnLangs.json",
         "cna_descriptions-multipleIdenticalEntries.json",
+        
+        # throws a 500 instead of 40X
+        # "cna_descriptions-multipleSameLangsNoEn.json",
+        
         # "cna_problemTypes_descriptions-multipleEnLangs.json",
         # "cna_problemTypes_descriptions-multipleIdenticalEntries.json",
     ]

--- a/test-http/src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published_langs/cna_descriptions-multipleEnLangs.json
+++ b/test-http/src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published_langs/cna_descriptions-multipleEnLangs.json
@@ -1,0 +1,66 @@
+{
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "vendor": "n/a",
+                    "product": "n/a",
+                    "versions": [
+                        {
+                            "version": "n/a",
+                            "status": "unknown"
+                        }
+                    ]
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "Cross-site scripting (XSS) vulnerability in Revive Adserver before 4.0.1 allows remote authenticated users to inject arbitrary web script or HTML via the user's email address."
+                },
+                {
+                    "lang": "en",
+                    "value": "A different description in the same language"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                            {
+                                "description": "n/a",
+                                "lang": "eng",
+                                "type": "text"
+                            }
+                        ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "9cbfeea8-dea2-4923-b772-1ab41730e742"
+            },
+            "references": [
+                {
+                    "name": "[oss-security] 20170202 Re: CVE request: multiples vulnerabilities in Revive Adserver",
+                    "refsource": "MLIST",
+                    "url": "http://www.openwall.com/lists/oss-security/2017/02/02/3"
+                },
+                {
+                    "name": "https://www.revive-adserver.com/security/revive-sa-2017-001/",
+                    "refsource": "CONFIRM",
+                    "url": "https://www.revive-adserver.com/security/revive-sa-2017-001/"
+                },
+                {
+                    "name": "95875",
+                    "refsource": "BID",
+                    "url": "http://www.securityfocus.com/bid/95875"
+                }
+            ]
+        }
+    },
+    "cveMetadata": {
+        "assignerOrgId": "9cbfeea8-dea2-4923-b772-1ab41730e742",
+        "cveId": "CVE-2000-0008",
+        "state": "PUBLISHED"
+    },
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0"
+}

--- a/test-http/src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published_langs/cna_descriptions-multipleEnLangsDifferentLocale.json
+++ b/test-http/src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published_langs/cna_descriptions-multipleEnLangsDifferentLocale.json
@@ -1,0 +1,66 @@
+{
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "vendor": "n/a",
+                    "product": "n/a",
+                    "versions": [
+                        {
+                            "version": "n/a",
+                            "status": "unknown"
+                        }
+                    ]
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "en",
+                    "value": "Cross-site scripting (XSS) vulnerability in Revive Adserver before 4.0.1 allows remote authenticated users to inject arbitrary web script or HTML via the user's email address."
+                },
+                {
+                    "lang": "en-gb",
+                    "value": "A different description in the same language"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                            {
+                                "description": "n/a",
+                                "lang": "eng",
+                                "type": "text"
+                            }
+                        ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "9cbfeea8-dea2-4923-b772-1ab41730e742"
+            },
+            "references": [
+                {
+                    "name": "[oss-security] 20170202 Re: CVE request: multiples vulnerabilities in Revive Adserver",
+                    "refsource": "MLIST",
+                    "url": "http://www.openwall.com/lists/oss-security/2017/02/02/3"
+                },
+                {
+                    "name": "https://www.revive-adserver.com/security/revive-sa-2017-001/",
+                    "refsource": "CONFIRM",
+                    "url": "https://www.revive-adserver.com/security/revive-sa-2017-001/"
+                },
+                {
+                    "name": "95875",
+                    "refsource": "BID",
+                    "url": "http://www.securityfocus.com/bid/95875"
+                }
+            ]
+        }
+    },
+    "cveMetadata": {
+        "assignerOrgId": "9cbfeea8-dea2-4923-b772-1ab41730e742",
+        "cveId": "CVE-2000-0008",
+        "state": "PUBLISHED"
+    },
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0"
+}

--- a/test-http/src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published_langs/cna_descriptions-multipleIdenticalEntries.json
+++ b/test-http/src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published_langs/cna_descriptions-multipleIdenticalEntries.json
@@ -1,0 +1,66 @@
+{
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "vendor": "n/a",
+                    "product": "n/a",
+                    "versions": [
+                        {
+                            "version": "n/a",
+                            "status": "unknown"
+                        }
+                    ]
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "fr",
+                    "value": "Cross-site scripting (XSS) vulnerability in Revive Adserver before 4.0.1 allows remote authenticated users to inject arbitrary web script or HTML via the user's email address."
+                },
+                {
+                    "lang": "fr",
+                    "value": "Cross-site scripting (XSS) vulnerability in Revive Adserver before 4.0.1 allows remote authenticated users to inject arbitrary web script or HTML via the user's email address."
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                            {
+                                "description": "n/a",
+                                "lang": "eng",
+                                "type": "text"
+                            }
+                        ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "9cbfeea8-dea2-4923-b772-1ab41730e742"
+            },
+            "references": [
+                {
+                    "name": "[oss-security] 20170202 Re: CVE request: multiples vulnerabilities in Revive Adserver",
+                    "refsource": "MLIST",
+                    "url": "http://www.openwall.com/lists/oss-security/2017/02/02/3"
+                },
+                {
+                    "name": "https://www.revive-adserver.com/security/revive-sa-2017-001/",
+                    "refsource": "CONFIRM",
+                    "url": "https://www.revive-adserver.com/security/revive-sa-2017-001/"
+                },
+                {
+                    "name": "95875",
+                    "refsource": "BID",
+                    "url": "http://www.securityfocus.com/bid/95875"
+                }
+            ]
+        }
+    },
+    "cveMetadata": {
+        "assignerOrgId": "9cbfeea8-dea2-4923-b772-1ab41730e742",
+        "cveId": "CVE-2000-0008",
+        "state": "PUBLISHED"
+    },
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0"
+}

--- a/test-http/src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published_langs/cna_descriptions-multipleSameLangs.json
+++ b/test-http/src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published_langs/cna_descriptions-multipleSameLangs.json
@@ -1,0 +1,66 @@
+{
+    "containers": {
+        "cna": {
+            "affected": [
+                {
+                    "vendor": "n/a",
+                    "product": "n/a",
+                    "versions": [
+                        {
+                            "version": "n/a",
+                            "status": "unknown"
+                        }
+                    ]
+                }
+            ],
+            "descriptions": [
+                {
+                    "lang": "fr",
+                    "value": "Cross-site scripting (XSS) vulnerability in Revive Adserver before 4.0.1 allows remote authenticated users to inject arbitrary web script or HTML via the user's email address."
+                },
+                {
+                    "lang": "fr",
+                    "value": "A different description in the same language"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                            {
+                                "description": "n/a",
+                                "lang": "eng",
+                                "type": "text"
+                            }
+                        ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "9cbfeea8-dea2-4923-b772-1ab41730e742"
+            },
+            "references": [
+                {
+                    "name": "[oss-security] 20170202 Re: CVE request: multiples vulnerabilities in Revive Adserver",
+                    "refsource": "MLIST",
+                    "url": "http://www.openwall.com/lists/oss-security/2017/02/02/3"
+                },
+                {
+                    "name": "https://www.revive-adserver.com/security/revive-sa-2017-001/",
+                    "refsource": "CONFIRM",
+                    "url": "https://www.revive-adserver.com/security/revive-sa-2017-001/"
+                },
+                {
+                    "name": "95875",
+                    "refsource": "BID",
+                    "url": "http://www.securityfocus.com/bid/95875"
+                }
+            ]
+        }
+    },
+    "cveMetadata": {
+        "assignerOrgId": "9cbfeea8-dea2-4923-b772-1ab41730e742",
+        "cveId": "CVE-2000-0008",
+        "state": "PUBLISHED"
+    },
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.0"
+}

--- a/test-http/src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published_langs/cna_descriptions-multipleSameLangsNoEn.json
+++ b/test-http/src/test/cve_tests/cve_record_fixtures/CVE-2000-0008_published_langs/cna_descriptions-multipleSameLangsNoEn.json
@@ -15,10 +15,6 @@
             ],
             "descriptions": [
                 {
-                    "lang": "en",
-                    "value": "An English description is required"
-                },
-                {
                     "lang": "fr",
                     "value": "Cross-site scripting (XSS) vulnerability in Revive Adserver before 4.0.1 allows remote authenticated users to inject arbitrary web script or HTML via the user's email address."
                 },

--- a/test-http/src/test/cve_tests/cve_record_fixtures/rejectBodyMultipleEngLangs.json
+++ b/test-http/src/test/cve_tests/cve_record_fixtures/rejectBodyMultipleEngLangs.json
@@ -1,0 +1,31 @@
+{
+    "cnaContainer": {
+        "rejectedReasons": [
+            {
+                "lang": "en-Gb",
+                "value": "I professional site herself recently behavior.",
+                "supportingMedia": [
+                    {
+                        "type": "test/markdown",
+                        "base64": false,
+                        "value": "*this* _is_ supporting media in ~markdown~"
+                    }
+                ]
+            },
+            {
+                "lang": "en-Gb",
+                "value": "Situation institution meeting recognize successful.",
+                "supportingMedia": [
+                    {
+                        "type": "test/markdown",
+                        "base64": false,
+                        "value": "*this* _is_ supporting media in ~markdown~"
+                    }
+                ]
+            }
+        ],
+        "replacedBy": [
+            "CVE-1999-0006"
+        ]
+    }
+}

--- a/test-http/src/test/cve_tests/cve_record_fixtures/rejectBodyMultipleIdenticalValues.json
+++ b/test-http/src/test/cve_tests/cve_record_fixtures/rejectBodyMultipleIdenticalValues.json
@@ -1,0 +1,31 @@
+{
+    "cnaContainer": {
+        "rejectedReasons": [
+            {
+                "lang": "fr",
+                "value": "I professional site herself recently behavior.",
+                "supportingMedia": [
+                    {
+                        "type": "test/markdown",
+                        "base64": false,
+                        "value": "*this* _is_ supporting media in ~markdown~"
+                    }
+                ]
+            },
+            {
+                "lang": "fr",
+                "value": "Situation institution meeting recognize successful.",
+                "supportingMedia": [
+                    {
+                        "type": "test/markdown",
+                        "base64": false,
+                        "value": "*this* _is_ supporting media in ~markdown~"
+                    }
+                ]
+            }
+        ],
+        "replacedBy": [
+            "CVE-1999-0006"
+        ]
+    }
+}

--- a/test-http/src/utils.py
+++ b/test-http/src/utils.py
@@ -37,8 +37,8 @@ def response_contains(response, has_this):
     assert_contains(response, has_this)
 
 
-def response_contains_json(response, json_key, is_this):
-    assert json.loads(response.content.decode())[json_key] == is_this
+def response_contains_json(response, json_key, is_this, msg=None):
+    assert json.loads(response.content.decode())[json_key] == is_this, msg
 
 
 def ok_response_contains(response, has_this):


### PR DESCRIPTION
Refs #717 

This only validates the `cnaContainer.descriptions` field. The `cnaContainer.problemTypes.descriptions` field does uses a different [schema](https://github.com/CVEProject/cve-schema/blob/master/schema/v5.0/CVE_JSON_5.0_schema.json#L753), so this validation is not applied to it.