### PR TITLE
Resolves #608 Improved error message for creating CVE records with $ in X_ values

### DIFF
--- a/src/controller/cve.controller/error.js
+++ b/src/controller/cve.controller/error.js
@@ -70,7 +70,7 @@ class CveControllerError extends idrErr.IDRError {
   unableToStoreCveRecord () { // cve
     const err = {}
     err.error = 'UNABLE_TO_STORE_CVE_RECORD'
-    err.message = 'A problem occurred while saving the CVE Record'
+    err.message = 'A problem occurred while saving the CVE Record, ensure that x_ values do not start with $'
     return err
   }
 


### PR DESCRIPTION

Closes Issue #608 

# Summary
Added additional context to the error message returned when attempting to create a CVE record with `x_` fields with values containing a `$`.  The new error message is 'A problem occurred while saving the CVE Record, ensure that x_ values do not start with $'.

# Important Changes
`/cve.controller/error.js`
- Updated `unableToStoreCveRecord` message

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Use the POST /cve/cna endpoint with a cnaContainer body that has a key value pair of `x_a: {"$b": "c"}`
- [ ] 2) Check if the error message is correct.
