### PR TITLE
#965 fix typo in error message about timestamp format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "cve-services",
-    "version": "0.0.3",
+    "version": "2.1.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "cve-services",
-            "version": "0.0.3",
+            "version": "2.1.1",
             "license": "(CC0)",
             "dependencies": {
                 "ajv": "^8.6.2",

--- a/src/middleware/errorMessages.js
+++ b/src/middleware/errorMessages.js
@@ -2,5 +2,5 @@
 
 module.exports = {
   ID_QUOTA: 'The id_quota does not comply with CVE id quota limitations',
-  TIMESTAMP_FORMAT: 'Bad date, or invalid timestamp format: valid format is yyyy-MM-ddTHH:mm:ss or yyyy-MM-ddTHH:mm:ss.ZZZZ'
+  TIMESTAMP_FORMAT: 'Bad date, or invalid timestamp format: valid format is yyyy-MM-ddTHH:mm:ss or yyyy-MM-ddTHH:mm:ssZZZZ'
 }


### PR DESCRIPTION
Also updates package-lock.json with new CVE Services version number
