### PR TITLE
Resolves #1011 Refactored null checks for owningCnaShortName and assignerShortName

### DIFF
--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -306,7 +306,7 @@ async function submitCna (req, res, next) {
 
     // create full cve record here
     const owningCna = await orgRepo.findOneByUUID(cveId.owning_cna)
-    const assignerShortName = owningCna?.short_name
+    const assignerShortName = owningCna.short_name
     const cnaContainer = req.ctx.body.cnaContainer
     const dateUpdated = (new Date()).toISOString()
     const additionalCveMetadataFields = {

--- a/src/model/cve.js
+++ b/src/model/cve.js
@@ -86,7 +86,10 @@ CveSchema.statics.newRejectedCve = function (cveIdObj, reqBody, owningCnaShortNa
   rejectedRecord.cveMetadata.dateReserved = new Date(cveIdObj.reserved).toISOString()
   rejectedRecord.cveMetadata.dateUpdated = providerMetadata.dateUpdated
   rejectedRecord.cveMetadata.dateRejected = providerMetadata.dateUpdated
-  rejectedRecord.cveMetadata.assignerShortName = owningCnaShortName || null
+
+  if (owningCnaShortName) {
+    rejectedRecord.cveMetadata.assignerShortName = owningCnaShortName
+  }
 
   const cnaRejectedContainer = createCnaRejectContainer(providerMetadata, reqBody.cnaContainer.rejectedReasons, reqBody.cnaContainer.replacedBy)
 


### PR DESCRIPTION
Closes Issue #1011

# Summary
Updated the null checks for owningCnaShortName and assignerShortName in `submitCna` and `newRejectedCve` functions.

# Important Changes
`cve.controller.js`
- Removed optional chaining for `owningCna` 

`cve.js`
-Removed `or` condition setting assignerShortName to `null`
