### PR TITLE
Resolves #951 implements bulk download org role

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -29,12 +29,14 @@ function getConstants () {
     AUTH_ROLE_ENUM: {
       SECRETARIAT: 'SECRETARIAT',
       CNA: 'CNA',
+      BULK_DOWNLOAD: 'BULK_DOWNLOAD',
       ROOT_CNA: 'ROOT_CNA',
       ADP: 'ADP'
     },
     ORG_ROLES: [
       'CNA',
       'SECRETARIAT',
+      'BULK_DOWNLOAD',
       'ROOT_CNA',
       'ADP'
     ],

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -34,6 +34,7 @@ async function getFilteredCveId (req, res, next) {
     const cveIdRepo = req.ctx.repositories.getCveIdRepository()
     const orgRepo = req.ctx.repositories.getOrgRepository()
     const isSecretariat = await orgRepo.isSecretariat(orgShortName)
+    const isBulkDownload = await orgRepo.isBulkDownload(orgShortName)
 
     Object.keys(req.ctx.query).forEach(k => {
       const key = k.toLowerCase()
@@ -61,7 +62,8 @@ async function getFilteredCveId (req, res, next) {
       state: { $ne: CONSTANTS.CVE_STATES.AVAILABLE }
     }
 
-    if (!isSecretariat) {
+    // Secretariat and BulkDownload get results for all CNAs
+    if (!(isSecretariat || isBulkDownload)) {
       query.owning_cna = await orgRepo.getOrgUUID(orgShortName)
     }
 

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -153,7 +153,7 @@ router.get('/cve',
   }
   */
   mw.validateUser,
-  mw.onlySecretariat,
+  mw.onlySecretariatOrBulkDownload,
   query().custom((query) => { return mw.validateQueryParameterNames(query, ['page', 'time_modified.lt', 'time_modified.gt', 'state', 'count_only', 'assigner_short_name', 'assigner']) }),
   query(['page']).optional().isInt({ min: CONSTANTS.PAGINATOR_PAGE }),
   query(['time_modified.lt']).optional().isString().trim().escape().customSanitizer(val => { return toDate(val) }).not().isEmpty().withMessage(errorMsgs.TIMESTAMP_FORMAT),

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -249,11 +249,11 @@ async function createOrg (req, res, next) {
       } else if (key === 'name') {
         newOrg.name = decodeEntities(req.ctx.body.name)
       } else if (key === 'authority') {
-        if (req.ctx.body.authority.active_roles) {
+        if ('active_roles' in req.ctx.body.authority === true) {
           newOrg.authority.active_roles = req.ctx.body.authority.active_roles
         }
       } else if (key === 'policies') {
-        if (req.ctx.body.policies.id_quota) {
+        if ('id_quota' in req.ctx.body.policies === true) {
           newOrg.policies.id_quota = req.ctx.body.policies.id_quota
         }
       } else if (key === 'uuid') {
@@ -269,9 +269,12 @@ async function createOrg (req, res, next) {
 
     newOrg.inUse = false
     newOrg.UUID = uuid.v4()
-    newOrg.authority.active_roles = [CONSTANTS.AUTH_ROLE_ENUM.CNA] // default role
 
-    if (!newOrg.policies.id_quota) {
+    if (newOrg.authority.active_roles.length === 0) { // default is to make the Org a CNA if no role is specified
+      newOrg.authority.active_roles = [CONSTANTS.AUTH_ROLE_ENUM.CNA]
+    }
+
+    if (newOrg.policies.id_quota === undefined) { // set to default quota if none is specified
       newOrg.policies.id_quota = CONSTANTS.DEFAULT_ID_QUOTA
     }
 

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -135,6 +135,31 @@ async function validateUser (req, res, next) {
   }
 }
 
+// Checks that the requester belongs to an org that has the 'BULK_DOWNLOAD' role
+async function onlySecretariatOrBulkDownload (req, res, next) {
+  const org = req.ctx.org
+  const orgRepo = req.ctx.repositories.getOrgRepository()
+  const CONSTANTS = getConstants()
+
+  try {
+    const isSec = await orgRepo.isSecretariat(org)
+    const isBulkDownload = await orgRepo.isBulkDownload(org)
+    if (!(isSec || isBulkDownload)) { // error message should only mention Secretariat
+      logger.info({ uuid: req.ctx.uuid, message: org + ' is NOT a ' + CONSTANTS.AUTH_ROLE_ENUM.SECRETARIAT })
+      return res.status(403).json(error.secretariatOnly())
+    }
+
+    logger.info({
+      uuid: req.ctx.uuid,
+      message: 'Confirmed ' + org + ' as a ' + CONSTANTS.AUTH_ROLE_ENUM.SECRETARIAT +
+                ' or as a ' + CONSTANTS.AUTH_ROLE_ENUM.BULK_DOWNLOAD
+    })
+    next()
+  } catch (err) {
+    next(err)
+  }
+}
+
 // Checks that the requester belongs to an org that has the 'SECREATARIAT' role
 async function onlySecretariat (req, res, next) {
   const org = req.ctx.org
@@ -155,7 +180,7 @@ async function onlySecretariat (req, res, next) {
   }
 }
 
-// Checks that the requester belongs to an org that has the 'SECREATARIAT' role or is a user with the 'ADMIN' role
+// Checks that the requester belongs to an org that has the 'SECRETARIAT' role or is a user with the 'ADMIN' role
 async function onlySecretariatOrAdmin (req, res, next) {
   const org = req.ctx.org
   const username = req.ctx.user
@@ -343,6 +368,7 @@ module.exports = {
   optionallyValidateUser,
   validateUser,
   onlySecretariat,
+  onlySecretariatOrBulkDownload,
   onlySecretariatOrAdmin,
   onlyCnas,
   onlyOrgWithRole,

--- a/src/repositories/orgRepository.js
+++ b/src/repositories/orgRepository.js
@@ -30,6 +30,10 @@ class OrgRepository extends BaseRepository {
   async isSecretariatUUID (shortName) {
     return utils.isSecretariatUUID(shortName)
   }
+
+  async isBulkDownload (shortName) {
+    return utils.isBulkDownload(shortName)
+  }
 }
 
 module.exports = OrgRepository

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -54,6 +54,23 @@ async function isSecretariatUUID (orgUUID) {
   return result // org is not secretariat
 }
 
+async function isBulkDownload (shortName) {
+  let result = false
+  const CONSTANTS = getConstants()
+  const orgUUID = await getOrgUUID(shortName) // may be null if org does not exists
+  const bulkDownloadOrgs = await Org.find({ 'authority.active_roles': { $in: [CONSTANTS.AUTH_ROLE_ENUM.BULK_DOWNLOAD] } })
+
+  if (orgUUID) {
+    bulkDownloadOrgs.forEach((obj) => {
+      if (obj.UUID === orgUUID) {
+        result = true // org has the bulk download role
+      }
+    })
+  }
+
+  return result // org does not have bulk download as a role
+}
+
 async function isAdmin (requesterUsername, requesterShortName) {
   let result = false
   const CONSTANTS = getConstants()
@@ -140,6 +157,7 @@ function toDate (val) {
 
 module.exports = {
   isSecretariat,
+  isBulkDownload,
   isAdmin,
   isAdminUUID,
   isSecretariatUUID,

--- a/test-http/src/conftest.py
+++ b/test-http/src/conftest.py
@@ -41,6 +41,33 @@ def org_admin_headers():
         'CVE-API-USER': user
     }
 
+@pytest.fixture
+def bulk_download_user_headers():
+    """ create an org and user for BULK_DOWNLOAD testing, return user's headers """
+    letters = string.ascii_lowercase
+    org = ''.join(random.choice(letters)
+                  for i in range(10))  # generate random org name
+    org_res = requests.post(
+        f'{env.AWG_BASE_URL}/api/org',  # secretariat creates an org
+        headers=utils.BASE_HEADERS,
+        json={'name': org, 'short_name': org, 'authority': {'active_roles': ['BULK_DOWNLOAD']}, \
+        'policies': {'id_quota': 0}}
+    )
+    user = str(uuid.uuid4())  # dummy user name
+    user_res = requests.post(
+        # secretariat creates a user that belongs to the new org
+        f'{env.AWG_BASE_URL}/api/org/{org}/user',
+        headers=utils.BASE_HEADERS,
+        json={'username': user}
+    )
+
+    secret = json.loads(user_res.content.decode())[
+        'created']['secret']  # dummy user API key
+    return {
+        'CVE-API-KEY': secret,
+        'CVE-API-ORG': org,
+        'CVE-API-USER': user
+    }    
 
 @pytest.fixture
 def reg_user_headers():

--- a/test-http/src/test/cve_id_tests/cve_id_as_general_user.py
+++ b/test-http/src/test/cve_id_tests/cve_id_as_general_user.py
@@ -36,7 +36,6 @@ def test_get_cve_id_bad_org_header(reg_user_headers):
     assert res.status_code == 200
     assert 'requested_by' not in res.content.decode()
 
-
 def test_get_cve_id_id(reg_user_headers):
     """ the id parameter must be a string """
     res = requests.get(
@@ -145,6 +144,19 @@ def test_post_cve_id_empty_year(reg_user_headers):
     assert res.status_code == 400
     response_contains_json(res, 'error', 'BAD_INPUT') 
 
+def test_get_cve_id_bulk_download_user(bulk_download_user_headers):
+    """ bulk download user should not be a CNA so can't reserve ids """
+    res = requests.post(
+        f'{env.AWG_BASE_URL}{CVE_ID_URL}',
+        headers=bulk_download_user_headers,
+        params={
+            'amount': '1',
+            'cve_year': f'{utils.CURRENT_YEAR}',
+            'short_name': bulk_download_user_headers['CVE-API-ORG']
+        }
+    )
+    assert res.status_code == 403
+    response_contains_json(res, 'error', 'CNA_ONLY')    
 
 def test_post_cve_id_bad_year(reg_user_headers):
     """ cve services rejects year that isn't a 4 digit number"""

--- a/test-http/src/test/cve_tests/cve.py
+++ b/test-http/src/test/cve_tests/cve.py
@@ -1,6 +1,7 @@
 import copy
 import datetime as dt
 import json
+import pytest
 import requests
 import time
 import uuid
@@ -24,8 +25,8 @@ ORG_URL = '/api/org'
 ### GET /cve ####
 
 
-def test_get_all_cves():
-    """ services api accepts requests for all CVEs for secretariat users """
+def test_get_all_cves_secretariat():
+    """ services api accepts requests for all CVEs for secretariat and bulk_download users """
     res = requests.get(
         f'{env.AWG_BASE_URL}{CVE_URL}/',
         headers=utils.BASE_HEADERS
@@ -33,6 +34,14 @@ def test_get_all_cves():
     assert res.status_code == utils.HTTP_OK
     assert len(json.loads(res.content.decode())['cveRecords']) >= 1
 
+def test_get_all_cves_bulk_download(bulk_download_user_headers):
+    """ services api accepts requests for all CVEs for secretariat and bulk_download users """
+    res = requests.get(
+        f'{env.AWG_BASE_URL}{CVE_URL}/',
+        headers=bulk_download_user_headers
+    )
+    assert res.status_code == utils.HTTP_OK
+    assert len(json.loads(res.content.decode())['cveRecords']) >= 1
 
 def test_get_cve_by_time_modified():
     # @todo - These records are created by the populate scripts on the node side

--- a/test/unit-tests/cve-id/cveIdGetAllTest.js
+++ b/test/unit-tests/cve-id/cveIdGetAllTest.js
@@ -408,7 +408,7 @@ describe('Testing the GET /cve-id endpoint in CveId Controller', () => {
         async isSecretariat () {
           return false
         }
-        
+
         async isBulkDownload () {
           return false
         }
@@ -644,7 +644,7 @@ describe('Testing the GET /cve-id endpoint in CveId Controller', () => {
           return false
         }
       }
-      
+
       class MyCveIdRepo {
         constructor () {
           this.testRes1 = JSON.parse(JSON.stringify(cveIdFixtures.cvePublished))
@@ -731,7 +731,7 @@ describe('Testing the GET /cve-id endpoint in CveId Controller', () => {
         async isSecretariat () {
           return true
         }
-        
+
         async isBulkDownload () {
           return false
         }
@@ -823,7 +823,7 @@ describe('Testing the GET /cve-id endpoint in CveId Controller', () => {
         async isSecretariat () {
           return true
         }
-        
+
         async isBulkDownload () {
           return false
         }

--- a/test/unit-tests/cve-id/cveIdGetAllTest.js
+++ b/test/unit-tests/cve-id/cveIdGetAllTest.js
@@ -21,6 +21,10 @@ class OrgGetCveIdNoCveIdsWithParams {
     return false
   }
 
+  async isBulkDownload () {
+    return false
+  }
+
   async getOrgUUID () {
     return cveIdFixtures.owningOrg.UUID
   }
@@ -302,6 +306,10 @@ describe('Testing the GET /cve-id endpoint in CveId Controller', () => {
           return true
         }
 
+        async isBulkDownload () {
+          return false
+        }
+
         async getOrgUUID () {
           return cveIdFixtures.org.UUID
         }
@@ -400,6 +408,10 @@ describe('Testing the GET /cve-id endpoint in CveId Controller', () => {
         async isSecretariat () {
           return false
         }
+        
+        async isBulkDownload () {
+          return false
+        }
       }
 
       app.route('/cve-id-filtered-requested-field-not-changed')
@@ -491,6 +503,10 @@ describe('Testing the GET /cve-id endpoint in CveId Controller', () => {
         async isSecretariat () {
           return true
         }
+
+        async isBulkDownload () {
+          return false
+        }
       }
 
       app.route('/cve-id-filtered-secretariat-no-query')
@@ -543,6 +559,10 @@ describe('Testing the GET /cve-id endpoint in CveId Controller', () => {
 
         async isSecretariat () {
           return true
+        }
+
+        async isBulkDownload () {
+          return false
         }
       }
 
@@ -619,8 +639,12 @@ describe('Testing the GET /cve-id endpoint in CveId Controller', () => {
         async isSecretariat () {
           return true
         }
-      }
 
+        async isBulkDownload () {
+          return false
+        }
+      }
+      
       class MyCveIdRepo {
         constructor () {
           this.testRes1 = JSON.parse(JSON.stringify(cveIdFixtures.cvePublished))
@@ -706,6 +730,10 @@ describe('Testing the GET /cve-id endpoint in CveId Controller', () => {
 
         async isSecretariat () {
           return true
+        }
+        
+        async isBulkDownload () {
+          return false
         }
       }
 
@@ -794,6 +822,10 @@ describe('Testing the GET /cve-id endpoint in CveId Controller', () => {
 
         async isSecretariat () {
           return true
+        }
+        
+        async isBulkDownload () {
+          return false
         }
       }
 


### PR DESCRIPTION
Closes Issue #951

# Summary
Implements BULK_DOWNLOAD org role. An org with this role is not given the CNA role by default. When the endpoint is called to create the bulk download org, the request should id_quota=0 and not contain any other roles. A single user should be created for the org, with no privileges granted (there should not be an ADMIN user for the org)

# Important Changes
- added BULK_DOWNLOAD as an org role
- updated POST /org endpoint to not add CNA as a role if org has BULK_DOWNLOAD as a role
- added middleware to test for SecretariatOrBulkDownload privileges
- updated GET /cve to allow access for both Secretariat and BULK_DOWNLOAD
- updated GET /cve-id to return ids for all orgs for BULK_DOWNLOAD
- added test that BULK_DOWNLOAD can access GET /cve
- added test that BULK_DOWNLOAD cannot reserve CVE IDs

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Create an org with the BULK_DOWNLOAD role. Do NOT include other roles for the org, and do set id_quota=0
- [ ] 2) Create a user in the org. Do NOT make the user an ADMIN
- [ ] 3) Test that the user can access GET /cve
- [ ] 4) Test that the user gets results from all CNAs when calling GET /cve-id  (filter the data set so it doesn't run out of memory))

# Notes
Automated tests were added to check that BULK_DOWNLOAD can retrieve all CVE records and that it cannot reserve CVE IDs
