### PR TITLE
#786 allow owning org of cve ID to be changed when a record already e…

### DIFF
--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -268,15 +268,18 @@ async function modifyCveId (req, res, next) {
     const userRepo = req.ctx.repositories.getUserRepository()
     const cveRepo = req.ctx.repositories.getCveRepository()
 
+    // Check for existing record - await only allowed at top level so cannot
+    // move inside of it statement below
     const cve = await cveRepo.findOneByCveId(id)
-    if (cve) {
-      return res.status(403).json(error.cannotChangeCveIdWithRecord(id))
-    }
 
     Object.keys(req.ctx.query).forEach(k => {
       const key = k.toLowerCase()
 
+      // Ok to change owning_cna if there is an existing record, but not state
       if (key === 'state') {
+        if (cve) {
+          return res.status(403).json(error.cannotChangeCveIdWithRecord(id))
+        }
         state = req.ctx.query.state
       } else if (key === 'org') {
         newOrgShortName = req.ctx.query.org


### PR DESCRIPTION
Move check for published record so that owning_org can be changed if one exists, but state cannot be. No fields are changed in the CVE record when owning_org is changed since the org fields in the record do not equate to the owning_org