### PR TITLE
Resolves #931 Fixes CVE v5 schema submission bug related to 'product' field

### DIFF
--- a/src/controller/cve.controller/cna_container_schema.json
+++ b/src/controller/cve.controller/cna_container_schema.json
@@ -143,7 +143,7 @@
             "description": "Provides information about the set of products and services affected by this vulnerability.",
             "allOf": [
                 {
-                    "oneOf": [
+                    "anyOf": [
                         {
                             "required": [
                                 "vendor",


### PR DESCRIPTION
Close #931. 

In `cna_container_schema.json` under "product",  `oneOf` was used instead of `anyOf`, causing a validation error when more than one valid type was was in a cnaContainer submission. Changing to `anyOf` resolved this. 