### PR TITLE
Resolves #697 Remove disallowed characters in endpoint calls to prevent reflected XSS

### DIFF
--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -299,7 +299,11 @@ function validateJsonSyntax (err, req, res, next) {
     } else if (err.status === 400) {
       console.warn('Request failed validation because JSON syntax is incorrect')
       console.info((JSON.stringify(err)))
-      return res.status(400).json(error.invalidJsonSyntax(err.message))
+      let filteredMessage = err.message
+      if (filteredMessage.includes('Failed to decode param')) {
+        filteredMessage = filteredMessage.replace(/[^A-Z0-9_ -]+/gi, '')
+      }
+      return res.status(400).json(error.invalidJsonSyntax(filteredMessage))
     } else {
       console.warn('Request failed')
       console.info((JSON.stringify(err)))


### PR DESCRIPTION
Closes issue #697 .

Added a regex filter in `validateJsonSyntax` in `middleware.js` to remove non alphanumeric characters to prevent reflected XSS in certain browsers.
