### PR TITLE
Resolves #809 Prevents org admins from removing their admin role

### DIFF
--- a/src/controller/org.controller/error.js
+++ b/src/controller/org.controller/error.js
@@ -77,6 +77,13 @@ class OrgControllerError extends idrErr.IDRError {
     err.message = `'${param}' is not a valid parameter.`
     return err
   }
+
+  notAllowedToSelfDemote () {
+    const err = {}
+    err.error = 'NOT_ALLOWED_TO_SELF_DEMOTE'
+    err.message = 'Please have another admin user from your organization change your role.'
+    return err
+  }
 }
 
 module.exports = {

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -575,7 +575,7 @@ async function updateUser (req, res, next) {
     newUser.name.middle = user.name.middle
     newUser.name.suffix = user.name.suffix
 
-    Object.keys(req.ctx.query).forEach(k => {
+    for (const k in req.ctx.query) {
       const key = k.toLowerCase()
 
       if (key === 'new_username') {
@@ -618,7 +618,7 @@ async function updateUser (req, res, next) {
           changesRequirePrivilegedRole = true
         }
       }
-    })
+    }
 
     // Check for correct privileges if the requested changes require them
     if (changesRequirePrivilegedRole && !(isAdmin || isSecretariat)) {

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -608,9 +608,13 @@ async function updateUser (req, res, next) {
         }
       } else if (key === 'active_roles.remove') {
         if (Array.isArray(req.ctx.query['active_roles.remove'])) {
-          req.ctx.query['active_roles.remove'].forEach(r => {
+          for (const r of req.ctx.query['active_roles.remove']) {
+            if (r.toLowerCase() === 'admin' && requesterUsername === username) {
+              logger.info({ uuid: req.ctx.uuid, message: 'The user could not be updated because ' + requesterUsername + ' is an Org Admin changing their own role.' })
+              return res.status(403).json(error.notAllowedToSelfDemote())
+            }
             removeRoles.push(r)
-          })
+          }
           changesRequirePrivilegedRole = true
         }
       }

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -609,7 +609,7 @@ async function updateUser (req, res, next) {
       } else if (key === 'active_roles.remove') {
         if (Array.isArray(req.ctx.query['active_roles.remove'])) {
           for (const r of req.ctx.query['active_roles.remove']) {
-            if (r.toLowerCase() === 'admin' && requesterUsername === username) {
+            if (r.toLowerCase() === 'admin' && requesterUsername === username && (isAdmin || isSecretariat)) {
               logger.info({ uuid: req.ctx.uuid, message: 'The user could not be updated because ' + requesterUsername + ' is an Org Admin changing their own role.' })
               return res.status(403).json(error.notAllowedToSelfDemote())
             }

--- a/test-http/src/test/org_user_tests/org_as_org_admin.py
+++ b/test-http/src/test/org_user_tests/org_as_org_admin.py
@@ -455,25 +455,9 @@ def test_org_admin_update_own_user_roles_name(org_admin_headers):
         f'{env.AWG_BASE_URL}{ORG_URL}/{org}/user/{user}?active_roles.remove=admin',
         headers=org_admin_headers
     )
-    assert res.status_code == 200
-    assert json.loads(res.content.decode())[
-        'updated']['authority']['active_roles'] == []
-    res = requests.put(
-        # adding role
-        f'{env.AWG_BASE_URL}{ORG_URL}/{org}/user/{user}?active_roles.add=admin',
-        headers=org_admin_headers
-    )
     assert res.status_code == 403
-    # cannot add role because org admin doesn't have "ADMIN" role anymore
-    response_contains_json(res, 'error', 'NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
-    res = requests.put(
-        # adding "ADMIN" role back to org admin user
-        f'{env.AWG_BASE_URL}{ORG_URL}/{org}/user/{user}?active_roles.add=admin',
-        headers=utils.BASE_HEADERS
-    )
-    assert res.status_code == 200
-    assert json.loads(res.content.decode())[
-        'updated']['authority']['active_roles'] == ["ADMIN"]
+    response_contains_json(res, 'error', 'NOT_ALLOWED_TO_SELF_DEMOTE')
+
     res = requests.put(
         # updating name
         f'{env.AWG_BASE_URL}{ORG_URL}/{org}/user/{user}?name.first=t&name.last=e&name.middle=s&name.suffix=t',


### PR DESCRIPTION

Closes Issue #809

# Summary
Added logic to prevent org admin users from self demoting and removing their own admin role. 

# Important Changes
`error.js`
- Added new error `notAllowedToSelfDemote` with message 'Please have another admin user from your organization change your role.'

`org.controller.js`
- In `updateUser` function, changed `forEach` loop to `for...in` so returning errors breaks out of function
- Throws `notAllowedToSelfDemote` when user tries to remove their own admin role

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Create new org with an admin user
- [ ] 2) Attempt to remove the admin role from this user, while using that user's credentials

