### PR TITLE
Resolves #1019 updates Swagger doc wording to say rejected rather than reject

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -1,2924 +1,2924 @@
 {
-    "openapi": "3.0.2",
-    "info": {
-        "version": "2.1.2",
-        "title": "CVE Services API",
-        "description": "The CVE Services API supports automation tooling for the CVE Program. Credentials are     required for most service endpoints. Representatives of     <a href='https://www.cve.org/ProgramOrganization/CNAs'>CVE Numbering Authorities (CNAs)</a> should     use one of the methods below to obtain credentials:    <ul><li>If your organization already has an Organizational Administrator (OA) account for the CVE     Services, ask your admin for credentials</li>     <li>Contact your Root (<a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/Google'>Google</a>,     <a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/INCIBE'>INCIBE</a>,     <a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/jpcert'>JPCERT/CC</a>, or     <a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/redhat'>Red Hat</a>) or     Top-Level Root (<a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/icscert'>CISA ICS</a>     or <a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/mitre'>MITRE</a>) to request credentials     </ul>     <p>CVE data is to be in the JSON 5.0 CVE Record format. Details of the JSON 5.0 schema are     located <a href='https://github.com/CVEProject/cve-schema/tree/master/schema/v5.0' target='_blank'>here</a>.</p>    <a href='https://cveform.mitre.org/' class='link' target='_blank'>Contact the CVE Services team</a>",
-        "contact": {
-            "name": "CVE Services Overview",
-            "url": "https://cveproject.github.io/automation-cve-services#services-overview"
-        }
-    },
-    "servers": [
-        {
-            "url": "https://cveawg-dev.mitre.org/api"
-        }
-    ],
-    "paths": {
-        "/cve-id": {
-            "get": {
-                "tags": [
-                    "CVE ID"
-                ],
-                "summary": "Retrieves information about CVE IDs after applying the query parameters as filters (accessible to all registered users)",
-                "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves filtered CVE IDs owned by the user's organization</p>  <p><b>Secretariat:</b> Retrieves filtered CVE IDs owned by any organization</p>",
-                "operationId": "cveIdGetFiltered",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/cveIdGetFilteredState"
-                    },
-                    {
-                        "$ref": "#/components/parameters/cveIdGetFilteredCveIdYear"
-                    },
-                    {
-                        "$ref": "#/components/parameters/cveIdGetFilteredTimeReservedLt"
-                    },
-                    {
-                        "$ref": "#/components/parameters/cveIdGetFilteredTimeReservedGt"
-                    },
-                    {
-                        "$ref": "#/components/parameters/cveIdGetFilteredTimeModifiedLt"
-                    },
-                    {
-                        "$ref": "#/components/parameters/cveIdGetFilteredTimeModifiedGt"
-                    },
-                    {
-                        "$ref": "#/components/parameters/pageQuery"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "A filtered list of information about CVE IDs owned by the organization, along with pagination fields if results span multiple pages of data",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/cve-id/list-cve-ids-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "CVE ID"
-                ],
-                "summary": "Reserves CVE IDs for the organization provided in the short_name query parameter (accessible to CNAs and Secretariat)",
-                "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Reserves CVE IDs for the CNA</p>  <p><b>Secretariat:</b> Reserves CVE IDs for any organization</p>",
-                "operationId": "cveIdReserve",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/amount"
-                    },
-                    {
-                        "$ref": "#/components/parameters/batch_type"
-                    },
-                    {
-                        "$ref": "#/components/parameters/cve_year"
-                    },
-                    {
-                        "$ref": "#/components/parameters/short_name"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "A list of the newly reserved CVE IDs",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/cve-id/create-cve-ids-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "206": {
-                        "description": "A partial list of the CVE IDs the IDR service managed to reserve before encountering a case where no more CVE IDs could be reserved",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/cve-id/create-cve-ids-partial-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/cve-id/{id}": {
-            "get": {
-                "tags": [
-                    "CVE ID"
-                ],
-                "summary": "Retrieves information about the specified CVE ID (accessible to all users)",
-                "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users: </b>Retrieves full information about a CVE ID owned by their organization; partial information about a CVE ID owned by other organizations</p>  <p><b>Unauthenticated Users: </b>Retrieves partial information about a CVE ID  <p><b>Secretariat: </b>Retrieves full information about a CVE ID owned by any organization</p>  <p><i><b>Note - </b>The owning organization of RESERVED CVE IDs is redacted for all users other than those in the owning organization or Secretariat</i></p>",
-                "operationId": "cveIdGetSingle",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The id of the CVE ID information to retrieve"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The requested CVE ID information is returned",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/cve-id/get-cve-id-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "429": {
-                        "description": "Too Many Requests",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": [
-                    "CVE ID"
-                ],
-                "summary": "Updates information related to the specified CVE ID (accessible to CNAs and Secretariat)",
-                "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Updates information related to a CVE ID owned by the CNA</p>  <p><b>Secretariat:</b> Updates a CVE ID owned by any organization</p>",
-                "operationId": "cveIdUpdateSingle",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The id of the CVE ID to update"
-                    },
-                    {
-                        "$ref": "#/components/parameters/org"
-                    },
-                    {
-                        "$ref": "#/components/parameters/state"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The updated CVE ID information is returned",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/cve-id/update-cve-id-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/cve-id-range/{year}": {
-            "post": {
-                "tags": [
-                    "CVE ID"
-                ],
-                "summary": "Creates a CVE-ID-Range for the specified year (accessible to Secretariat)",
-                "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates a CVE-ID-Range for the specified year</p>",
-                "operationId": "cveIdRangeCreate",
-                "parameters": [
-                    {
-                        "name": "year",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "integer"
-                        },
-                        "description": "The year of the CVE-ID-Range"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The CVE-ID-Range was created"
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/cve/{id}": {
-            "get": {
-                "tags": [
-                    "CVE Record"
-                ],
-                "summary": "Returns a CVE Record by CVE ID (accessible to all users)",
-                "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p><b>All users:</b> Retrieves the CVE Record specified</p>",
-                "operationId": "cveGetSingle",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The CVE ID for the Record to be retrieved"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The requested CVE Record",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "oneOf": [
-                                        {
-                                            "$ref": "/schemas/cve/get-cve-record-response.json"
-                                        },
-                                        {
-                                            "$ref": "/schemas/cve/create-cve-record-rejection-response.json"
-                                        }
-                                    ]
-                                },
-                                "examples": {
-                                    "Published Record": {
-                                        "$ref": "#/components/examples/publishedRecord"
-                                    },
-                                    "Rejected Record": {
-                                        "$ref": "#/components/examples/rejectedRecord"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "429": {
-                        "description": "Too Many Requests",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "CVE Record"
-                ],
-                "summary": "Creates a CVE Record from full CVE Record JSON for the specified ID (accessible to Secretariat.)",
-                "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates a CVE Record for any organization</p>",
-                "operationId": "cveSubmit",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The CVE ID for the record being submitted"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The CVE Record created",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/cve/create-cve-record-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                },
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "/schemas/cve/create-full-cve-record-request.json"
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": [
-                    "CVE Record"
-                ],
-                "summary": "Updates a CVE Record from full CVE Record JSON for the specified ID (accessible to Secretariat.)",
-                "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Updates a CVE Record for any organization</p>",
-                "operationId": "cveUpdateSingle",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The CVE ID for the record being updated"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The updated CVE Record",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/cve/update-full-cve-record-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                },
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "/schemas/cve/create-full-cve-record-request.json"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/cve": {
-            "get": {
-                "tags": [
-                    "CVE Record"
-                ],
-                "summary": "Retrieves all CVE Records after applying the query parameters as filters (accessible to Secretariat)",
-                "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves all CVE records for all organizations</p>",
-                "operationId": "cveGetFiltered",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/cveRecordFilteredTimeModifiedLt"
-                    },
-                    {
-                        "$ref": "#/components/parameters/cveRecordFilteredTimeModifiedGt"
-                    },
-                    {
-                        "$ref": "#/components/parameters/cveState"
-                    },
-                    {
-                        "$ref": "#/components/parameters/countOnly"
-                    },
-                    {
-                        "$ref": "#/components/parameters/assignerShortName"
-                    },
-                    {
-                        "$ref": "#/components/parameters/assigner"
-                    },
-                    {
-                        "$ref": "#/components/parameters/pageQuery"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "A filtered list of CVE Records, along with pagination fields if results span multiple pages of data",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "oneOf": [
-                                        {
-                                            "$ref": "/schemas/cve/list-cve-records-response.json"
-                                        },
-                                        {
-                                            "$ref": "/schemas/cve/create-cve-record-rejection-response.json"
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized"
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/cve/{id}/cna": {
-            "post": {
-                "tags": [
-                    "CVE Record"
-                ],
-                "summary": "Creates a CVE Record from CNA Container JSON for the specified ID (accessible to CNAs and Secretariat)",
-                "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Creates CVE Record for a CVE ID owned by their organization</p>  <p><b>Secretariat:</b> Creates CVE Record for CVE IDs owned by any organization</p>",
-                "operationId": "cveCnaCreateSingle",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The CVE ID for the record being created"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The CVE Record created",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/cve/create-cve-record-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                },
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "/schemas/cve/cve-record-minimum-request.json"
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": [
-                    "CVE Record"
-                ],
-                "summary": "Updates the CVE Record from CNA Container JSON for the specified ID (accessible to CNAs and Secretariat)",
-                "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Updates a CVE Record for records that are owned by their organization</p>  <p><b>Secretariat:</b> Updates a CVE Record for records that are owned by any organization</p>",
-                "operationId": "cveCnaUpdateSingle",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The CVE ID for which the record is being updated"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The updated CVE Record",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/cve/update-full-cve-record-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                },
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "/schemas/cve/cve-record-minimum-request.json"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/cve/{id}/reject": {
-            "post": {
-                "tags": [
-                    "CVE Record"
-                ],
-                "summary": "Creates a reject CVE Record for the specified ID if no record yet exists (accessible to CNAs and Secretariat)",
-                "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Creates a reject CVE Record for a record owned by their organization</p>  <p><b>Secretariat:</b> Creates a reject CVE Record for a record owned by any organization</p>",
-                "operationId": "cveCnaCreateReject",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The CVE ID for the record being rejected"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The rejected CVE Record",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/cve/create-cve-record-rejection-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                },
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "/schemas/cve/create-cve-record-rejection-request.json"
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": [
-                    "CVE Record"
-                ],
-                "summary": "Updates an existing CVE Record with a reject record for the specified ID (accessible to CNAs and Secretariat)",
-                "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Updates a reject CVE Record for a record owned by their organization</p>  <p><b>Secretariat:</b> Updates a reject CVE Record for a record owned by any organization</p>",
-                "operationId": "cveCnaUpdateReject",
-                "parameters": [
-                    {
-                        "name": "id",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The CVE ID for the record being rejected"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "The rejected CVE Record",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/cve/update-cve-record-rejection-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                },
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "/schemas/cve/update-cve-record-rejection-request.json"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/org": {
-            "get": {
-                "tags": [
-                    "Organization"
-                ],
-                "summary": "Retrieves all organizations (accessible to Secretariat)",
-                "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves information about all organizations</p>",
-                "operationId": "orgAll",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/pageQuery"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns information about all organizations, along with pagination fields if results span multiple pages of data",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/org/list-orgs-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "post": {
-                "tags": [
-                    "Organization"
-                ],
-                "summary": "Creates an organization as specified in the request body (accessible to Secretariat)",
-                "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates an organization</p>  ",
-                "operationId": "orgCreateSingle",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns information about the organization created",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/org/create-org-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                },
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "/schemas/org/create-org-request.json"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/org/{identifier}": {
-            "get": {
-                "tags": [
-                    "Organization"
-                ],
-                "summary": "Retrieves information about the organization specified by short name or UUID (accessible to all registered users)",
-                "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves organization record for the specified shortname or UUID if it is the user's organization</p>  <p><b>Secretariat:</b> Retrieves information about any organization</p>",
-                "operationId": "orgSingle",
-                "parameters": [
-                    {
-                        "name": "identifier",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The shortname or UUID of the organization"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns the organization information",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/org/get-org-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/org/{shortname}": {
-            "put": {
-                "tags": [
-                    "Organization"
-                ],
-                "summary": "Updates information about the organization specified by short name (accessible to Secretariat)",
-                "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Updates any organization's information</p>",
-                "operationId": "orgUpdateSingle",
-                "parameters": [
-                    {
-                        "name": "shortname",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The shortname of the organization"
-                    },
-                    {
-                        "$ref": "#/components/parameters/id_quota"
-                    },
-                    {
-                        "$ref": "#/components/parameters/name"
-                    },
-                    {
-                        "$ref": "#/components/parameters/newShortname"
-                    },
-                    {
-                        "$ref": "#/components/parameters/active_roles_add"
-                    },
-                    {
-                        "$ref": "#/components/parameters/active_roles_remove"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns information about the organization updated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/org/update-org-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/org/{shortname}/id_quota": {
-            "get": {
-                "tags": [
-                    "Organization"
-                ],
-                "summary": "Retrieves an organization's CVE ID quota (accessible to all registered users)",
-                "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves the CVE ID quota for the user's organization</p>  <p><b>Secretariat:</b> Retrieves the CVE ID quota for any organization</p>",
-                "operationId": "orgIdQuota",
-                "parameters": [
-                    {
-                        "name": "shortname",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The shortname of the organization"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns the CVE ID quota for an organization",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/org/get-org-quota-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/org/{shortname}/users": {
-            "get": {
-                "tags": [
-                    "Users"
-                ],
-                "summary": "Retrieves all users for the organization with the specified short name (accessible to all registered users)",
-                "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about users in the same organization</p>  <p><b>Secretariat:</b> Retrieves all user information for any organization</p>",
-                "operationId": "userOrgAll",
-                "parameters": [
-                    {
-                        "name": "shortname",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The shortname of the organization"
-                    },
-                    {
-                        "$ref": "#/components/parameters/pageQuery"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns all users for the organization, along with pagination fields if results span multiple pages of data",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/user/list-users-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/org/{shortname}/user": {
-            "post": {
-                "tags": [
-                    "Users"
-                ],
-                "summary": "Create a user with the provided short name as the owning organization (accessible to Admins and Secretariats)",
-                "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>  <h2>Expected Behavior</h2>  <p><b>Admin User:</b> Creates a user for the Admin's organization</p>  <p><b>Secretariat:</b> Creates a user for any organization</p>",
-                "operationId": "userCreateSingle",
-                "parameters": [
-                    {
-                        "name": "shortname",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The shortname of the organization"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns the new user information (with the secret)",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/user/create-user-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                },
-                "requestBody": {
-                    "required": true,
-                    "content": {
-                        "application/json": {
-                            "schema": {
-                                "$ref": "/schemas/user/create-user-request.json"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/org/{shortname}/user/{username}": {
-            "get": {
-                "tags": [
-                    "Users"
-                ],
-                "summary": "Retrieves information about a user for the specified username and organization short name (accessible to all registered users)",
-                "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about a user in the same organization</p>  <p><b>Secretariat:</b> Retrieves any user's information</p>",
-                "operationId": "userSingle",
-                "parameters": [
-                    {
-                        "name": "shortname",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The shortname of the organization"
-                    },
-                    {
-                        "name": "username",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The username of the user"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns information about the specified user",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/user/get-user-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "put": {
-                "tags": [
-                    "Users"
-                ],
-                "summary": "Updates information about a user for the specified username and organization shortname (accessible to all registered users)",
-                "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular User:</b> Updates the user's own information. Only name fields may be changed.</p>  <p><b>Admin User:</b> Updates information about a user in the Admin's organization. Allowed to change all fields except org_short_name. </p>  <p><b>Secretariat:</b> Updates information about a user in any organization. Allowed to change all fields.</p>",
-                "operationId": "userUpdateSingle",
-                "parameters": [
-                    {
-                        "name": "shortname",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The shortname of the organization"
-                    },
-                    {
-                        "name": "username",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The username of the user"
-                    },
-                    {
-                        "$ref": "#/components/parameters/active"
-                    },
-                    {
-                        "$ref": "#/components/parameters/activeUserRolesAdd"
-                    },
-                    {
-                        "$ref": "#/components/parameters/activeUserRolesRemove"
-                    },
-                    {
-                        "$ref": "#/components/parameters/nameFirst"
-                    },
-                    {
-                        "$ref": "#/components/parameters/nameLast"
-                    },
-                    {
-                        "$ref": "#/components/parameters/nameMiddle"
-                    },
-                    {
-                        "$ref": "#/components/parameters/nameSuffix"
-                    },
-                    {
-                        "$ref": "#/components/parameters/newUsername"
-                    },
-                    {
-                        "$ref": "#/components/parameters/orgShortname"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns the updated user information",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/user/update-user-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/org/{shortname}/user/{username}/reset_secret": {
-            "put": {
-                "tags": [
-                    "Users"
-                ],
-                "summary": "Reset the API key for a user (accessible to all registered users)",
-                "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular User:</b> Resets user's own API secret</p>  <p><b>Admin User:</b> Resets any user's API secret in the Admin's organization</p>  <p><b>Secretariat:</b> Resets any user's API secret</p>",
-                "operationId": "userResetSecret",
-                "parameters": [
-                    {
-                        "name": "shortname",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The shortname of the organization"
-                    },
-                    {
-                        "name": "username",
-                        "in": "path",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        },
-                        "description": "The username of the user"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns the new API key",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/user/reset-secret-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/users": {
-            "get": {
-                "tags": [
-                    "Users"
-                ],
-                "summary": "Retrieves information about all registered users (accessible to Secretariat)",
-                "description": "  <h2>Access Control</h2>  <p> User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves information about all users for all organizations</p>",
-                "operationId": "userAll",
-                "parameters": [
-                    {
-                        "$ref": "#/components/parameters/pageQuery"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiEntityHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiUserHeader"
-                    },
-                    {
-                        "$ref": "#/components/parameters/apiSecretHeader"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Returns all users, along with pagination fields if results span multiple pages of data.",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/user/list-users-response.json"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/bad-request.json"
-                                }
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Not Authenticated",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "/schemas/errors/generic.json"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/health-check": {
-            "get": {
-                "tags": [
-                    "Utilities"
-                ],
-                "summary": "Checks that the system is running (accessible to all users)",
-                "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p>Returns a 200 response code when CVE Services are running</p>",
-                "operationId": "healthCheck",
-                "parameters": [],
-                "responses": {
-                    "200": {
-                        "description": "Returns a 200 response code"
-                    }
-                }
-            }
-        }
-    },
-    "components": {
-        "parameters": {
-            "active": {
-                "in": "query",
-                "name": "active",
-                "description": "The new active state for the user entry.  Accepted values are 1, true, or yes to indicate true, and 0, false, or no to indicate false",
-                "required": false,
-                "schema": {
-                    "type": "boolean"
-                }
-            },
-            "active_roles_add": {
-                "in": "query",
-                "name": "active_roles.add",
-                "description": "Add an active role to the organization",
-                "required": false,
-                "schema": {
-                    "type": "string",
-                    "enum": [
-                        "CNA",
-                        "SECRETARIAT",
-                        "ROOT_CNA",
-                        "ADP"
-                    ]
-                }
-            },
-            "active_roles_remove": {
-                "in": "query",
-                "name": "active_roles.remove",
-                "description": "Remove an active role from the organization",
-                "required": false,
-                "schema": {
-                    "type": "string",
-                    "enum": [
-                        "CNA",
-                        "SECRETARIAT",
-                        "ROOT_CNA",
-                        "ADP"
-                    ]
-                }
-            },
-            "activeUserRolesAdd": {
-                "in": "query",
-                "name": "active_roles.add",
-                "description": "Add an active role to the user",
-                "required": false,
-                "schema": {
-                    "type": "string",
-                    "enum": [
-                        "ADMIN"
-                    ]
-                }
-            },
-            "activeUserRolesRemove": {
-                "in": "query",
-                "name": "active_roles.remove",
-                "description": "Remove an active role from the user",
-                "required": false,
-                "schema": {
-                    "type": "string",
-                    "enum": [
-                        "ADMIN"
-                    ]
-                }
-            },
-            "apiEntityHeader": {
-                "in": "header",
-                "name": "CVE-API-ORG",
-                "description": "The shortname for the organization associated with the user requesting authentication",
-                "required": true,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "apiUserHeader": {
-                "in": "header",
-                "name": "CVE-API-USER",
-                "description": "The username for the account making the request",
-                "required": true,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "apiSecretHeader": {
-                "in": "header",
-                "name": "CVE-API-KEY",
-                "description": "The user's API key",
-                "required": true,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "amount": {
-                "in": "query",
-                "name": "amount",
-                "description": "Quantity of CVE IDs to reserve",
-                "required": true,
-                "schema": {
-                    "type": "integer",
-                    "format": "int32"
-                }
-            },
-            "assigner": {
-                "in": "query",
-                "name": "assigner",
-                "description": "Filter by assigner org UUID",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "assignerShortName": {
-                "in": "query",
-                "name": "assigner_short_name",
-                "description": "Filter by assignerShortName",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "batch_type": {
-                "in": "query",
-                "name": "batch_type",
-                "description": "Required when amount is greater than one, determines whether the reserved CVE IDs should be sequential or non-sequential",
-                "required": false,
-                "schema": {
-                    "type": "string",
-                    "enum": [
-                        "sequential",
-                        "non-sequential",
-                        "nonsequential"
-                    ]
-                }
-            },
-            "countOnly": {
-                "in": "query",
-                "name": "count_only",
-                "description": "Get count of records that match query. Accepted values are 1, true, or yes to indicate true, and 0, false, or no to indicate false",
-                "required": false,
-                "schema": {
-                    "type": "boolean"
-                }
-            },
-            "cveState": {
-                "in": "query",
-                "name": "state",
-                "description": "Filter by state",
-                "schema": {
-                    "type": "string",
-                    "enum": [
-                        "PUBLISHED",
-                        "REJECTED"
-                    ]
-                }
-            },
-            "cve_year": {
-                "in": "query",
-                "name": "cve_year",
-                "description": "The year the CVE IDs will be reserved for (i.e., 1999, ..., currentYear + 1)",
-                "required": true,
-                "schema": {
-                    "type": "integer",
-                    "format": "int32"
-                }
-            },
-            "cveIdGetFilteredState": {
-                "in": "query",
-                "name": "state",
-                "description": "Filter by state [RESERVED, PUBLISHED, REJECTED]",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "cveIdGetFilteredCveIdYear": {
-                "in": "query",
-                "name": "cve_id_year",
-                "description": "Filter by the year of the CVE IDs",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "cveIdGetFilteredTimeReservedLt": {
-                "in": "query",
-                "name": "time_reserved.lt",
-                "description": "Most recent reserved timestamp to retrieve. Include with all requests potentially returning multiple pages of CVE IDs to avoid issues if new IDs are reserved during use.",
-                "required": false,
-                "schema": {
-                    "type": "string",
-                    "format": "date-time"
-                }
-            },
-            "cveIdGetFilteredTimeReservedGt": {
-                "in": "query",
-                "name": "time_reserved.gt",
-                "description": "Earliest CVE ID reserved timestamp to retrieve",
-                "required": false,
-                "schema": {
-                    "type": "string",
-                    "format": "date-time"
-                }
-            },
-            "cveIdGetFilteredTimeModifiedLt": {
-                "in": "query",
-                "name": "time_modified.lt",
-                "description": "Most recent modified timestamp to retrieve. Include with all requests using a time_modified.gt filter potentially returning multiple pages of CVE IDs. This will avoid issues if IDs are reserved or modified during use.",
-                "required": false,
-                "schema": {
-                    "type": "string",
-                    "format": "date-time"
-                }
-            },
-            "cveIdGetFilteredTimeModifiedGt": {
-                "in": "query",
-                "name": "time_modified.gt",
-                "description": "Earliest CVE ID modified timestamp to retrieve",
-                "required": false,
-                "schema": {
-                    "type": "string",
-                    "format": "date-time"
-                }
-            },
-            "cveRecordFilteredTimeModifiedLt": {
-                "in": "query",
-                "name": "time_modified.lt",
-                "description": "Most recent CVE record modified timestamp to retrieve",
-                "required": false,
-                "schema": {
-                    "type": "string",
-                    "format": "date-time"
-                }
-            },
-            "cveRecordFilteredTimeModifiedGt": {
-                "in": "query",
-                "name": "time_modified.gt",
-                "description": "Earliest CVE record modified timestamp to retrieve",
-                "required": false,
-                "schema": {
-                    "type": "string",
-                    "format": "date-time"
-                }
-            },
-            "id_quota": {
-                "in": "query",
-                "name": "id_quota",
-                "description": "The new number of CVE IDs the organization is allowed to have in the RESERVED state at one time",
-                "required": false,
-                "schema": {
-                    "type": "integer",
-                    "format": "int32",
-                    "minimum": 0,
-                    "maximum": 100000
-                }
-            },
-            "name": {
-                "in": "query",
-                "name": "name",
-                "description": "The new name for the organization",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "nameFirst": {
-                "in": "query",
-                "name": "name.first",
-                "description": "The new first name for the user entry",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "nameLast": {
-                "in": "query",
-                "name": "name.last",
-                "description": "The new last name for the user entry",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "nameMiddle": {
-                "in": "query",
-                "name": "name.middle",
-                "description": "The new middle name for the user entry",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "nameSuffix": {
-                "in": "query",
-                "name": "name.suffix",
-                "description": "The new suffix for the user entry",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "newShortname": {
-                "in": "query",
-                "name": "new_short_name",
-                "description": "The new shortname for the organization",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "newUsername": {
-                "in": "query",
-                "name": "new_username",
-                "description": "The new username for the user, preferably the user's email address. Must be 3-50 characters in length; allowed characters are alphanumberic and -_@.",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "org": {
-                "in": "query",
-                "name": "org",
-                "description": "The new owning_cna for the CVE ID",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "orgShortname": {
-                "in": "query",
-                "name": "org_short_name",
-                "description": "The new organization for the user",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "pageQuery": {
-                "in": "query",
-                "name": "page",
-                "description": "The current page in the paginator",
-                "required": false,
-                "schema": {
-                    "type": "integer",
-                    "format": "int32",
-                    "minimum": 1
-                }
-            },
-            "short_name": {
-                "in": "query",
-                "name": "short_name",
-                "description": "The CNA that will own the reserved CVE IDs",
-                "required": true,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "shortname": {
-                "in": "query",
-                "name": "shortname",
-                "description": "The new shortname for the organization",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            "state": {
-                "in": "query",
-                "name": "state",
-                "description": "The new state for the CVE ID",
-                "required": false,
-                "schema": {
-                    "type": "string"
-                }
-            }
-        },
-        "examples": {
-            "publishedRecord": {
-                "value": {
-                    "containers": {
-                        "cna": {
-                            "affected": [
-                                {
-                                    "vendor": "string",
-                                    "product": "string",
-                                    "versions": [
-                                        {
-                                            "version": "string",
-                                            "status": "string"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "descriptions": [
-                                {
-                                    "lang": "string",
-                                    "value": "string"
-                                }
-                            ],
-                            "problemTypes": [
-                                {
-                                    "descriptions": [
-                                        {
-                                            "description": "string",
-                                            "lang": "string",
-                                            "type": "string"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "providerMetadata": {
-                                "orgId": "string",
-                                "shortName": "string",
-                                "dateUpdated": "2022-05-13T14:26:39.293Z"
-                            },
-                            "references": [
-                                {
-                                    "name": "string",
-                                    "tags": [
-                                        "string"
-                                    ],
-                                    "url": "string"
-                                }
-                            ]
-                        }
-                    },
-                    "cveMetadata": {
-                        "assignerOrgId": "string",
-                        "cveId": "string",
-                        "state": "string",
-                        "assignerShortName": "string",
-                        "requesterUserId": "string",
-                        "dateReserved": "string",
-                        "datePublished": "string"
-                    },
-                    "dataType": "string",
-                    "dataVersion": "string"
-                }
-            },
-            "rejectedRecord": {
-                "value": {
-                    "containers": {
-                        "cna": {
-                            "rejectedReasons": [
-                                {
-                                    "lang": "string",
-                                    "value": "string",
-                                    "supportingMedia": [
-                                        {
-                                            "type": "string",
-                                            "base64": false,
-                                            "value": "string"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "replacedBy": [
-                                "string"
-                            ],
-                            "providerMetadata": {
-                                "orgId": "string",
-                                "shortName": "string",
-                                "dateUpdated": "2022-05-13T14:27:39.617Z"
-                            }
-                        }
-                    },
-                    "cveMetadata": {
-                        "assignerOrgId": "string",
-                        "cveId": "string",
-                        "state": "string",
-                        "assignerShortName": "string",
-                        "requesterUserId": "string",
-                        "dateReserved": "string",
-                        "datePublished": "string"
-                    },
-                    "dataType": "string",
-                    "dataVersion": "string"
-                }
-            },
-            "rejectedCreateCVERecord": {
-                "value": {
-                    "message": "string",
-                    "created": {
-                        "containers": {
-                            "cna": {
-                                "rejectedReasons": [
-                                    {
-                                        "lang": "string",
-                                        "value": "string",
-                                        "supportingMedia": [
-                                            {
-                                                "type": "string",
-                                                "base64": false,
-                                                "value": "string"
-                                            }
-                                        ]
-                                    }
-                                ],
-                                "replacedBy": [
-                                    "string"
-                                ],
-                                "providerMetadata": {
-                                    "orgId": "string",
-                                    "shortName": "string",
-                                    "dateUpdated": "2022-05-13T14:27:39.617Z"
-                                }
-                            }
-                        },
-                        "cveMetadata": {
-                            "assignerOrgId": "string",
-                            "cveId": "string",
-                            "state": "string",
-                            "assignerShortName": "string",
-                            "requesterUserId": "string",
-                            "dateReserved": "string",
-                            "datePublished": "string"
-                        },
-                        "dataType": "string",
-                        "dataVersion": "string"
-                    }
-                }
-            }
-        }
+  "openapi": "3.0.2",
+  "info": {
+    "version": "2.1.2",
+    "title": "CVE Services API",
+    "description": "The CVE Services API supports automation tooling for the CVE Program. Credentials are     required for most service endpoints. Representatives of     <a href='https://www.cve.org/ProgramOrganization/CNAs'>CVE Numbering Authorities (CNAs)</a> should     use one of the methods below to obtain credentials:    <ul><li>If your organization already has an Organizational Administrator (OA) account for the CVE     Services, ask your admin for credentials</li>     <li>Contact your Root (<a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/Google'>Google</a>,     <a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/INCIBE'>INCIBE</a>,     <a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/jpcert'>JPCERT/CC</a>, or     <a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/redhat'>Red Hat</a>) or     Top-Level Root (<a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/icscert'>CISA ICS</a>     or <a href='https://www.cve.org/PartnerInformation/ListofPartners/partner/mitre'>MITRE</a>) to request credentials     </ul>     <p>CVE data is to be in the JSON 5.0 CVE Record format. Details of the JSON 5.0 schema are     located <a href='https://github.com/CVEProject/cve-schema/tree/master/schema/v5.0' target='_blank'>here</a>.</p>    <a href='https://cveform.mitre.org/' class='link' target='_blank'>Contact the CVE Services team</a>",
+    "contact": {
+      "name": "CVE Services Overview",
+      "url": "https://cveproject.github.io/automation-cve-services#services-overview"
     }
+  },
+  "servers": [
+    {
+      "url": "https://cveawg-dev.mitre.org/api"
+    }
+  ],
+  "paths": {
+    "/cve-id": {
+      "get": {
+        "tags": [
+          "CVE ID"
+        ],
+        "summary": "Retrieves information about CVE IDs after applying the query parameters as filters (accessible to all registered users)",
+        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves filtered CVE IDs owned by the user's organization</p>  <p><b>Secretariat:</b> Retrieves filtered CVE IDs owned by any organization</p>",
+        "operationId": "cveIdGetFiltered",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/cveIdGetFilteredState"
+          },
+          {
+            "$ref": "#/components/parameters/cveIdGetFilteredCveIdYear"
+          },
+          {
+            "$ref": "#/components/parameters/cveIdGetFilteredTimeReservedLt"
+          },
+          {
+            "$ref": "#/components/parameters/cveIdGetFilteredTimeReservedGt"
+          },
+          {
+            "$ref": "#/components/parameters/cveIdGetFilteredTimeModifiedLt"
+          },
+          {
+            "$ref": "#/components/parameters/cveIdGetFilteredTimeModifiedGt"
+          },
+          {
+            "$ref": "#/components/parameters/pageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A filtered list of information about CVE IDs owned by the organization, along with pagination fields if results span multiple pages of data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/cve-id/list-cve-ids-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CVE ID"
+        ],
+        "summary": "Reserves CVE IDs for the organization provided in the short_name query parameter (accessible to CNAs and Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Reserves CVE IDs for the CNA</p>  <p><b>Secretariat:</b> Reserves CVE IDs for any organization</p>",
+        "operationId": "cveIdReserve",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/amount"
+          },
+          {
+            "$ref": "#/components/parameters/batch_type"
+          },
+          {
+            "$ref": "#/components/parameters/cve_year"
+          },
+          {
+            "$ref": "#/components/parameters/short_name"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of the newly reserved CVE IDs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/cve-id/create-cve-ids-response.json"
+                }
+              }
+            }
+          },
+          "206": {
+            "description": "A partial list of the CVE IDs the IDR service managed to reserve before encountering a case where no more CVE IDs could be reserved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/cve-id/create-cve-ids-partial-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cve-id/{id}": {
+      "get": {
+        "tags": [
+          "CVE ID"
+        ],
+        "summary": "Retrieves information about the specified CVE ID (accessible to all users)",
+        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users: </b>Retrieves full information about a CVE ID owned by their organization; partial information about a CVE ID owned by other organizations</p>  <p><b>Unauthenticated Users: </b>Retrieves partial information about a CVE ID  <p><b>Secretariat: </b>Retrieves full information about a CVE ID owned by any organization</p>  <p><i><b>Note - </b>The owning organization of RESERVED CVE IDs is redacted for all users other than those in the owning organization or Secretariat</i></p>",
+        "operationId": "cveIdGetSingle",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The id of the CVE ID information to retrieve"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested CVE ID information is returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/cve-id/get-cve-id-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CVE ID"
+        ],
+        "summary": "Updates information related to the specified CVE ID (accessible to CNAs and Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Updates information related to a CVE ID owned by the CNA</p>  <p><b>Secretariat:</b> Updates a CVE ID owned by any organization</p>",
+        "operationId": "cveIdUpdateSingle",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The id of the CVE ID to update"
+          },
+          {
+            "$ref": "#/components/parameters/org"
+          },
+          {
+            "$ref": "#/components/parameters/state"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated CVE ID information is returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/cve-id/update-cve-id-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cve-id-range/{year}": {
+      "post": {
+        "tags": [
+          "CVE ID"
+        ],
+        "summary": "Creates a CVE-ID-Range for the specified year (accessible to Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates a CVE-ID-Range for the specified year</p>",
+        "operationId": "cveIdRangeCreate",
+        "parameters": [
+          {
+            "name": "year",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "The year of the CVE-ID-Range"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The CVE-ID-Range was created"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cve/{id}": {
+      "get": {
+        "tags": [
+          "CVE Record"
+        ],
+        "summary": "Returns a CVE Record by CVE ID (accessible to all users)",
+        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p><b>All users:</b> Retrieves the CVE Record specified</p>",
+        "operationId": "cveGetSingle",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The CVE ID for the Record to be retrieved"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The requested CVE Record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "/schemas/cve/get-cve-record-response.json"
+                    },
+                    {
+                      "$ref": "/schemas/cve/create-cve-record-rejection-response.json"
+                    }
+                  ]
+                },
+                "examples": {
+                  "Published Record": {
+                    "$ref": "#/components/examples/publishedRecord"
+                  },
+                  "Rejected Record": {
+                    "$ref": "#/components/examples/rejectedRecord"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CVE Record"
+        ],
+        "summary": "Creates a CVE Record from full CVE Record JSON for the specified ID (accessible to Secretariat.)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates a CVE Record for any organization</p>",
+        "operationId": "cveSubmit",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The CVE ID for the record being submitted"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The CVE Record created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/cve/create-cve-record-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "/schemas/cve/create-full-cve-record-request.json"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CVE Record"
+        ],
+        "summary": "Updates a CVE Record from full CVE Record JSON for the specified ID (accessible to Secretariat.)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Updates a CVE Record for any organization</p>",
+        "operationId": "cveUpdateSingle",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The CVE ID for the record being updated"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated CVE Record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/cve/update-full-cve-record-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "/schemas/cve/create-full-cve-record-request.json"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cve": {
+      "get": {
+        "tags": [
+          "CVE Record"
+        ],
+        "summary": "Retrieves all CVE Records after applying the query parameters as filters (accessible to Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves all CVE records for all organizations</p>",
+        "operationId": "cveGetFiltered",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/cveRecordFilteredTimeModifiedLt"
+          },
+          {
+            "$ref": "#/components/parameters/cveRecordFilteredTimeModifiedGt"
+          },
+          {
+            "$ref": "#/components/parameters/cveState"
+          },
+          {
+            "$ref": "#/components/parameters/countOnly"
+          },
+          {
+            "$ref": "#/components/parameters/assignerShortName"
+          },
+          {
+            "$ref": "#/components/parameters/assigner"
+          },
+          {
+            "$ref": "#/components/parameters/pageQuery"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A filtered list of CVE Records, along with pagination fields if results span multiple pages of data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "/schemas/cve/list-cve-records-response.json"
+                    },
+                    {
+                      "$ref": "/schemas/cve/create-cve-record-rejection-response.json"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cve/{id}/cna": {
+      "post": {
+        "tags": [
+          "CVE Record"
+        ],
+        "summary": "Creates a CVE Record from CNA Container JSON for the specified ID (accessible to CNAs and Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Creates CVE Record for a CVE ID owned by their organization</p>  <p><b>Secretariat:</b> Creates CVE Record for CVE IDs owned by any organization</p>",
+        "operationId": "cveCnaCreateSingle",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The CVE ID for the record being created"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The CVE Record created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/cve/create-cve-record-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "/schemas/cve/cve-record-minimum-request.json"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CVE Record"
+        ],
+        "summary": "Updates the CVE Record from CNA Container JSON for the specified ID (accessible to CNAs and Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Updates a CVE Record for records that are owned by their organization</p>  <p><b>Secretariat:</b> Updates a CVE Record for records that are owned by any organization</p>",
+        "operationId": "cveCnaUpdateSingle",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The CVE ID for which the record is being updated"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated CVE Record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/cve/update-full-cve-record-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "/schemas/cve/cve-record-minimum-request.json"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/cve/{id}/reject": {
+      "post": {
+        "tags": [
+          "CVE Record"
+        ],
+        "summary": "Creates a rejected CVE Record for the specified ID if no record yet exists (accessible to CNAs and Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Creates a rejected CVE Record for a record owned by their organization</p>  <p><b>Secretariat:</b> Creates a rejected CVE Record for a record owned by any organization</p>",
+        "operationId": "cveCnaCreateReject",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The CVE ID for the record being rejected"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The rejected CVE Record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/cve/create-cve-record-rejection-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "/schemas/cve/create-cve-record-rejection-request.json"
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CVE Record"
+        ],
+        "summary": "Updates an existing CVE Record with a rejected record for the specified ID (accessible to CNAs and Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Updates a rejected CVE Record for a record owned by their organization</p>  <p><b>Secretariat:</b> Updates a rejected CVE Record for a record owned by any organization</p>",
+        "operationId": "cveCnaUpdateReject",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The CVE ID for the record being rejected"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The rejected CVE Record",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/cve/update-cve-record-rejection-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "/schemas/cve/update-cve-record-rejection-request.json"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/org": {
+      "get": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "Retrieves all organizations (accessible to Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves information about all organizations</p>",
+        "operationId": "orgAll",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/pageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns information about all organizations, along with pagination fields if results span multiple pages of data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/org/list-orgs-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "Creates an organization as specified in the request body (accessible to Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates an organization</p>  ",
+        "operationId": "orgCreateSingle",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns information about the organization created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/org/create-org-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "/schemas/org/create-org-request.json"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/org/{identifier}": {
+      "get": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "Retrieves information about the organization specified by short name or UUID (accessible to all registered users)",
+        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves organization record for the specified shortname or UUID if it is the user's organization</p>  <p><b>Secretariat:</b> Retrieves information about any organization</p>",
+        "operationId": "orgSingle",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The shortname or UUID of the organization"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the organization information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/org/get-org-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/org/{shortname}": {
+      "put": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "Updates information about the organization specified by short name (accessible to Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Updates any organization's information</p>",
+        "operationId": "orgUpdateSingle",
+        "parameters": [
+          {
+            "name": "shortname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The shortname of the organization"
+          },
+          {
+            "$ref": "#/components/parameters/id_quota"
+          },
+          {
+            "$ref": "#/components/parameters/name"
+          },
+          {
+            "$ref": "#/components/parameters/newShortname"
+          },
+          {
+            "$ref": "#/components/parameters/active_roles_add"
+          },
+          {
+            "$ref": "#/components/parameters/active_roles_remove"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns information about the organization updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/org/update-org-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/org/{shortname}/id_quota": {
+      "get": {
+        "tags": [
+          "Organization"
+        ],
+        "summary": "Retrieves an organization's CVE ID quota (accessible to all registered users)",
+        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves the CVE ID quota for the user's organization</p>  <p><b>Secretariat:</b> Retrieves the CVE ID quota for any organization</p>",
+        "operationId": "orgIdQuota",
+        "parameters": [
+          {
+            "name": "shortname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The shortname of the organization"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the CVE ID quota for an organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/org/get-org-quota-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/org/{shortname}/users": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Retrieves all users for the organization with the specified short name (accessible to all registered users)",
+        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about users in the same organization</p>  <p><b>Secretariat:</b> Retrieves all user information for any organization</p>",
+        "operationId": "userOrgAll",
+        "parameters": [
+          {
+            "name": "shortname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The shortname of the organization"
+          },
+          {
+            "$ref": "#/components/parameters/pageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all users for the organization, along with pagination fields if results span multiple pages of data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/user/list-users-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/org/{shortname}/user": {
+      "post": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Create a user with the provided short name as the owning organization (accessible to Admins and Secretariats)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>  <h2>Expected Behavior</h2>  <p><b>Admin User:</b> Creates a user for the Admin's organization</p>  <p><b>Secretariat:</b> Creates a user for any organization</p>",
+        "operationId": "userCreateSingle",
+        "parameters": [
+          {
+            "name": "shortname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The shortname of the organization"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the new user information (with the secret)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/user/create-user-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "/schemas/user/create-user-request.json"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/org/{shortname}/user/{username}": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Retrieves information about a user for the specified username and organization short name (accessible to all registered users)",
+        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about a user in the same organization</p>  <p><b>Secretariat:</b> Retrieves any user's information</p>",
+        "operationId": "userSingle",
+        "parameters": [
+          {
+            "name": "shortname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The shortname of the organization"
+          },
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The username of the user"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns information about the specified user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/user/get-user-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Updates information about a user for the specified username and organization shortname (accessible to all registered users)",
+        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular User:</b> Updates the user's own information. Only name fields may be changed.</p>  <p><b>Admin User:</b> Updates information about a user in the Admin's organization. Allowed to change all fields except org_short_name. </p>  <p><b>Secretariat:</b> Updates information about a user in any organization. Allowed to change all fields.</p>",
+        "operationId": "userUpdateSingle",
+        "parameters": [
+          {
+            "name": "shortname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The shortname of the organization"
+          },
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The username of the user"
+          },
+          {
+            "$ref": "#/components/parameters/active"
+          },
+          {
+            "$ref": "#/components/parameters/activeUserRolesAdd"
+          },
+          {
+            "$ref": "#/components/parameters/activeUserRolesRemove"
+          },
+          {
+            "$ref": "#/components/parameters/nameFirst"
+          },
+          {
+            "$ref": "#/components/parameters/nameLast"
+          },
+          {
+            "$ref": "#/components/parameters/nameMiddle"
+          },
+          {
+            "$ref": "#/components/parameters/nameSuffix"
+          },
+          {
+            "$ref": "#/components/parameters/newUsername"
+          },
+          {
+            "$ref": "#/components/parameters/orgShortname"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the updated user information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/user/update-user-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/org/{shortname}/user/{username}/reset_secret": {
+      "put": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Reset the API key for a user (accessible to all registered users)",
+        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular User:</b> Resets user's own API secret</p>  <p><b>Admin User:</b> Resets any user's API secret in the Admin's organization</p>  <p><b>Secretariat:</b> Resets any user's API secret</p>",
+        "operationId": "userResetSecret",
+        "parameters": [
+          {
+            "name": "shortname",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The shortname of the organization"
+          },
+          {
+            "name": "username",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The username of the user"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the new API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/user/reset-secret-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/users": {
+      "get": {
+        "tags": [
+          "Users"
+        ],
+        "summary": "Retrieves information about all registered users (accessible to Secretariat)",
+        "description": "  <h2>Access Control</h2>  <p> User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves information about all users for all organizations</p>",
+        "operationId": "userAll",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/pageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns all users, along with pagination fields if results span multiple pages of data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/user/list-users-response.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "/schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/health-check": {
+      "get": {
+        "tags": [
+          "Utilities"
+        ],
+        "summary": "Checks that the system is running (accessible to all users)",
+        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p>Returns a 200 response code when CVE Services are running</p>",
+        "operationId": "healthCheck",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Returns a 200 response code"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "active": {
+        "in": "query",
+        "name": "active",
+        "description": "The new active state for the user entry.  Accepted values are 1, true, or yes to indicate true, and 0, false, or no to indicate false",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "active_roles_add": {
+        "in": "query",
+        "name": "active_roles.add",
+        "description": "Add an active role to the organization",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "CNA",
+            "SECRETARIAT",
+            "ROOT_CNA",
+            "ADP"
+          ]
+        }
+      },
+      "active_roles_remove": {
+        "in": "query",
+        "name": "active_roles.remove",
+        "description": "Remove an active role from the organization",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "CNA",
+            "SECRETARIAT",
+            "ROOT_CNA",
+            "ADP"
+          ]
+        }
+      },
+      "activeUserRolesAdd": {
+        "in": "query",
+        "name": "active_roles.add",
+        "description": "Add an active role to the user",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "ADMIN"
+          ]
+        }
+      },
+      "activeUserRolesRemove": {
+        "in": "query",
+        "name": "active_roles.remove",
+        "description": "Remove an active role from the user",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "ADMIN"
+          ]
+        }
+      },
+      "apiEntityHeader": {
+        "in": "header",
+        "name": "CVE-API-ORG",
+        "description": "The shortname for the organization associated with the user requesting authentication",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "apiUserHeader": {
+        "in": "header",
+        "name": "CVE-API-USER",
+        "description": "The username for the account making the request",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "apiSecretHeader": {
+        "in": "header",
+        "name": "CVE-API-KEY",
+        "description": "The user's API key",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "amount": {
+        "in": "query",
+        "name": "amount",
+        "description": "Quantity of CVE IDs to reserve",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "assigner": {
+        "in": "query",
+        "name": "assigner",
+        "description": "Filter by assigner org UUID",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "assignerShortName": {
+        "in": "query",
+        "name": "assigner_short_name",
+        "description": "Filter by assignerShortName",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "batch_type": {
+        "in": "query",
+        "name": "batch_type",
+        "description": "Required when amount is greater than one, determines whether the reserved CVE IDs should be sequential or non-sequential",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "enum": [
+            "sequential",
+            "non-sequential",
+            "nonsequential"
+          ]
+        }
+      },
+      "countOnly": {
+        "in": "query",
+        "name": "count_only",
+        "description": "Get count of records that match query. Accepted values are 1, true, or yes to indicate true, and 0, false, or no to indicate false",
+        "required": false,
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "cveState": {
+        "in": "query",
+        "name": "state",
+        "description": "Filter by state",
+        "schema": {
+          "type": "string",
+          "enum": [
+            "PUBLISHED",
+            "REJECTED"
+          ]
+        }
+      },
+      "cve_year": {
+        "in": "query",
+        "name": "cve_year",
+        "description": "The year the CVE IDs will be reserved for (i.e., 1999, ..., currentYear + 1)",
+        "required": true,
+        "schema": {
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "cveIdGetFilteredState": {
+        "in": "query",
+        "name": "state",
+        "description": "Filter by state [RESERVED, PUBLISHED, REJECTED]",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "cveIdGetFilteredCveIdYear": {
+        "in": "query",
+        "name": "cve_id_year",
+        "description": "Filter by the year of the CVE IDs",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "cveIdGetFilteredTimeReservedLt": {
+        "in": "query",
+        "name": "time_reserved.lt",
+        "description": "Most recent reserved timestamp to retrieve. Include with all requests potentially returning multiple pages of CVE IDs to avoid issues if new IDs are reserved during use.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "cveIdGetFilteredTimeReservedGt": {
+        "in": "query",
+        "name": "time_reserved.gt",
+        "description": "Earliest CVE ID reserved timestamp to retrieve",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "cveIdGetFilteredTimeModifiedLt": {
+        "in": "query",
+        "name": "time_modified.lt",
+        "description": "Most recent modified timestamp to retrieve. Include with all requests using a time_modified.gt filter potentially returning multiple pages of CVE IDs. This will avoid issues if IDs are reserved or modified during use.",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "cveIdGetFilteredTimeModifiedGt": {
+        "in": "query",
+        "name": "time_modified.gt",
+        "description": "Earliest CVE ID modified timestamp to retrieve",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "cveRecordFilteredTimeModifiedLt": {
+        "in": "query",
+        "name": "time_modified.lt",
+        "description": "Most recent CVE record modified timestamp to retrieve",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "cveRecordFilteredTimeModifiedGt": {
+        "in": "query",
+        "name": "time_modified.gt",
+        "description": "Earliest CVE record modified timestamp to retrieve",
+        "required": false,
+        "schema": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "id_quota": {
+        "in": "query",
+        "name": "id_quota",
+        "description": "The new number of CVE IDs the organization is allowed to have in the RESERVED state at one time",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 0,
+          "maximum": 100000
+        }
+      },
+      "name": {
+        "in": "query",
+        "name": "name",
+        "description": "The new name for the organization",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "nameFirst": {
+        "in": "query",
+        "name": "name.first",
+        "description": "The new first name for the user entry",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "nameLast": {
+        "in": "query",
+        "name": "name.last",
+        "description": "The new last name for the user entry",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "nameMiddle": {
+        "in": "query",
+        "name": "name.middle",
+        "description": "The new middle name for the user entry",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "nameSuffix": {
+        "in": "query",
+        "name": "name.suffix",
+        "description": "The new suffix for the user entry",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "newShortname": {
+        "in": "query",
+        "name": "new_short_name",
+        "description": "The new shortname for the organization",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "newUsername": {
+        "in": "query",
+        "name": "new_username",
+        "description": "The new username for the user, preferably the user's email address. Must be 3-50 characters in length; allowed characters are alphanumberic and -_@.",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "org": {
+        "in": "query",
+        "name": "org",
+        "description": "The new owning_cna for the CVE ID",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "orgShortname": {
+        "in": "query",
+        "name": "org_short_name",
+        "description": "The new organization for the user",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "pageQuery": {
+        "in": "query",
+        "name": "page",
+        "description": "The current page in the paginator",
+        "required": false,
+        "schema": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 1
+        }
+      },
+      "short_name": {
+        "in": "query",
+        "name": "short_name",
+        "description": "The CNA that will own the reserved CVE IDs",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "shortname": {
+        "in": "query",
+        "name": "shortname",
+        "description": "The new shortname for the organization",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "state": {
+        "in": "query",
+        "name": "state",
+        "description": "The new state for the CVE ID",
+        "required": false,
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "examples": {
+      "publishedRecord": {
+        "value": {
+          "containers": {
+            "cna": {
+              "affected": [
+                {
+                  "vendor": "string",
+                  "product": "string",
+                  "versions": [
+                    {
+                      "version": "string",
+                      "status": "string"
+                    }
+                  ]
+                }
+              ],
+              "descriptions": [
+                {
+                  "lang": "string",
+                  "value": "string"
+                }
+              ],
+              "problemTypes": [
+                {
+                  "descriptions": [
+                    {
+                      "description": "string",
+                      "lang": "string",
+                      "type": "string"
+                    }
+                  ]
+                }
+              ],
+              "providerMetadata": {
+                "orgId": "string",
+                "shortName": "string",
+                "dateUpdated": "2022-05-13T14:26:39.293Z"
+              },
+              "references": [
+                {
+                  "name": "string",
+                  "tags": [
+                    "string"
+                  ],
+                  "url": "string"
+                }
+              ]
+            }
+          },
+          "cveMetadata": {
+            "assignerOrgId": "string",
+            "cveId": "string",
+            "state": "string",
+            "assignerShortName": "string",
+            "requesterUserId": "string",
+            "dateReserved": "string",
+            "datePublished": "string"
+          },
+          "dataType": "string",
+          "dataVersion": "string"
+        }
+      },
+      "rejectedRecord": {
+        "value": {
+          "containers": {
+            "cna": {
+              "rejectedReasons": [
+                {
+                  "lang": "string",
+                  "value": "string",
+                  "supportingMedia": [
+                    {
+                      "type": "string",
+                      "base64": false,
+                      "value": "string"
+                    }
+                  ]
+                }
+              ],
+              "replacedBy": [
+                "string"
+              ],
+              "providerMetadata": {
+                "orgId": "string",
+                "shortName": "string",
+                "dateUpdated": "2022-05-13T14:27:39.617Z"
+              }
+            }
+          },
+          "cveMetadata": {
+            "assignerOrgId": "string",
+            "cveId": "string",
+            "state": "string",
+            "assignerShortName": "string",
+            "requesterUserId": "string",
+            "dateReserved": "string",
+            "datePublished": "string"
+          },
+          "dataType": "string",
+          "dataVersion": "string"
+        }
+      },
+      "rejectedCreateCVERecord": {
+        "value": {
+          "message": "string",
+          "created": {
+            "containers": {
+              "cna": {
+                "rejectedReasons": [
+                  {
+                    "lang": "string",
+                    "value": "string",
+                    "supportingMedia": [
+                      {
+                        "type": "string",
+                        "base64": false,
+                        "value": "string"
+                      }
+                    ]
+                  }
+                ],
+                "replacedBy": [
+                  "string"
+                ],
+                "providerMetadata": {
+                  "orgId": "string",
+                  "shortName": "string",
+                  "dateUpdated": "2022-05-13T14:27:39.617Z"
+                }
+              }
+            },
+            "cveMetadata": {
+              "assignerOrgId": "string",
+              "cveId": "string",
+              "state": "string",
+              "assignerShortName": "string",
+              "requesterUserId": "string",
+              "dateReserved": "string",
+              "datePublished": "string"
+            },
+            "dataType": "string",
+            "dataVersion": "string"
+          }
+        }
+      }
+    }
+  }
 }

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -504,13 +504,13 @@ router.post('/cve/:id/reject',
   /*
   #swagger.tags = ['CVE Record']
   #swagger.operationId = 'cveCnaCreateReject'
-  #swagger.summary = "Creates a reject CVE Record for the specified ID if no record yet exists (accessible to CNAs and Secretariat)"
+  #swagger.summary = "Creates a rejected CVE Record for the specified ID if no record yet exists (accessible to CNAs and Secretariat)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>
         <h2>Expected Behavior</h2>
-        <p><b>CNA:</b> Creates a reject CVE Record for a record owned by their organization</p>
-        <p><b>Secretariat:</b> Creates a reject CVE Record for a record owned by any organization</p>"
+        <p><b>CNA:</b> Creates a rejected CVE Record for a record owned by their organization</p>
+        <p><b>Secretariat:</b> Creates a rejected CVE Record for a record owned by any organization</p>"
   #swagger.parameters['id'] = { description: 'The CVE ID for the record being rejected' }
   #swagger.parameters['$ref'] = [
     '#/components/parameters/apiEntityHeader',
@@ -589,13 +589,13 @@ router.put('/cve/:id/reject',
   /*
   #swagger.tags = ['CVE Record']
   #swagger.operationId = 'cveCnaUpdateReject'
-  #swagger.summary = "Updates an existing CVE Record with a reject record for the specified ID (accessible to CNAs and Secretariat)"
+  #swagger.summary = "Updates an existing CVE Record with a rejected record for the specified ID (accessible to CNAs and Secretariat)"
   #swagger.description = "
         <h2>Access Control</h2>
         <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>
         <h2>Expected Behavior</h2>
-        <p><b>CNA:</b> Updates a reject CVE Record for a record owned by their organization</p>
-        <p><b>Secretariat:</b> Updates a reject CVE Record for a record owned by any organization</p>"
+        <p><b>CNA:</b> Updates a rejected CVE Record for a record owned by their organization</p>
+        <p><b>Secretariat:</b> Updates a rejected CVE Record for a record owned by any organization</p>"
   #swagger.parameters['id'] = { description: 'The CVE ID for the record being rejected' }
   #swagger.parameters['$ref'] = [
     '#/components/parameters/apiEntityHeader',


### PR DESCRIPTION
Closes Issue #1019

# Summary
Corrects wording in the documentation for the /cve/:id/reject endpoints

# Important Changes
cve.controller/index.js

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Examine Swagger documentation for the POST and PUT /cve/:id/reject endpoints

