### PR TITLE
Resolves #972 Sort /cve and /cve-id by time.created to mitigate unexpected order and possible race condition

### DIFF
--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -16,7 +16,9 @@ async function getFilteredCveId (req, res, next) {
   }
 
   const options = CONSTANTS.PAGINATOR_OPTIONS
-  options.sort = { owning_cna: 'asc', cve_id: 'asc' }
+  options.sort = {
+    'time.created': 1
+  }
 
   try {
     const orgShortName = req.ctx.org

--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -110,13 +110,7 @@ async function getFilteredCves (req, res, next) {
       // so need to explicitly specify it here and remove it from the options
       {
         $sort: {
-          'cve.cveMetadata.cveId': 1
-        }
-      },
-      {
-        $project: {
-          _id: false,
-          time: false
+          'time.created': 1
         }
       }
     ]

--- a/test-http/src/test/cve_tests/cve.py
+++ b/test-http/src/test/cve_tests/cve.py
@@ -966,19 +966,3 @@ def test_cve_get_bad_page():
     response_contains_json(res, 'error', 'BAD_INPUT')
     response_contains_json(res, 'details', utils.BAD_PAGE_ERROR_DETAILS)
 
-
-
-def test_get_cve_ensure_sorted():
-    """ Should be ordered by CVE ID asc. """
-    res = requests.get(
-        f'{env.AWG_BASE_URL}{CVE_URL}/',
-        headers=utils.BASE_HEADERS,
-    )
-
-    assert res.status_code == 200
-    records = json.loads(res.content.decode())['cveRecords']
-
-    prev_id = "CVE-1900-0000"
-    for record in records:
-        assert record['cveMetadata']['cveId'] > prev_id
-        prev_id = record['cveMetadata']['cveId']


### PR DESCRIPTION
Closes #972

# Summary

The endpoints `/cve` and `/cve-id` are now sorted by the internal `time.created` fields. This addresses unexpected sort orders due to a record changing during pagination.