### PR TITLE
Resolves #838 Updated isValidUsername error message 

### DIFF
--- a/src/controller/org.controller/org.middleware.js
+++ b/src/controller/org.controller/org.middleware.js
@@ -59,7 +59,7 @@ function parseError (req, res, next) {
 function isValidUsername (val) {
   const value = val.match(/^[A-Za-z0-9\-_@.]{3,128}$/)
   if (value == null) {
-    throw new Error('Username should be 3-50 characters. Allowed characters are alphanumberic and -_@.')
+    throw new Error('Username should be 3-128 characters. Allowed characters are alphanumberic and -_@.')
   }
   return true
 }


### PR DESCRIPTION

Closes Issue #838

# Summary
The `isValidUsername` error message was updated from 'Username should be 3-50 characters' to 'Username should be 3-128 characters'.

# Important Changes
`org.middleware.js`
- `isValidUsername` error message

