### PR TITLE
Resolves #894 Cve database updates must succeed before Cve-Id database updates

### DIFF
--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -165,8 +165,8 @@ async function submitCve (req, res, next) {
       return res.status(400).json(error.cveRecordExists())
     }
 
-    await cveIdRepo.updateByCveId(cveId, { state: state })
     await cveRepo.updateByCveId(cveId, newCve, { upsert: true })
+    await cveIdRepo.updateByCveId(cveId, { state: state })
 
     const responseMessage = {
       message: cveId + ' record was successfully created.',
@@ -382,6 +382,7 @@ async function updateCna (req, res, next) {
       return res.status(500).json(error.serverError())
     }
 
+    await cveRepo.updateByCveId(id, cveModel)
     // change cve id state to publish
     if (cveId.state === CONSTANTS.CVE_STATES.REJECTED) {
       result = await cveIdRepo.updateByCveId(id, { state: CONSTANTS.CVE_STATES.PUBLISHED })
@@ -389,7 +390,6 @@ async function updateCna (req, res, next) {
         return res.status(500).json(error.serverError())
       }
     }
-    await cveRepo.updateByCveId(id, cveModel)
 
     const responseMessage = {
       message: id + ' record was successfully updated.',
@@ -447,14 +447,15 @@ async function rejectCVE (req, res, next) {
     if (!result) {
       return res.status(500).json(error.serverError())
     }
-    // Update state of CVE ID
-    result = await cveIdRepo.updateByCveId(id, { state: CONSTANTS.CVE_STATES.REJECTED })
+
+    // Save rejected CVE record object
+    result = await cveRepo.updateByCveId(id, newCveObj, { upsert: true })
     if (!result) {
       return res.status(500).json(error.serverError())
     }
 
-    // Save rejected CVE record object
-    result = await cveRepo.updateByCveId(id, newCveObj, { upsert: true })
+    // Update state of CVE ID
+    result = await cveIdRepo.updateByCveId(id, { state: CONSTANTS.CVE_STATES.REJECTED })
     if (!result) {
       return res.status(500).json(error.serverError())
     }


### PR DESCRIPTION
Closes #894

## Summary
Changed the order of database calls when creating or updating Cve records, so updating the Cve collection must succeed before updating the Cve-id collection. This prevents Cve records from being out of sync with their corresponding Cve-id.


## Important Changes
`cve.controller.js`
- Swapped the database update order in `submitCve()`, `updateCna()`, and `rejectCve()`

