### PR TITLE
Update comments to clarify why two language keys are passed in POST/PUT /cve/:id

### DIFF
--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -232,7 +232,7 @@ router.post('/cve/:id',
   mw.validateUser,
   mw.onlySecretariat,
   mw.validateCveJsonSchema,
-  // the lang entry is cnaContainer.cnaRejectedContainer if state is rejected
+  // the lang key to check depends on the state, so pass both
   validateUniqueEnglishEntry(['containers.cna.descriptions', 'containers.cna.rejectedReasons']),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
@@ -315,7 +315,7 @@ router.put('/cve/:id',
   mw.validateUser,
   mw.onlySecretariat,
   mw.validateCveJsonSchema,
-  // the lang entry is cnaContainer.cnaRejectedContainer if state is rejected
+  // the lang key to check depends on the state, so pass both
   validateUniqueEnglishEntry(['containers.cna.descriptions', 'containers.cna.rejectedReasons']),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,


### PR DESCRIPTION
Comment change only. No functional changes.