### PR TITLE
#858 use estimatedDocumentCount for counting full CVE Record collection

### DIFF
--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -40,6 +40,15 @@ async function getFilteredCves (req, res, next) {
       dateOperator: []
     }
 
+    // if count_only is the only parameter, return estimated count of full set of records
+    if ((Object.keys(req.ctx.query).length === 1) &&
+        (req.ctx.query.count_only === '1')) {
+      const payload = {}
+      payload.totalCount = await cveRepo.estimatedDocumentCount()
+      logger.info({ uuid: req.ctx.uuid, message: 'The cve records estimated count was sent to the user.' })
+      return res.status(200).json(payload) // only return estimated count, not the records
+    }
+
     Object.keys(req.ctx.query).forEach(k => {
       const key = k.toLowerCase()
       if (key === 'time_modified.lt') {
@@ -95,7 +104,7 @@ async function getFilteredCves (req, res, next) {
       }
     ]
 
-    // check whether user requested count_only
+    // check whether user requested count_only for filtered set of records
     if (req.ctx.query.count_only === '1') {
       const payload = {}
       payload.totalCount = await cveRepo.countDocuments(query)

--- a/src/repositories/baseRepository.js
+++ b/src/repositories/baseRepository.js
@@ -59,6 +59,10 @@ class BaseRepository {
     return this.collection.countDocuments(query)
   }
 
+  async estimatedDocumentCount (query = {}) {
+    return this.collection.estimatedDocumentCount(query)
+  }
+
   async deleteMany (query = {}) {
     return this.collection.deleteMany(query)
   }


### PR DESCRIPTION
When GET /cve is called with only the count_only parameter set, uses estimatedDocumentCount for efficient response
