### PR TITLE
Output JSON for 429 errors

### DIFF
--- a/src/controller/cve-id.controller/index.js
+++ b/src/controller/cve-id.controller/index.js
@@ -244,6 +244,14 @@ router.get('/cve-id/:id',
       }
     }
   }
+  #swagger.responses[429] = {
+    description: 'Too Many Requests',
+    content: {
+      "application/json": {
+        schema: { $ref: '/schemas/errors/generic.json' }
+      }
+    }
+  }
   #swagger.responses[500] = {
     description: 'Internal Server Error',
     content: {

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -63,6 +63,14 @@ router.get('/cve/:id',
       }
     }
   }
+  #swagger.responses[429] = {
+    description: 'Too Many Requests',
+    content: {
+      "application/json": {
+        schema: { $ref: '/schemas/errors/generic.json' }
+      }
+    }
+  }
   #swagger.responses[500] = {
     description: 'Internal Server Error',
     content: {

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -327,14 +327,15 @@ function errorHandler (err, req, res, next) {
 }
 
 const limiter = rateLimit({
-  // over 1 minutes, allow a max of 1000 requests
+  // over 1 second, allow a max of 1000 requests
   // can configure by setting env vars
   windowMs: 1000 * parseInt((process.env.RATE_LIMIT_WINDOW_SECONDS || 1)),
   max: parseInt(process.env.RATE_LIMIT_MAX_CONNECTIONS || 1000),
   // apply to all requests this middleware is used, so always return the same key
   keyGenerator: (req, res) => '*',
   standardHeaders: true,
-  legacyHeaders: false
+  legacyHeaders: false,
+  message: error.tooManyRequests()
 })
 
 module.exports = {

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -96,6 +96,13 @@ class IDRError {
 
     return err
   }
+
+  tooManyRequests () {
+    return {
+      error: 'TOO_MANY_REQUESTS',
+      message: 'Too many requests. Please try again later.'
+    }
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
429 errors caused by rate limiting in code will return JSON output with `TOO_MANY_REQUESTS` as the error.

Also added 429 error documentation to the Swagger API docs.