### PR TITLE
Resolves #785 Remove disallowed characters in query parameter names to prevent XSS reflection

### DIFF
--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -223,10 +223,8 @@ async function onlyOrgWithRole (req, res, next) {
 function validateQueryParameterNames (queryParamNames, validNames) {
   Object.keys(queryParamNames).forEach(k => {
     if (!validNames.includes(k)) {
-      let filteredMessage = `'${k}' is not a valid parameter name.`
-      filteredMessage = filteredMessage.replace(/[^A-Z0-9_ -]+/gi, ' ')
-
-      throw new Error(filteredMessage)
+      const filteredMessage = k.replace(/[^A-Z0-9_ -]+/gi, ' ')
+      throw new Error("'" + filteredMessage.trim() + "'" + ' is not a valid parameter name.')
     }
   })
   return true

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -299,7 +299,11 @@ function validateJsonSyntax (err, req, res, next) {
     } else if (err.status === 400) {
       console.warn('Request failed validation because JSON syntax is incorrect')
       console.info((JSON.stringify(err)))
-      return res.status(400).json(error.invalidJsonSyntax(err.message))
+      let filteredMessage = err.message
+      if (filteredMessage.includes('Failed to decode param')) {
+        filteredMessage = filteredMessage.replace(/[^A-Z0-9_ -]+/gi, '')
+      }
+      return res.status(400).json(error.invalidJsonSyntax(filteredMessage))
     } else {
       console.warn('Request failed')
       console.info((JSON.stringify(err)))

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -223,7 +223,10 @@ async function onlyOrgWithRole (req, res, next) {
 function validateQueryParameterNames (queryParamNames, validNames) {
   Object.keys(queryParamNames).forEach(k => {
     if (!validNames.includes(k)) {
-      throw new Error(`'${k}' is not a valid parameter name.`)
+      let filteredMessage = `'${k}' is not a valid parameter name.`
+      filteredMessage = filteredMessage.replace(/[^A-Z0-9_ -]+/gi, ' ')
+
+      throw new Error(filteredMessage)
     }
   })
   return true


### PR DESCRIPTION
Similar to PR #921 but this filters parameters used in error messages in `validateQueryParameterNames` in `middleware.js` to prevent possible XSS reflection in certain browsers.
