### PR TITLE
#925 updates to Swagger docs, including removal of the term CVE ID entry

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -20,7 +20,7 @@
         "tags": [
           "CVE ID"
         ],
-        "summary": "Retrieves CVE ID entries after applying the query parameters as filters (accessible to all registered users)",
+        "summary": "Retrieves information about CVE IDs after applying the query parameters as filters (accessible to all registered users)",
         "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves filtered CVE IDs owned by the user's organization</p>  <p><b>Secretariat:</b> Retrieves filtered CVE IDs owned by any organization</p>",
         "operationId": "cveIdGetFiltered",
         "parameters": [
@@ -57,7 +57,7 @@
         ],
         "responses": {
           "200": {
-            "description": "A filtered list of CVE ID entries owned by the organization, along with pagination fields if results span multiple pages of data",
+            "description": "A filtered list of information about CVE IDs owned by the organization, along with pagination fields if results span multiple pages of data",
             "content": {
               "application/json": {
                 "schema": {
@@ -227,8 +227,8 @@
         "tags": [
           "CVE ID"
         ],
-        "summary": "Retrieves a CVE ID entry for the specified id (acessible to all users)",
-        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users: </b>Retrieves full information for a CVE ID owned by their organization; partial information for a CVE ID owned by other organizations</p>  <p><b>Unauthenticated Users: Retrieves partial information for a CVE ID</b>  <p><b>Secretariat: </b>Retrieves full information for a CVE ID owned by any organization</p>  <p><i><b>Note - </b>The owning organization of RESERVED CVE IDs is redacted for all users other than those in the owning organization or Secretariat</i></p>",
+        "summary": "Retrieves information about the specified CVE ID (accessible to all users)",
+        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users: </b>Retrieves full information about a CVE ID owned by their organization; partial information about a CVE ID owned by other organizations</p>  <p><b>Unauthenticated Users: Retrieves partial information about a CVE ID</b>  <p><b>Secretariat: </b>Retrieves full information about a CVE ID owned by any organization</p>  <p><i><b>Note - </b>The owning organization of RESERVED CVE IDs is redacted for all users other than those in the owning organization or Secretariat</i></p>",
         "operationId": "cveIdGetSingle",
         "parameters": [
           {
@@ -238,7 +238,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The id of CVE ID entry to retrieve"
+            "description": "The id of the CVE ID information to retrieve"
           },
           {
             "$ref": "#/components/parameters/apiEntityHeader"
@@ -252,7 +252,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The requested CVE ID entry is returned",
+            "description": "The requested CVE ID information is returned",
             "content": {
               "application/json": {
                 "schema": {
@@ -317,8 +317,8 @@
         "tags": [
           "CVE ID"
         ],
-        "summary": "Updates the CVE ID entry for the specified id (accessible to CNAs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Updates a CVE ID entry owned by the CNA's organization</p>  <p><b>Secretariat:</b> Updates a CVE ID entry owned by any organization</p>",
+        "summary": "Updates information related to the specified CVE ID (accessible to CNAs and Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Updates information related to a CVE ID owned by the CNA's organization</p>  <p><b>Secretariat:</b> Updates a CVE ID owned by any organization</p>",
         "operationId": "cveIdUpdateSingle",
         "parameters": [
           {
@@ -328,7 +328,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "The id of the CVE ID entry to update"
+            "description": "The id of the CVE ID to update"
           },
           {
             "$ref": "#/components/parameters/org"
@@ -348,7 +348,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The updated CVE ID entry is returned",
+            "description": "The updated CVE ID information is returned",
             "content": {
               "application/json": {
                 "schema": {
@@ -415,8 +415,8 @@
         "tags": [
           "CVE ID"
         ],
-        "summary": "Creates a CVE-ID-Range entry for the specified year (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates a CVE-ID-Range entry for the specified year</p>",
+        "summary": "Creates a CVE-ID-Range for the specified year (accessible to Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates a CVE-ID-Range for the specified year</p>",
         "operationId": "cveIdRangeCreate",
         "parameters": [
           {
@@ -426,7 +426,7 @@
             "schema": {
               "type": "integer"
             },
-            "description": "The year of the CVE-ID-Range entry"
+            "description": "The year of the CVE-ID-Range"
           },
           {
             "$ref": "#/components/parameters/apiEntityHeader"
@@ -440,7 +440,7 @@
         ],
         "responses": {
           "200": {
-            "description": "The CVE-ID-Range entity was created"
+            "description": "The CVE-ID-Range was created"
           },
           "400": {
             "description": "Bad Request",
@@ -789,7 +789,7 @@
           "CVE Record"
         ],
         "summary": "Retrieves all CVE Records after applying the query parameters as filters (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves all CVE entries for all organizations</p>",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves all CVE records for all organizations</p>",
         "operationId": "cveGetFiltered",
         "parameters": [
           {
@@ -1287,8 +1287,8 @@
         "tags": [
           "Organization"
         ],
-        "summary": "Retrieves all organization entries (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves all organization entries</p>",
+        "summary": "Retrieves all organizations (accessible to Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves information about all organizations</p>",
         "operationId": "orgAll",
         "parameters": [
           {
@@ -1306,7 +1306,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns all organization entries, along with pagination fields if results span multiple pages of data",
+            "description": "Returns information about all organizations, along with pagination fields if results span multiple pages of data",
             "content": {
               "application/json": {
                 "schema": {
@@ -1371,8 +1371,8 @@
         "tags": [
           "Organization"
         ],
-        "summary": "Creates an organization entry as specified in the request body (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates an organization entry</p>  ",
+        "summary": "Creates an organization as specified in the request body (accessible to Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates an organization</p>  ",
         "operationId": "orgCreateSingle",
         "parameters": [
           {
@@ -1387,7 +1387,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the organization entry created",
+            "description": "Returns information about the organization created",
             "content": {
               "application/json": {
                 "schema": {
@@ -1464,8 +1464,8 @@
         "tags": [
           "Organization"
         ],
-        "summary": "Retrieves the organization entry for the specified short name or UUID (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves organization record for the specified shortname or UUID if it is the user's organization</p>  <p><b>Secretariat:</b> Retrieves any organization entry</p>",
+        "summary": "Retrieves information about the organization specified by short name or UUID (accessible to all registered users)",
+        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves organization record for the specified shortname or UUID if it is the user's organization</p>  <p><b>Secretariat:</b> Retrieves information for any organization</p>",
         "operationId": "orgSingle",
         "parameters": [
           {
@@ -1489,7 +1489,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the organization entry",
+            "description": "Returns the organization information",
             "content": {
               "application/json": {
                 "schema": {
@@ -1556,7 +1556,7 @@
         "tags": [
           "Organization"
         ],
-        "summary": "Updates an organization entry for the specified organization short name (accessible to Secretariat)",
+        "summary": "Updates information about the organization specified by short name (accessible to Secretariat)",
         "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Updates any organization's information</p>",
         "operationId": "orgUpdateSingle",
         "parameters": [
@@ -1596,7 +1596,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the organization entry updated",
+            "description": "Returns information about the organization updated",
             "content": {
               "application/json": {
                 "schema": {
@@ -1663,8 +1663,8 @@
         "tags": [
           "Organization"
         ],
-        "summary": "Retrieves an organization's CVE ID quota information (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves CVE ID quota information for user's organization</p>  <p><b>Secretariat:</b> Retrieves CVE ID quota information of any organization</p>",
+        "summary": "Retrieves an organization's CVE ID quota (accessible to all registered users)",
+        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves the CVE ID quota for the user's organization</p>  <p><b>Secretariat:</b> Retrieves the CVE ID quota for any organization</p>",
         "operationId": "orgIdQuota",
         "parameters": [
           {
@@ -1688,7 +1688,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns CVE ID quota details of an organization",
+            "description": "Returns the CVE ID quota details of an organization",
             "content": {
               "application/json": {
                 "schema": {
@@ -1756,7 +1756,7 @@
           "Users"
         ],
         "summary": "Retrieves all users for the organization with the specified short name (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves information for users in the same organization</p>  <p><b>Secretariat:</b> Retrieves all user information from any organization</p>",
+        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about users in the same organization</p>  <p><b>Secretariat:</b> Retrieves all user information for any organization</p>",
         "operationId": "userOrgAll",
         "parameters": [
           {
@@ -1850,8 +1850,8 @@
         "tags": [
           "Users"
         ],
-        "summary": "Create a user entry with the provided short name as the owning organization (accessible to Admins and Secretariats)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>  <h2>Expected Behavior</h2>  <p><b>Admin User:</b> Creates a user entry for the Admin's organization</p>  <p><b>Secretariat:</b> Creates a user entry for any organization</p>",
+        "summary": "Create a user with the provided short name as the owning organization (accessible to Admins and Secretariats)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>  <h2>Expected Behavior</h2>  <p><b>Admin User:</b> Creates a user for the Admin's organization</p>  <p><b>Secretariat:</b> Creates a user for any organization</p>",
         "operationId": "userCreateSingle",
         "parameters": [
           {
@@ -1875,7 +1875,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the created user entry (with the secret)",
+            "description": "Returns the user created (with the secret)",
             "content": {
               "application/json": {
                 "schema": {
@@ -1952,7 +1952,7 @@
         "tags": [
           "Users"
         ],
-        "summary": "Retrieves a user entry for the specified username and organization short name (accessible to all registered users)",
+        "summary": "Retrieves information about a user for the specified username and organization short name (accessible to all registered users)",
         "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves information for a user in the same organization</p>  <p><b>Secretariat:</b> Retrieves any user's information</p>",
         "operationId": "userSingle",
         "parameters": [
@@ -1986,7 +1986,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns user entry details",
+            "description": "Returns user related details",
             "content": {
               "application/json": {
                 "schema": {
@@ -2051,8 +2051,8 @@
         "tags": [
           "Users"
         ],
-        "summary": "Updates a user entry for the specified username and organization shortname (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular User:</b> Updates the user's own user entry. Only name fields may be changed.</p>  <p><b>Admin User:</b> Updates a user entry for users in the Admin's organization. Allowed to change all fields except org_short_name. </p>  <p><b>Secretariat:</b> Updates a user entry in any organization. Allowed to change all fields.</p>",
+        "summary": "Updates information about a user for the specified username and organization shortname (accessible to all registered users)",
+        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular User:</b> Updates the user's own information. Only name fields may be changed.</p>  <p><b>Admin User:</b> Updates information about a user for users in the Admin's organization. Allowed to change all fields except org_short_name. </p>  <p><b>Secretariat:</b> Updates information about a user in any organization. Allowed to change all fields.</p>",
         "operationId": "userUpdateSingle",
         "parameters": [
           {
@@ -2112,7 +2112,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Returns the updated user entry",
+            "description": "Returns the updated user information",
             "content": {
               "application/json": {
                 "schema": {
@@ -2280,8 +2280,8 @@
         "tags": [
           "Users"
         ],
-        "summary": "Retrieves information for all registered users (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p> User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves information of all users from any organization</p>",
+        "summary": "Retrieves information about all registered users (accessible to Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p> User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves information about all users for all organizations</p>",
         "operationId": "userAll",
         "parameters": [
           {
@@ -2324,11 +2324,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "/schemas/errors/generic.json"
-                },
-                "examples": {
-                  "errorGeneric": {
-                    "$ref": "#/components/examples/errorGeneric"
-                  }
                 }
               }
             }
@@ -2609,7 +2604,7 @@
       "cveRecordFilteredTimeModifiedLt": {
         "in": "query",
         "name": "time_modified.lt",
-        "description": "Most recent CVE entry modified timestamp to retrieve",
+        "description": "Most recent CVE record modified timestamp to retrieve",
         "required": false,
         "schema": {
           "type": "string",
@@ -2619,7 +2614,7 @@
       "cveRecordFilteredTimeModifiedGt": {
         "in": "query",
         "name": "time_modified.gt",
-        "description": "Earliest CVE entry modified timestamp to retrieve",
+        "description": "Earliest CVE record modified timestamp to retrieve",
         "required": false,
         "schema": {
           "type": "string",
@@ -2704,7 +2699,7 @@
       "org": {
         "in": "query",
         "name": "org",
-        "description": "The new owning_cna for the CVE ID entry",
+        "description": "The new owning_cna for the CVE ID",
         "required": false,
         "schema": {
           "type": "string"
@@ -2751,7 +2746,7 @@
       "state": {
         "in": "query",
         "name": "state",
-        "description": "The new state for the CVE ID entry",
+        "description": "The new state for the CVE ID",
         "required": false,
         "schema": {
           "type": "string"

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -200,7 +200,7 @@ async function reserveCveId (req, res, next) {
 }
 
 /* Expected behavior by role:
-Secretariat: can retrieve all information for all CVE IDs
+Secretariat: can retrieve full information for all CVE IDs
 Regular, CNA & Admin Users: Retrieve full information for a CVE ID owned by their organization
 Unauthenticated users along with Regular, CNA & Admin users requesting ids not owned by their organization retrieve
   partial information as follows:

--- a/src/controller/cve-id.controller/index.js
+++ b/src/controller/cve-id.controller/index.js
@@ -14,7 +14,7 @@ router.get('/cve-id',
   /*
   #swagger.tags = ['CVE ID']
   #swagger.operationId = 'cveIdGetFiltered'
-  #swagger.summary = "Retrieves CVE ID entries after applying the query parameters as filters (accessible to all registered users)"
+  #swagger.summary = "Retrieves information about CVE IDs after applying the query parameters as filters (accessible to all registered users)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>All registered users can access this endpoint</p>
@@ -34,7 +34,7 @@ router.get('/cve-id',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.responses[200] = {
-    description: 'A filtered list of CVE ID entries owned by the organization, along with pagination fields if results span multiple pages of data',
+    description: 'A filtered list of information about CVE IDs owned by the organization, along with pagination fields if results span multiple pages of data',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/cve-id/list-cve-ids-response.json' }
@@ -187,23 +187,23 @@ router.get('/cve-id/:id',
   /*
   #swagger.tags = ['CVE ID']
   #swagger.operationId = 'cveIdGetSingle'
-  #swagger.summary = "Retrieves a CVE ID entry for the specified id (acessible to all users)"
+  #swagger.summary = "Retrieves information about the specified CVE ID (accessible to all users)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>Endpoint is accessible to all</p>
         <h2>Expected Behavior</h2>
-        <p><b>Regular, CNA & Admin Users: </b>Retrieves full information for a CVE ID owned by their organization; partial information for a CVE ID owned by other organizations</p>
-        <p><b>Unauthenticated Users: Retrieves partial information for a CVE ID</b>
-        <p><b>Secretariat: </b>Retrieves full information for a CVE ID owned by any organization</p>
+        <p><b>Regular, CNA & Admin Users: </b>Retrieves full information about a CVE ID owned by their organization; partial information about a CVE ID owned by other organizations</p>
+        <p><b>Unauthenticated Users: Retrieves partial information about a CVE ID</b>
+        <p><b>Secretariat: </b>Retrieves full information about a CVE ID owned by any organization</p>
         <p><i><b>Note - </b>The owning organization of RESERVED CVE IDs is redacted for all users other than those in the owning organization or Secretariat</i></p>
-  #swagger.parameters['id'] = { description: 'The id of CVE ID entry to retrieve' }
+  #swagger.parameters['id'] = { description: 'The id of the CVE ID information to retrieve' }
   #swagger.parameters['$ref'] = [
     '#/components/parameters/apiEntityHeader',
     '#/components/parameters/apiUserHeader',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.responses[200] = {
-    description: 'The requested CVE ID entry is returned',
+    description: 'The requested CVE ID information is returned',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/cve-id/get-cve-id-response.json' }
@@ -262,14 +262,14 @@ router.put('/cve-id/:id',
   /*
   #swagger.tags = ['CVE ID']
   #swagger.operationId = 'cveIdUpdateSingle'
-  #swagger.summary = "Updates the CVE ID entry for the specified id (accessible to CNAs and Secretariat)"
+  #swagger.summary = "Updates information related to the specified CVE ID (accessible to CNAs and Secretariat)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>
         <h2>Expected Behavior</h2>
-        <p><b>CNA:</b> Updates a CVE ID entry owned by the CNA's organization</p>
-        <p><b>Secretariat:</b> Updates a CVE ID entry owned by any organization</p>"
-  #swagger.parameters['id'] = { description: 'The id of the CVE ID entry to update' }
+        <p><b>CNA:</b> Updates information related to a CVE ID owned by the CNA's organization</p>
+        <p><b>Secretariat:</b> Updates a CVE ID owned by any organization</p>"
+  #swagger.parameters['id'] = { description: 'The id of the CVE ID to update' }
   #swagger.parameters['$ref'] = [
     '#/components/parameters/org`,
     '#/components/parameters/state',
@@ -278,7 +278,7 @@ router.put('/cve-id/:id',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.responses[200] = {
-    description: 'The updated CVE ID entry is returned',
+    description: 'The updated CVE ID information is returned',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/cve-id/update-cve-id-response.json' }
@@ -341,14 +341,14 @@ router.post('/cve-id-range/:year',
   /*
   #swagger.tags = ['CVE ID']
   #swagger.operationId = 'cveIdRangeCreate'
-  #swagger.summary = "Creates a CVE-ID-Range entry for the specified year (accessible to Secretariat)"
+  #swagger.summary = "Creates a CVE-ID-Range for the specified year (accessible to Secretariat)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>User must belong to an organization with the <b>Secretariat</b> role</p>
         <h2>Expected Behavior</h2>
-        <p><b>Secretariat:</b> Creates a CVE-ID-Range entry for the specified year</p>"
+        <p><b>Secretariat:</b> Creates a CVE-ID-Range for the specified year</p>"
   #swagger.parameters['year'] = {
-    description: 'The year of the CVE-ID-Range entry',
+    description: 'The year of the CVE-ID-Range',
     schema: {
       type: 'integer'
     }
@@ -359,7 +359,7 @@ router.post('/cve-id-range/:year',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.responses[200] = {
-    description: 'The CVE-ID-Range entity was created',
+    description: 'The CVE-ID-Range was created',
   }
   #swagger.responses[400] = {
     description: 'Bad Request',

--- a/src/controller/cve-id.controller/index.js
+++ b/src/controller/cve-id.controller/index.js
@@ -104,7 +104,7 @@ router.post('/cve-id',
   <h2>Access Control</h2>
         <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>
         <h2>Expected Behavior</h2>
-        <p><b>CNA:</b> Reserves CVE IDs for the CNA's organization</p>
+        <p><b>CNA:</b> Reserves CVE IDs for the CNA</p>
         <p><b>Secretariat:</b> Reserves CVE IDs for any organization</p>"
   #swagger.parameters['$ref'] = [
     '#/components/parameters/amount',
@@ -267,7 +267,7 @@ router.put('/cve-id/:id',
         <h2>Access Control</h2>
         <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>
         <h2>Expected Behavior</h2>
-        <p><b>CNA:</b> Updates information related to a CVE ID owned by the CNA's organization</p>
+        <p><b>CNA:</b> Updates information related to a CVE ID owned by the CNA</p>
         <p><b>Secretariat:</b> Updates a CVE ID owned by any organization</p>"
   #swagger.parameters['id'] = { description: 'The id of the CVE ID to update' }
   #swagger.parameters['$ref'] = [

--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -447,7 +447,7 @@ async function rejectCVE (req, res, next) {
     if (!result) {
       return res.status(500).json(error.serverError())
     }
-    // Update state of CVE ID entry
+    // Update state of CVE ID
     result = await cveIdRepo.updateByCveId(id, { state: CONSTANTS.CVE_STATES.REJECTED })
     if (!result) {
       return res.status(500).json(error.serverError())

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -85,7 +85,7 @@ router.get('/cve',
         <h2>Access Control</h2>
         <p>User must belong to an organization with the <b>Secretariat</b> role</p>
         <h2>Expected Behavior</h2>
-        <p><b>Secretariat:</b> Retrieves all CVE entries for all organizations</p>"
+        <p><b>Secretariat:</b> Retrieves all CVE records for all organizations</p>"
   #swagger.parameters['$ref'] = [
     '#/components/parameters/cveRecordFilteredTimeModifiedLt',
     '#/components/parameters/cveRecordFilteredTimeModifiedGt',

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -11,12 +11,12 @@ router.get('/org',
   /*
   #swagger.tags = ['Organization']
   #swagger.operationId = 'orgAll'
-  #swagger.summary = "Retrieves all organization entries (accessible to Secretariat)"
+  #swagger.summary = "Retrieves all organizations (accessible to Secretariat)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>User must belong to an organization with the <b>Secretariat</b> role</p>
         <h2>Expected Behavior</h2>
-        <p><b>Secretariat:</b> Retrieves all organization entries</p>"
+        <p><b>Secretariat:</b> Retrieves information about all organizations</p>"
   #swagger.parameters['$ref'] = [
     '#/components/parameters/pageQuery',
     '#/components/parameters/apiEntityHeader',
@@ -24,7 +24,7 @@ router.get('/org',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.responses[200] = {
-    description: 'Returns all organization entries, along with pagination fields if results span multiple pages of data',
+    description: 'Returns information about all organizations, along with pagination fields if results span multiple pages of data',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/org/list-orgs-response.json' }
@@ -83,12 +83,12 @@ router.post('/org',
   /*
   #swagger.tags = ['Organization']
   #swagger.operationId = 'orgCreateSingle'
-  #swagger.summary = "Creates an organization entry as specified in the request body (accessible to Secretariat)"
+  #swagger.summary = "Creates an organization as specified in the request body (accessible to Secretariat)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>User must belong to an organization with the <b>Secretariat</b> role</p>
         <h2>Expected Behavior</h2>
-        <p><b>Secretariat:</b> Creates an organization entry</p>
+        <p><b>Secretariat:</b> Creates an organization</p>
   "
   #swagger.parameters['$ref'] = [
     '#/components/parameters/apiEntityHeader',
@@ -104,7 +104,7 @@ router.post('/org',
     }
   }
   #swagger.responses[200] = {
-    description: 'Returns the organization entry created',
+    description: 'Returns information about the organization created',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/org/create-org-response.json' }
@@ -167,13 +167,13 @@ router.get('/org/:identifier',
   /*
   #swagger.tags = ['Organization']
   #swagger.operationId = 'orgSingle'
-  #swagger.summary = "Retrieves the organization entry for the specified short name or UUID (accessible to all registered users)"
+  #swagger.summary = "Retrieves information about the organization specified by short name or UUID (accessible to all registered users)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>All registered users can access this endpoint</p>
         <h2>Expected Behavior</h2>
         <p><b>Regular, CNA & Admin Users:</b> Retrieves organization record for the specified shortname or UUID if it is the user's organization</p>
-        <p><b>Secretariat:</b> Retrieves any organization entry</p>"
+        <p><b>Secretariat:</b> Retrieves information for any organization</p>"
   #swagger.parameters['identifier'] = { description: 'The shortname or UUID of the organization' }
   #swagger.parameters['$ref'] = [
     '#/components/parameters/apiEntityHeader',
@@ -181,7 +181,7 @@ router.get('/org/:identifier',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.responses[200] = {
-    description: 'Returns the organization entry',
+    description: 'Returns the organization information',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/org/get-org-response.json' }
@@ -238,7 +238,7 @@ router.put('/org/:shortname',
   /*
   #swagger.tags = ['Organization']
   #swagger.operationId = 'orgUpdateSingle'
-  #swagger.summary = "Updates an organization entry for the specified organization short name (accessible to Secretariat)"
+  #swagger.summary = "Updates information about the organization specified by short name (accessible to Secretariat)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>User must belong to an organization with the <b>Secretariat</b> role</p>
@@ -256,7 +256,7 @@ router.put('/org/:shortname',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.responses[200] = {
-    description: 'Returns the organization entry updated',
+    description: 'Returns information about the organization updated',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/org/update-org-response.json' }
@@ -322,13 +322,13 @@ router.get('/org/:shortname/id_quota',
   /*
   #swagger.tags = ['Organization']
   #swagger.operationId = 'orgIdQuota'
-  #swagger.summary = "Retrieves an organization's CVE ID quota information (accessible to all registered users)"
+  #swagger.summary = "Retrieves an organization's CVE ID quota (accessible to all registered users)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>All registered users can access this endpoint</p>
         <h2>Expected Behavior</h2>
-        <p><b>Regular, CNA & Admin Users:</b> Retrieves CVE ID quota information for user's organization</p>
-        <p><b>Secretariat:</b> Retrieves CVE ID quota information of any organization</p>"
+        <p><b>Regular, CNA & Admin Users:</b> Retrieves the CVE ID quota for the user's organization</p>
+        <p><b>Secretariat:</b> Retrieves the CVE ID quota for any organization</p>"
   #swagger.parameters['shortname'] = { description: 'The shortname of the organization' }
   #swagger.parameters['$ref'] = [
     '#/components/parameters/apiEntityHeader',
@@ -336,7 +336,7 @@ router.get('/org/:shortname/id_quota',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.responses[200] = {
-    description: 'Returns CVE ID quota details of an organization',
+    description: 'Returns the CVE ID quota details of an organization',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/org/get-org-quota-response.json' }
@@ -398,8 +398,8 @@ router.get('/org/:shortname/users',
         <h2>Access Control</h2>
         <p>All registered users can access this endpoint</p>
         <h2>Expected Behavior</h2>
-        <p><b>Regular, CNA & Admin Users:</b> Retrieves information for users in the same organization</p>
-        <p><b>Secretariat:</b> Retrieves all user information from any organization</p>"
+        <p><b>Regular, CNA & Admin Users:</b> Retrieves information about users in the same organization</p>
+        <p><b>Secretariat:</b> Retrieves all user information for any organization</p>"
   #swagger.parameters['shortname'] = { description: 'The shortname of the organization' }
   #swagger.parameters['$ref'] = [
     '#/components/parameters/pageQuery',
@@ -466,13 +466,13 @@ router.post('/org/:shortname/user',
   /*
   #swagger.tags = ['Users']
   #swagger.operationId = 'userCreateSingle'
-  #swagger.summary = "Create a user entry with the provided short name as the owning organization (accessible to Admins and Secretariats)"
+  #swagger.summary = "Create a user with the provided short name as the owning organization (accessible to Admins and Secretariats)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>
         <h2>Expected Behavior</h2>
-        <p><b>Admin User:</b> Creates a user entry for the Admin's organization</p>
-        <p><b>Secretariat:</b> Creates a user entry for any organization</p>"
+        <p><b>Admin User:</b> Creates a user for the Admin's organization</p>
+        <p><b>Secretariat:</b> Creates a user for any organization</p>"
   #swagger.parameters['shortname'] = { description: 'The shortname of the organization' }
   #swagger.parameters['$ref'] = [
     '#/components/parameters/apiEntityHeader',
@@ -488,7 +488,7 @@ router.post('/org/:shortname/user',
     }
   }
   #swagger.responses[200] = {
-    description: 'Returns the created user entry (with the secret)',
+    description: 'Returns the user created (with the secret)',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/user/create-user-response.json' },
@@ -555,7 +555,7 @@ router.get('/org/:shortname/user/:username',
   /*
   #swagger.tags = ['Users']
   #swagger.operationId = 'userSingle'
-  #swagger.summary = "Retrieves a user entry for the specified username and organization short name (accessible to all registered users)"
+  #swagger.summary = "Retrieves information about a user for the specified username and organization short name (accessible to all registered users)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>All registered users can access this endpoint</p>
@@ -570,7 +570,7 @@ router.get('/org/:shortname/user/:username',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.responses[200] = {
-    description: 'Returns user entry details',
+    description: 'Returns user related details',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/user/get-user-response.json' }
@@ -628,14 +628,14 @@ router.put('/org/:shortname/user/:username',
   /*
   #swagger.tags = ['Users']
    #swagger.operationId = 'userUpdateSingle'
-  #swagger.summary = "Updates a user entry for the specified username and organization shortname (accessible to all registered users)"
+  #swagger.summary = "Updates information about a user for the specified username and organization shortname (accessible to all registered users)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>All registered users can access this endpoint</p>
         <h2>Expected Behavior</h2>
-        <p><b>Regular User:</b> Updates the user's own user entry. Only name fields may be changed.</p>
-        <p><b>Admin User:</b> Updates a user entry for users in the Admin's organization. Allowed to change all fields except org_short_name. </p>
-        <p><b>Secretariat:</b> Updates a user entry in any organization. Allowed to change all fields.</p>"
+        <p><b>Regular User:</b> Updates the user's own information. Only name fields may be changed.</p>
+        <p><b>Admin User:</b> Updates information about a user for users in the Admin's organization. Allowed to change all fields except org_short_name. </p>
+        <p><b>Secretariat:</b> Updates information about a user in any organization. Allowed to change all fields.</p>"
   #swagger.parameters['shortname'] = { description: 'The shortname of the organization' }
   #swagger.parameters['username'] = { description: 'The username of the user' }
   #swagger.parameters['$ref'] = [
@@ -653,7 +653,7 @@ router.put('/org/:shortname/user/:username',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.responses[200] = {
-    description: 'Returns the updated user entry',
+    description: 'Returns the updated user information',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/user/update-user-response.json' }

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -173,7 +173,7 @@ router.get('/org/:identifier',
         <p>All registered users can access this endpoint</p>
         <h2>Expected Behavior</h2>
         <p><b>Regular, CNA & Admin Users:</b> Retrieves organization record for the specified shortname or UUID if it is the user's organization</p>
-        <p><b>Secretariat:</b> Retrieves information for any organization</p>"
+        <p><b>Secretariat:</b> Retrieves information about any organization</p>"
   #swagger.parameters['identifier'] = { description: 'The shortname or UUID of the organization' }
   #swagger.parameters['$ref'] = [
     '#/components/parameters/apiEntityHeader',
@@ -560,7 +560,7 @@ router.get('/org/:shortname/user/:username',
         <h2>Access Control</h2>
         <p>All registered users can access this endpoint</p>
         <h2>Expected Behavior</h2>
-        <p><b>Regular, CNA & Admin Users:</b> Retrieves information for a user in the same organization</p>
+        <p><b>Regular, CNA & Admin Users:</b> Retrieves information about a user in the same organization</p>
         <p><b>Secretariat:</b> Retrieves any user's information</p>"
   #swagger.parameters['shortname'] = { description: 'The shortname of the organization' }
   #swagger.parameters['username'] = { description: 'The username of the user' }
@@ -570,7 +570,7 @@ router.get('/org/:shortname/user/:username',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.responses[200] = {
-    description: 'Returns user related details',
+    description: 'Returns information about the specified user',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/user/get-user-response.json' }

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -336,7 +336,7 @@ router.get('/org/:shortname/id_quota',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.responses[200] = {
-    description: 'Returns the CVE ID quota details of an organization',
+    description: 'Returns the CVE ID quota for an organization',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/org/get-org-quota-response.json' }
@@ -408,7 +408,7 @@ router.get('/org/:shortname/users',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.responses[200] = {
-    description: 'Returns all user entries for the organization, along with pagination fields if results span multiple pages of data',
+    description: 'Returns all users for the organization, along with pagination fields if results span multiple pages of data',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/user/list-users-response.json' }
@@ -488,7 +488,7 @@ router.post('/org/:shortname/user',
     }
   }
   #swagger.responses[200] = {
-    description: 'Returns the user created (with the secret)',
+    description: 'Returns the new user information (with the secret)',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/user/create-user-response.json' },
@@ -634,7 +634,7 @@ router.put('/org/:shortname/user/:username',
         <p>All registered users can access this endpoint</p>
         <h2>Expected Behavior</h2>
         <p><b>Regular User:</b> Updates the user's own information. Only name fields may be changed.</p>
-        <p><b>Admin User:</b> Updates information about a user for users in the Admin's organization. Allowed to change all fields except org_short_name. </p>
+        <p><b>Admin User:</b> Updates information about a user in the Admin's organization. Allowed to change all fields except org_short_name. </p>
         <p><b>Secretariat:</b> Updates information about a user in any organization. Allowed to change all fields.</p>"
   #swagger.parameters['shortname'] = { description: 'The shortname of the organization' }
   #swagger.parameters['username'] = { description: 'The username of the user' }

--- a/src/controller/user.controller/index.js
+++ b/src/controller/user.controller/index.js
@@ -10,12 +10,12 @@ router.get('/users',
   /*
   #swagger.tags = ['Users']
   #swagger.operationId = 'userAll'
-  #swagger.summary = "Retrieves information for all registered users (accessible to Secretariat)"
+  #swagger.summary = "Retrieves information about all registered users (accessible to Secretariat)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p> User must belong to an organization with the <b>Secretariat</b> role</p>
         <h2>Expected Behavior</h2>
-        <p><b>Secretariat:</b> Retrieves information of all users from any organization</p>"
+        <p><b>Secretariat:</b> Retrieves information about all users for all organizations</p>"
   #swagger.parameters['$ref'] = [
     '#/components/parameters/pageQuery',
     '#/components/parameters/apiEntityHeader',
@@ -43,7 +43,6 @@ router.get('/users',
     content: {
       "application/json": {
         schema: { $ref: '/schemas/errors/generic.json' },
-        examples:{ errorGeneric: { $ref: '#/components/examples/errorGeneric' }}
       }
     }
   }

--- a/src/controller/user.controller/user.controller.js
+++ b/src/controller/user.controller/user.controller.js
@@ -26,7 +26,7 @@ async function getAllUsers (req, res, next) {
       payload.nextPage = pg.nextPage
     }
 
-    logger.info({ uuid: req.ctx.uuid, message: 'The users information was sent to the secretariat user.' })
+    logger.info({ uuid: req.ctx.uuid, message: 'The user information was sent to the secretariat user.' })
     return res.status(200).json(payload)
   } catch (err) {
     next(err)

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -275,7 +275,7 @@ const doc = {
       cveRecordFilteredTimeModifiedLt: {
         in: 'query',
         name: 'time_modified.lt',
-        description: 'Most recent CVE entry modified timestamp to retrieve',
+        description: 'Most recent CVE record modified timestamp to retrieve',
         required: false,
         schema: {
           type: 'string',
@@ -285,7 +285,7 @@ const doc = {
       cveRecordFilteredTimeModifiedGt: {
         in: 'query',
         name: 'time_modified.gt',
-        description: 'Earliest CVE entry modified timestamp to retrieve',
+        description: 'Earliest CVE record modified timestamp to retrieve',
         required: false,
         schema: {
           type: 'string',
@@ -370,7 +370,7 @@ const doc = {
       org: {
         in: 'query',
         name: 'org',
-        description: 'The new owning_cna for the CVE ID entry',
+        description: 'The new owning_cna for the CVE ID',
         required: false,
         schema: {
           type: 'string'
@@ -417,7 +417,7 @@ const doc = {
       state: {
         in: 'query',
         name: 'state',
-        description: 'The new state for the CVE ID entry',
+        description: 'The new state for the CVE ID',
         required: false,
         schema: {
           type: 'string'


### PR DESCRIPTION
Remove phrase 'CVE ID entry' from docs, plus other wording updates to make wording more consistent
