### PR TITLE
#961 Bump CVE Services version number, plus doc update

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.2",
   "info": {
-    "version": "2.1.0",
+    "version": "2.1.1",
     "title": "CVE Services API",
     "description": "The CVE Services API supports automation tooling for the CVE Program. Credentials are     required for most service endpoints. Representatives of     <a href='https://www.cve.org/ProgramOrganization/CNAs'>CVE Numbering Authorities (CNAs)</a> should     use one of the methods below to obtain credentials:    <ul><li>If your organization already has an Organizational Administrator (OA) account for the CVE     Services, ask your admin for credentials</li>     <li>Contact your Root (<a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/Google'>Google</a>,     <a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/INCIBE'>INCIBE</a>,     <a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/jpcert'>JPCERT/CC</a>, or     <a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/redhat'>Red Hat</a>) or     Top-Level Root (<a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/icscert'>CISA ICS</a>     or <a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/mitre'>MITRE</a>) to request credentials     </ul>     <p>CVE data is to be in the JSON 5.0 CVE Record format. Details of the JSON 5.0 schema are     located <a href='https://github.com/CVEProject/cve-schema/tree/master/schema/v5.0' target='_blank'>here</a>.</p>    <a href='https://cveform.mitre.org/' class='link' target='_blank'>Contact the CVE Services team</a>",
     "contact": {
@@ -2564,7 +2564,7 @@
       "cveIdGetFilteredTimeReservedLt": {
         "in": "query",
         "name": "time_reserved.lt",
-        "description": "Most recent CVE ID reserved timestamp to retrieve",
+        "description": "Most recent reserved timestamp to retrieve. Include with all requests potentially returning multiple pages of CVE IDs to avoid issues if new IDs are reserved during use.",
         "required": false,
         "schema": {
           "type": "string",
@@ -2584,7 +2584,7 @@
       "cveIdGetFilteredTimeModifiedLt": {
         "in": "query",
         "name": "time_modified.lt",
-        "description": "Most recent CVE ID modified timestamp to retrieve",
+        "description": "Most recent modified timestamp to retrieve. Include with all requests using a time_modified.gt filter potentially returning multiple pages of CVE IDs. This will avoid issues if IDs are reserved or modified during use.",
         "required": false,
         "schema": {
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "cve-services",
     "author": "Automation Working Group",
-    "version": "0.0.3",
+    "version": "2.1.1",
     "license": "(CC0)",
     "devDependencies": {
         "apidoc": "^0.53.1",

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -14,7 +14,7 @@ const rejectedCreateCVERecord = require('../schemas/cve/rejected-create-cve-exam
 /* eslint-disable no-multi-str */
 const doc = {
   info: {
-    version: '2.1.0',
+    version: '2.1.1',
     title: 'CVE Services API',
     description: "The CVE Services API supports automation tooling for the CVE Program. Credentials are \
     required for most service endpoints. Representatives of \
@@ -235,7 +235,7 @@ const doc = {
       cveIdGetFilteredTimeReservedLt: {
         in: 'query',
         name: 'time_reserved.lt',
-        description: 'Most recent CVE ID reserved timestamp to retrieve',
+        description: 'Most recent reserved timestamp to retrieve. Include with all requests potentially returning multiple pages of CVE IDs to avoid issues if new IDs are reserved during use.',
         required: false,
         schema: {
           type: 'string',
@@ -255,7 +255,7 @@ const doc = {
       cveIdGetFilteredTimeModifiedLt: {
         in: 'query',
         name: 'time_modified.lt',
-        description: 'Most recent CVE ID modified timestamp to retrieve',
+        description: 'Most recent modified timestamp to retrieve. Include with all requests using a time_modified.gt filter potentially returning multiple pages of CVE IDs. This will avoid issues if IDs are reserved or modified during use.',
         required: false,
         schema: {
           type: 'string',


### PR DESCRIPTION
Improve wording of time_reserved.lt and time_modified.lt for GET /cve-id endpoint. Bumps CVE Services version number to 2.1.1
