### PR TITLE
Resolves #787 Prevents updating CVE-ID states to RESERVED if owning Org has no remaining quota

### DIFF
--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -267,6 +267,11 @@ async function modifyCveId (req, res, next) {
     const cveIdRepo = req.ctx.repositories.getCveIdRepository()
     const userRepo = req.ctx.repositories.getUserRepository()
     const cveRepo = req.ctx.repositories.getCveRepository()
+    const org = await orgRepo.findOneByShortName(req.ctx.org)
+
+    // Get remaining org quota
+    const totalReserved = await cveIdRepo.countDocuments({ owning_cna: org.UUID, state: 'RESERVED' })
+    const remainingQuota = (org.policies.id_quota - totalReserved)
 
     // Check for existing record - await only allowed at top level so cannot
     // move inside of it statement below
@@ -281,6 +286,11 @@ async function modifyCveId (req, res, next) {
           return res.status(403).json(error.cannotChangeCveIdWithRecord(id))
         }
         state = req.ctx.query.state
+
+        // Don't allow state transition to RESERVED if org has no remaining quota
+        if (state === 'RESERVED' && remainingQuota <= 0) {
+          return res.status(403).json(error.modifyCveIdNoQuota())
+        }
       } else if (key === 'org') {
         newOrgShortName = req.ctx.query.org
       }

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -276,8 +276,10 @@ async function modifyCveId (req, res, next) {
     // Check for existing record - await only allowed at top level so cannot
     // move inside of it statement below
     const cve = await cveRepo.findOneByCveId(id)
-
-    Object.keys(req.ctx.query).forEach(k => {
+    const queryKeys = Object.keys(req.ctx.query)
+    // Object.keys(req.ctx.query).forEach(k => {
+    for (let i = 0; i < queryKeys.length; i++) {
+      const k = queryKeys[i]
       const key = k.toLowerCase()
 
       // Ok to change owning_cna if there is an existing record, but not state
@@ -294,7 +296,8 @@ async function modifyCveId (req, res, next) {
       } else if (key === 'org') {
         newOrgShortName = req.ctx.query.org
       }
-    })
+    }
+    // })
 
     let result = await cveIdRepo.findOneByCveId(id)
     if (!result) {

--- a/src/controller/cve-id.controller/error.js
+++ b/src/controller/cve-id.controller/error.js
@@ -125,6 +125,14 @@ class CveIdControllerError extends idrErr.IDRError {
     }
     return err
   }
+
+  modifyCveIdNoQuota () {
+    const err = {
+      error: 'TRANSITION_STATE_RESERVED_NO_QUOTA',
+      message: 'A CVE ID state cannot be changed to RESERVED if the owning organization has no remaining quota.'
+    }
+    return err
+  }
 }
 
 module.exports = {

--- a/test/unit-tests/cve-id/cveIdUpdateTest.js
+++ b/test/unit-tests/cve-id/cveIdUpdateTest.js
@@ -48,6 +48,10 @@ class OrgModifyCveIdOrgAndStateModified {
   async getOrgUUID () {
     return cveIdFixtures.org.UUID
   }
+
+  async findOneByShortName (shortName) {
+    return cveIdFixtures.org
+  }
 }
 
 class CveIdModifyCveIdOrgAndStateModified {
@@ -259,6 +263,11 @@ describe('Testing the PUT /cve-id/:id endpoint in CveId Controller', () => {
 
         async aggregate () {
           return [this.testRes1]
+        }
+
+        // Returns count less than quota for testing
+        async countDocuments (uuid, state) {
+          return 200
         }
       }
 

--- a/test/unit-tests/cve-id/cveIdUpdateTest.js
+++ b/test/unit-tests/cve-id/cveIdUpdateTest.js
@@ -69,6 +69,11 @@ class CveIdModifyCveIdOrgAndStateModified {
   async aggregate () {
     return [this.testRes1]
   }
+
+  // Returns count less than quota for testing
+  async countDocuments (uuid, state) {
+    return 200
+  }
 }
 
 describe('Testing the PUT /cve-id/:id endpoint in CveId Controller', () => {
@@ -78,11 +83,20 @@ describe('Testing the PUT /cve-id/:id endpoint in CveId Controller', () => {
         async findOneByCveId () {
           return null
         }
+
+        // Returns count less than quota for testing
+        async countDocuments (uuid, state) {
+          return 200
+        }
       }
 
       class OrgModifyCveIdDoesntExist {
         async getOrgUUID () {
           return null
+        }
+
+        async findOneByShortName (shortName) {
+          return cveIdFixtures.org
         }
       }
 
@@ -119,6 +133,10 @@ describe('Testing the PUT /cve-id/:id endpoint in CveId Controller', () => {
       class OrgModifyCveIdOrgDoesntExist {
         async getOrgUUID () {
           return null
+        }
+
+        async findOneByShortName (shortName) {
+          return cveIdFixtures.org
         }
       }
 


### PR DESCRIPTION
Closes #787 

Added check in `modifyCveId` in  `cve-id.controller.js` to throw an error when a user attempts to update a Cve-Id state to RESERVED when the owning organization has no remaining quota.