### PR TITLE
Resolves #810 Updated misleading comment

### DIFF
--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -604,7 +604,7 @@ async function updateUser (req, res, next) {
       }
     })
 
-    // updating user's roles and org_uuid is only allowed for secretariats and org admins
+    // Check for correct privileges if the requested changes require them
     if (changesRequirePrivilegedRole && !(isAdmin || isSecretariat)) {
       logger.info({ uuid: req.ctx.uuid, message: 'The user could not be updated because ' + requesterUsername + ' user is not Org Admin or Secretariat to modify these fields.' })
       return res.status(403).json(error.notOrgAdminOrSecretariat())


### PR DESCRIPTION
Closes Issue #810

## Summary
An existing comment incorrectly represented a code block. Updated it to be accurate.


