### PR TITLE
Resolves #881 Invalid Cve Schemas Posts and Puts now return a 400 status code and corresponding errors

### DIFF
--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -317,8 +317,9 @@ async function submitCna (req, res, next) {
 
     result = Cve.validateCveRecord(cveModel.cve)
 
-    if (!result) {
-      return res.status(500).json(error.serverError())
+    if (!result.isValid) {
+      logger.error(JSON.stringify({ uuid: req.ctx.uuid, message: 'CVE JSON schema validation FAILED.' }))
+      return res.status(400).json(error.invalidCnaContainerJsonSchema(result.errors))
     }
 
     try {
@@ -403,8 +404,10 @@ async function updateCna (req, res, next) {
     cveRecord.containers.cna = cnaContainer
     const cveModel = new Cve({ cve: cveRecord })
     result = Cve.validateCveRecord(cveModel.cve)
-    if (!result) {
-      return res.status(500).json(error.serverError())
+
+    if (!result.isValid) {
+      logger.error(JSON.stringify({ uuid: req.ctx.uuid, message: 'CVE JSON schema validation FAILED.' }))
+      return res.status(400).json(error.invalidCnaContainerJsonSchema(result.errors))
     }
 
     await cveRepo.updateByCveId(id, cveModel)

--- a/src/model/cve.js
+++ b/src/model/cve.js
@@ -30,11 +30,13 @@ CveSchema.index({ 'cve.cveMetadata.cveId': 1 })
 CveSchema.index({ 'cve.cveMetadata.dateUpdated': 1 })
 
 CveSchema.statics.validateCveRecord = function (record) {
-  const result = validate(record)
-  if (result) {
-    return true
+  const validateObject = {}
+  validateObject.isValid = validate(record)
+
+  if (!validateObject.isValid) {
+    validateObject.errors = validate.errors
   }
-  return false
+  return validateObject
 }
 
 function createBaseCveMetadata (id, assignerOrgId, state) {

--- a/test/unit-tests/cve/cveCnaContainerCreateTest.js
+++ b/test/unit-tests/cve/cveCnaContainerCreateTest.js
@@ -196,7 +196,7 @@ describe('Testing the POST /cve/:id/cna endpoint in Cve Controller', () => {
         })
     })
 
-    it('should return 500 when cve record is not valid', (done) => {
+    it('should return 400 when cve record is not valid', (done) => {
       chai.request(app)
         .post(`/cve-cna-negative-tests/${cveIdReserved}`)
         .set(cveFixtures.secretariatHeader)
@@ -206,9 +206,9 @@ describe('Testing the POST /cve/:id/cna endpoint in Cve Controller', () => {
             done(err)
           }
 
-          expect(res).to.have.status(500)
+          expect(res).to.have.status(400)
           expect(res).to.have.property('body').and.to.be.a('object')
-          const errObj = error.serverError()
+          const errObj = error.invalidCnaContainerJsonSchema()
           expect(res.body.error).to.equal(errObj.error)
           expect(res.body.message).to.equal(errObj.message)
           done()

--- a/test/unit-tests/cve/cveCnaContainerUpdateTest.js
+++ b/test/unit-tests/cve/cveCnaContainerUpdateTest.js
@@ -208,7 +208,7 @@ describe('Testing the PUT /cve/:id/cna endpoint in Cve Controller', () => {
         })
     })
 
-    it('should return 500 when cve record is not valid', (done) => {
+    it('should return 400 when cve record is not valid', (done) => {
       chai.request(app)
         .put(`/cve-cna-negative-tests/${cveIdPublished5}`)
         .set(cveFixtures.secretariatHeader)
@@ -218,9 +218,9 @@ describe('Testing the PUT /cve/:id/cna endpoint in Cve Controller', () => {
             done(err)
           }
 
-          expect(res).to.have.status(500)
+          expect(res).to.have.status(400)
           expect(res).to.have.property('body').and.to.be.a('object')
-          const errObj = error.serverError()
+          const errObj = error.invalidCnaContainerJsonSchema()
           expect(res.body.error).to.equal(errObj.error)
           expect(res.body.message).to.equal(errObj.message)
           done()


### PR DESCRIPTION
Closes #881

# Summary
Invalid language codes in POST/PUT` /api/cve/:id/cna` would cause a 500 error. This was because the language code didn't validate against the Cve schema, causing an invalid schema error that threw a 500. This was changed to throw a 400 error and return corresponding schema validation errors.


# Important Changes
`cve.js`
- Updated `validateCveRecord()` to return an object with corresponding schema validation errors

`cve.controller.js`
- Updated `submitCna()` and `updateCna()` to throw 400 errors instead of 500 errors when the Cve schema is invalid.

# Testing
Sample JSON for testing

{"cnaContainer" : {
"descriptions" : [ { "lang" : "eng", "value" : "One more CVE Services test CVE Record post." } ],
"affected" : [ { "versions" : [ { "version" : "1.1.0", "status" : "affected" } ],
"product" : "CVE Services product number two", "vendor" : "MITRE" } ],
"references" : [ { "url" : "http://mitre.org" } ],
"providerMetadata" : { "orgId" : "466e066c-d384-4b8a-8b15-067d9c22c5af",
"shortName" : "mitre",
"dateUpdated" : "2022-04-28T21:30:13.057Z"
}
}}
