### PR TITLE
Resolves #998 adds dateUpdated to cna created CVE records

### DIFF
--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -312,7 +312,8 @@ async function submitCna (req, res, next) {
     const additionalCveMetadataFields = {
       assignerShortName: assignerShortName,
       dateReserved: (cveId.reserved).toISOString(),
-      datePublished: dateUpdated
+      datePublished: dateUpdated,
+      dateUpdated: dateUpdated
     }
 
     const providerMetadata = createProviderMetadata(orgUuid, req.ctx.org, dateUpdated)


### PR DESCRIPTION

Closes Issue #998

# Summary
Added `dateUpdated` field to `cveMetadata` when creating a CVE record through the POST `/cve/{id}/cna` endpoint.

# Important Changes
`cve.controller.js`
- `subtmitCna` function, added `dateUpdated` to metadata.
