### PR TITLE
Resolves #1017 Updates Swagger docs to reflect that providerMetadata is set by…

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -11,7 +11,7 @@
   },
   "servers": [
     {
-      "url": "https://cveawg-int.mitre.org/api"
+      "url": "https://cveawg-dev.mitre.org/api"
     }
   ],
   "paths": {
@@ -989,6 +989,7 @@
           }
         },
         "requestBody": {
+          "description": "Note: providerMetadata is set by the server. If provided, it will be overwritten.",
           "required": true,
           "content": {
             "application/json": {
@@ -1089,6 +1090,7 @@
           }
         },
         "requestBody": {
+          "description": "Note: providerMetadata is set by the server. If provided, it will be overwritten.",
           "required": true,
           "content": {
             "application/json": {
@@ -1191,6 +1193,7 @@
           }
         },
         "requestBody": {
+          "description": "Note: providerMetadata is set by the server. If provided, it will be overwritten.",
           "required": true,
           "content": {
             "application/json": {
@@ -1291,6 +1294,7 @@
           }
         },
         "requestBody": {
+          "description": "Note: providerMetadata is set by the server. If provided, it will be overwritten.",
           "required": true,
           "content": {
             "application/json": {

--- a/schemas/cve/create-cve-record-rejection-request.json
+++ b/schemas/cve/create-cve-record-rejection-request.json
@@ -2,12 +2,14 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "type": "object",
     "required": [
-        "cnaContainer",
-        "rejectedReasons"
+        "cnaContainer"
     ],
     "properties": {
         "cnaContainer": {
             "type": "object",
+            "required": [
+                "rejectedReasons"
+            ],
             "properties": {
                 "providerMetadata": {
                     "type": "object",

--- a/schemas/cve/cve-record-minimum-request.json
+++ b/schemas/cve/cve-record-minimum-request.json
@@ -1,13 +1,13 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema",
     "type": "object",
+    "required":["cnaContainer"],
     "properties": {
         "cnaContainer": {
             "type": "object",
             "required": [
                 "affected",
                 "descriptions",
-                "providerMetadata",
                 "references"
             ],
             "properties": {

--- a/schemas/cve/update-cve-record-rejection-request.json
+++ b/schemas/cve/update-cve-record-rejection-request.json
@@ -2,12 +2,14 @@
     "$schema": "http://json-schema.org/draft-04/schema",
     "type": "object",
     "required": [
-        "cnaContainer",
-        "rejectedReasons"
+        "cnaContainer"
     ],
     "properties": {
         "cnaContainer": {
             "type": "object",
+            "required": [
+                "rejectedReasons"
+            ],
             "properties": {
                 "providerMetadata": {
                     "type": "object",

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -350,6 +350,7 @@ router.post('/cve/:id/cna',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.requestBody = {
+    description: 'Note: providerMetadata is set by the server. If provided, it will be overwritten.',
     required: true,
     content: {
       "application/json": {
@@ -434,6 +435,7 @@ router.put('/cve/:id/cna',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.requestBody = {
+    description: 'Note: providerMetadata is set by the server. If provided, it will be overwritten.',
     required: true,
     content: {
       "application/json": {
@@ -518,6 +520,7 @@ router.post('/cve/:id/reject',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.requestBody = {
+    description: 'Note: providerMetadata is set by the server. If provided, it will be overwritten.',
     required: true,
     content: {
       "application/json": {
@@ -603,6 +606,7 @@ router.put('/cve/:id/reject',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.requestBody = {
+    description: 'Note: providerMetadata is set by the server. If provided, it will be overwritten.',
     required: true,
     content: {
       "application/json": {


### PR DESCRIPTION
Closes Issue #1017 

# Summary
providerMetadata is set by the server in the POST & PUT /cve/:id/cna and /cve/:id/reject endpoints. This PR updates the Swagger docs to reflect that. It also updates the request body schemas for the Swagger docs for those endpoints to correct which fields are required.

# Important Changes
schemas in schemas/cve/
src/controllers/cve.controller/index.js

# Testing
Review documentation for  the POST & PUT /cve/:id/cna and /cve/:id/reject endpoints.

