### PR TITLE
Resolves #804 provide useful error message for bad timestamps that include whites…

### DIFF
--- a/datadump/pre-population/cve-ids-range.json
+++ b/datadump/pre-population/cve-ids-range.json
@@ -358,6 +358,21 @@
               "end": 50000000
           }
       }
-    }
+    },
+    {
+        "cve_year": 2023,
+        "ranges": {
+            "priority": {
+                "top_id": 0,
+                "start": 0,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
+      }
   ]
   

--- a/src/middleware/errorMessages.js
+++ b/src/middleware/errorMessages.js
@@ -2,5 +2,5 @@
 
 module.exports = {
   ID_QUOTA: 'The id_quota does not comply with CVE id quota limitations',
-  TIMESTAMP_FORMAT: 'Bad date, or invalid timestamp format: valid format is yyyy-MM-ddTHH:mm:ss or yyyy-MM-ddTHH:mm:ssZZZZ'
+  TIMESTAMP_FORMAT: "Bad date, or invalid timestamp format: valid format is yyyy-MM-ddTHH:mm:ss or yyyy-MM-ddTHH:mm:ssZZZZ (to use '+' in timezone offset, encode as '%2B)"
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -117,10 +117,9 @@ function booleanIsTrue (val) {
 // Sanitizer for dates
 function toDate (val) {
   val = val.toUpperCase()
-  let value = val.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(|Z|((-|\+|\s)\d{2}:\d{2}))$/)
+  let value = val.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(|Z|((-|\+)\d{2}:\d{2}))$/)
   let result = null
   if (value) {
-    value[0] = value[0].replace(' ', '+') // Re-add literal '+' which was stripped
     const dateStr = value[0]
     // Make sure that the string passed is a valid date
     // eslint doesn't like that responseType is not defined, but it is needed as is


### PR DESCRIPTION
Do not allow whitespace or '+' in timestamps. Using '+' in a timezone offset requires it to be encoded as %2B
