### PR TITLE
Resolves #980 Fixed validation calls for rejecting new and existing CVEs

### DIFF
--- a/datadump/pre-population/cve-ids-range.json
+++ b/datadump/pre-population/cve-ids-range.json
@@ -358,6 +358,21 @@
               "end": 50000000
           }
       }
-    }
+    },
+    {
+        "cve_year": 2023,
+        "ranges": {
+            "priority": {
+                "top_id": 0,
+                "start": 0,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
+      }
   ]
   

--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -475,8 +475,9 @@ async function rejectCVE (req, res, next) {
     const newCveObj = new Cve({ cve: rejectedCve })
 
     result = Cve.validateCveRecord(newCveObj.cve)
-    if (!result) {
-      return res.status(500).json(error.serverError())
+    if (!result.isValid) {
+      logger.error(JSON.stringify({ uuid: req.ctx.uuid, message: 'CVE JSON schema validation FAILED.' }))
+      return res.status(400).json(error.invalidCnaContainerJsonSchema(result.errors))
     }
 
     // Save rejected CVE record object
@@ -540,9 +541,10 @@ async function rejectExistingCve (req, res, next) {
     // update CVE record to rejected
     const updatedRecord = Cve.updateCveToRejected(id, providerMetadata, result.cve, req.ctx.body)
     const updatedCve = new Cve({ cve: updatedRecord })
-    result = Cve.validateCveRecord(updatedCve)
-    if (!result) {
-      return res.status(500).json(error.serverError())
+    result = Cve.validateCveRecord(updatedCve.cve)
+    if (!result.isValid) {
+      logger.error(JSON.stringify({ uuid: req.ctx.uuid, message: 'CVE JSON schema validation FAILED.' }))
+      return res.status(400).json(error.invalidCnaContainerJsonSchema(result.errors))
     }
     result = await cveRepo.updateByCveId(id, updatedCve)
     if (!result) {


### PR DESCRIPTION
Closes Issue #980

## Summary
`RejectCVE()` and `rejectExistingCve()` were calling `validateCveRecord()` incorrectly. Updated this function call to correctly validate rejected CVE objects.

### Important Changes
`cve.controller.js`
- updated `rejectCVE()` and `rejectedExistingCve()` to be called on the correct object.
- Added better error logging for failed validation

