### PR TITLE
#959 fixes HTML error in Swagger docs

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -228,7 +228,7 @@
           "CVE ID"
         ],
         "summary": "Retrieves information about the specified CVE ID (accessible to all users)",
-        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users: </b>Retrieves full information about a CVE ID owned by their organization; partial information about a CVE ID owned by other organizations</p>  <p><b>Unauthenticated Users: Retrieves partial information about a CVE ID</b>  <p><b>Secretariat: </b>Retrieves full information about a CVE ID owned by any organization</p>  <p><i><b>Note - </b>The owning organization of RESERVED CVE IDs is redacted for all users other than those in the owning organization or Secretariat</i></p>",
+        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users: </b>Retrieves full information about a CVE ID owned by their organization; partial information about a CVE ID owned by other organizations</p>  <p><b>Unauthenticated Users: </b>Retrieves partial information about a CVE ID  <p><b>Secretariat: </b>Retrieves full information about a CVE ID owned by any organization</p>  <p><i><b>Note - </b>The owning organization of RESERVED CVE IDs is redacted for all users other than those in the owning organization or Secretariat</i></p>",
         "operationId": "cveIdGetSingle",
         "parameters": [
           {

--- a/src/controller/cve-id.controller/index.js
+++ b/src/controller/cve-id.controller/index.js
@@ -195,7 +195,7 @@ router.get('/cve-id/:id',
         <p>Endpoint is accessible to all</p>
         <h2>Expected Behavior</h2>
         <p><b>Regular, CNA & Admin Users: </b>Retrieves full information about a CVE ID owned by their organization; partial information about a CVE ID owned by other organizations</p>
-        <p><b>Unauthenticated Users: Retrieves partial information about a CVE ID</b>
+        <p><b>Unauthenticated Users: </b>Retrieves partial information about a CVE ID
         <p><b>Secretariat: </b>Retrieves full information about a CVE ID owned by any organization</p>
         <p><i><b>Note - </b>The owning organization of RESERVED CVE IDs is redacted for all users other than those in the owning organization or Secretariat</i></p>
   #swagger.parameters['id'] = { description: 'The id of the CVE ID information to retrieve' }


### PR DESCRIPTION
Adjust </b> tag for GET /cve-id/:id in Swagger docs
