### PR TITLE
Resolves issue #907 fixes error in Swagger doc response json for GET /cve

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -301,6 +301,16 @@
               }
             }
           },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal Server Error",
             "content": {
@@ -562,6 +572,16 @@
           },
           "404": {
             "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
             "content": {
               "application/json": {
                 "schema": {

--- a/schemas/cve/list-cve-records-response.json
+++ b/schemas/cve/list-cve-records-response.json
@@ -26,7 +26,7 @@
             "type": "integer",
             "format": "int32"
         },
-        "cve_records": {
+        "cveRecords": {
             "type": "array",
             "items": {
                 "type": "object",

--- a/test-http/src/test/user_tests/user.py
+++ b/test-http/src/test/user_tests/user.py
@@ -132,6 +132,18 @@ def test_put_user_update_name():
 
     assert json.loads(res.content.decode())['name']['first'] == test_name
 
+    # put the name back to what it was because tests don't reset the data
+
+    res = requests.put(
+        f'{env.AWG_BASE_URL}/api/org/{org["short_name"]}/user/{test_user["username"]}',
+        headers=utils.BASE_HEADERS,
+        params={
+            'name.first': test_user['name']['first']
+        }
+    )
+
+    assert res.status_code == 200
+
 
 
 def test_put_user_error_for_same_org():
@@ -172,4 +184,4 @@ def test_put_user_error_for_same_org():
     err = json.loads(res.content.decode())
 
     assert err['error'] == 'USER_ALREADY_IN_ORG'
-    assert err['message'] == 'The user could not be updated because the user \'cps@mitre.org\' already belongs to the \'mitre\' organization.'
+    assert err['message'] == f'The user could not be updated because the user \'{test_user["username"]}\' already belongs to the \'{org["short_name"]}\' organization.'


### PR DESCRIPTION
Note: Please format the pull request title like:
"Resolves issue ###, High level description of pull request."

Closes Issue #907

# Summary
Corrects 200 response schema in Swagger docs for GET /cve by replacing cve_records with cveRecords

# Important Changes
`schemas/cve/list-cve-records-response.json`
- Replaced JSON field name cve_records with cveRecords

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Review 200 response description in Swagger docs for GET /cve

