### PR TITLE
Resolves #743 Updated swagger docs to include parameter formats

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -2422,8 +2422,7 @@
           "type": "string",
           "enum": [
             "CNA",
-            "SECRETARIAT",
-            "ROOT_CNA"
+            "SECRETARIAT"
           ]
         }
       },
@@ -2436,8 +2435,7 @@
           "type": "string",
           "enum": [
             "CNA",
-            "SECRETARIAT",
-            "ROOT_CNA"
+            "SECRETARIAT"
           ]
         }
       },

--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -2728,7 +2728,7 @@
       "org": {
         "in": "query",
         "name": "org",
-        "description": "The new owning_cna for the CVE ID (shortname)",
+        "description": "The shortname of the new owning_cna for the CVE ID",
         "required": false,
         "schema": {
           "type": "string"

--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -2423,8 +2423,7 @@
           "enum": [
             "CNA",
             "SECRETARIAT",
-            "ROOT_CNA",
-            "ADP"
+            "ROOT_CNA"
           ]
         }
       },
@@ -2438,8 +2437,7 @@
           "enum": [
             "CNA",
             "SECRETARIAT",
-            "ROOT_CNA",
-            "ADP"
+            "ROOT_CNA"
           ]
         }
       },

--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -2570,10 +2570,15 @@
       "cveIdGetFilteredState": {
         "in": "query",
         "name": "state",
-        "description": "Filter by state [RESERVED, PUBLISHED, REJECTED]",
+        "description": "Filter by state ",
         "required": false,
         "schema": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "RESERVED",
+            "PUBLISHED",
+            "REJECTED"
+          ]
         }
       },
       "cveIdGetFilteredCveIdYear": {
@@ -2588,7 +2593,7 @@
       "cveIdGetFilteredTimeReservedLt": {
         "in": "query",
         "name": "time_reserved.lt",
-        "description": "Most recent reserved timestamp to retrieve. Include with all requests potentially returning multiple pages of CVE IDs to avoid issues if new IDs are reserved during use. (yyyy-MM-ddTHH:mm:ssZZZZ)",
+        "description": "Most recent reserved timestamp to retrieve. Include with all requests potentially returning multiple pages of CVE IDs to avoid issues if new IDs are reserved during use. <br><br> <i>Timestamp format</i> : yyyy-MM-ddTHH:mm:ssZZZZ",
         "required": false,
         "schema": {
           "type": "string",
@@ -2598,7 +2603,7 @@
       "cveIdGetFilteredTimeReservedGt": {
         "in": "query",
         "name": "time_reserved.gt",
-        "description": "Earliest CVE ID reserved timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)",
+        "description": "Earliest CVE ID reserved timestamp to retrieve <br><br> <i>Timestamp format</i> : yyyy-MM-ddTHH:mm:ssZZZZ",
         "required": false,
         "schema": {
           "type": "string",
@@ -2608,7 +2613,7 @@
       "cveIdGetFilteredTimeModifiedLt": {
         "in": "query",
         "name": "time_modified.lt",
-        "description": "Most recent modified timestamp to retrieve. Include with all requests using a time_modified.gt filter potentially returning multiple pages of CVE IDs. This will avoid issues if IDs are reserved or modified during use. (yyyy-MM-ddTHH:mm:ssZZZZ)",
+        "description": "Most recent modified timestamp to retrieve. Include with all requests using a time_modified.gt filter potentially returning multiple pages of CVE IDs. This will avoid issues if IDs are reserved or modified during use.<br><br> <i>Timestamp format</i> : yyyy-MM-ddTHH:mm:ssZZZZ",
         "required": false,
         "schema": {
           "type": "string",
@@ -2618,7 +2623,7 @@
       "cveIdGetFilteredTimeModifiedGt": {
         "in": "query",
         "name": "time_modified.gt",
-        "description": "Earliest CVE ID modified timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)",
+        "description": "Earliest CVE ID modified timestamp to retrieve <br><br> <i>Timestamp format</i> : yyyy-MM-ddTHH:mm:ssZZZZ",
         "required": false,
         "schema": {
           "type": "string",
@@ -2628,7 +2633,7 @@
       "cveRecordFilteredTimeModifiedLt": {
         "in": "query",
         "name": "time_modified.lt",
-        "description": "Most recent CVE record modified timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)",
+        "description": "Most recent CVE record modified timestamp to retrieve <br><br> <i>Timestamp format</i> : yyyy-MM-ddTHH:mm:ssZZZZ",
         "required": false,
         "schema": {
           "type": "string",
@@ -2638,7 +2643,7 @@
       "cveRecordFilteredTimeModifiedGt": {
         "in": "query",
         "name": "time_modified.gt",
-        "description": "Earliest CVE record modified timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)",
+        "description": "Earliest CVE record modified timestamp to retrieve <br><br> <i>Timestamp format</i> : yyyy-MM-ddTHH:mm:ssZZZZ",
         "required": false,
         "schema": {
           "type": "string",
@@ -2770,10 +2775,14 @@
       "state": {
         "in": "query",
         "name": "state",
-        "description": "The new state for the CVE ID [RESERVED, REJECTED]",
+        "description": "The new state for the CVE ID",
         "required": false,
         "schema": {
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "RESERVED",
+            "REJECTED"
+          ]
         }
       }
     },

--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -2588,7 +2588,7 @@
       "cveIdGetFilteredTimeReservedLt": {
         "in": "query",
         "name": "time_reserved.lt",
-        "description": "Most recent reserved timestamp to retrieve. Include with all requests potentially returning multiple pages of CVE IDs to avoid issues if new IDs are reserved during use.",
+        "description": "Most recent reserved timestamp to retrieve. Include with all requests potentially returning multiple pages of CVE IDs to avoid issues if new IDs are reserved during use. (yyyy-MM-ddTHH:mm:ssZZZZ)",
         "required": false,
         "schema": {
           "type": "string",
@@ -2598,7 +2598,7 @@
       "cveIdGetFilteredTimeReservedGt": {
         "in": "query",
         "name": "time_reserved.gt",
-        "description": "Earliest CVE ID reserved timestamp to retrieve",
+        "description": "Earliest CVE ID reserved timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)",
         "required": false,
         "schema": {
           "type": "string",
@@ -2608,7 +2608,7 @@
       "cveIdGetFilteredTimeModifiedLt": {
         "in": "query",
         "name": "time_modified.lt",
-        "description": "Most recent modified timestamp to retrieve. Include with all requests using a time_modified.gt filter potentially returning multiple pages of CVE IDs. This will avoid issues if IDs are reserved or modified during use.",
+        "description": "Most recent modified timestamp to retrieve. Include with all requests using a time_modified.gt filter potentially returning multiple pages of CVE IDs. This will avoid issues if IDs are reserved or modified during use. (yyyy-MM-ddTHH:mm:ssZZZZ)",
         "required": false,
         "schema": {
           "type": "string",
@@ -2618,7 +2618,7 @@
       "cveIdGetFilteredTimeModifiedGt": {
         "in": "query",
         "name": "time_modified.gt",
-        "description": "Earliest CVE ID modified timestamp to retrieve",
+        "description": "Earliest CVE ID modified timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)",
         "required": false,
         "schema": {
           "type": "string",
@@ -2628,7 +2628,7 @@
       "cveRecordFilteredTimeModifiedLt": {
         "in": "query",
         "name": "time_modified.lt",
-        "description": "Most recent CVE record modified timestamp to retrieve",
+        "description": "Most recent CVE record modified timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)",
         "required": false,
         "schema": {
           "type": "string",
@@ -2638,7 +2638,7 @@
       "cveRecordFilteredTimeModifiedGt": {
         "in": "query",
         "name": "time_modified.gt",
-        "description": "Earliest CVE record modified timestamp to retrieve",
+        "description": "Earliest CVE record modified timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)",
         "required": false,
         "schema": {
           "type": "string",
@@ -2723,7 +2723,7 @@
       "org": {
         "in": "query",
         "name": "org",
-        "description": "The new owning_cna for the CVE ID",
+        "description": "The new owning_cna for the CVE ID (shortname)",
         "required": false,
         "schema": {
           "type": "string"
@@ -2770,7 +2770,7 @@
       "state": {
         "in": "query",
         "name": "state",
-        "description": "The new state for the CVE ID",
+        "description": "The new state for the CVE ID [RESERVED, REJECTED]",
         "required": false,
         "schema": {
           "type": "string"

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -216,10 +216,15 @@ const doc = {
       cveIdGetFilteredState: {
         in: 'query',
         name: 'state',
-        description: 'Filter by state [RESERVED, PUBLISHED, REJECTED]',
+        description: 'Filter by state ',
         required: false,
         schema: {
-          type: 'string'
+          type: 'string',
+          enum: [
+            'RESERVED',
+            'PUBLISHED',
+            'REJECTED'
+          ]
         }
       },
       cveIdGetFilteredCveIdYear: {
@@ -235,7 +240,7 @@ const doc = {
       cveIdGetFilteredTimeReservedLt: {
         in: 'query',
         name: 'time_reserved.lt',
-        description: 'Most recent reserved timestamp to retrieve. Include with all requests potentially returning multiple pages of CVE IDs to avoid issues if new IDs are reserved during use. (yyyy-MM-ddTHH:mm:ssZZZZ)',
+        description: 'Most recent reserved timestamp to retrieve. Include with all requests potentially returning multiple pages of CVE IDs to avoid issues if new IDs are reserved during use. <br><br> <i>Timestamp format</i> : yyyy-MM-ddTHH:mm:ssZZZZ',
         required: false,
         schema: {
           type: 'string',
@@ -245,7 +250,7 @@ const doc = {
       cveIdGetFilteredTimeReservedGt: {
         in: 'query',
         name: 'time_reserved.gt',
-        description: 'Earliest CVE ID reserved timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)',
+        description: 'Earliest CVE ID reserved timestamp to retrieve <br><br> <i>Timestamp format</i> : yyyy-MM-ddTHH:mm:ssZZZZ',
         required: false,
         schema: {
           type: 'string',
@@ -255,7 +260,7 @@ const doc = {
       cveIdGetFilteredTimeModifiedLt: {
         in: 'query',
         name: 'time_modified.lt',
-        description: 'Most recent modified timestamp to retrieve. Include with all requests using a time_modified.gt filter potentially returning multiple pages of CVE IDs. This will avoid issues if IDs are reserved or modified during use. (yyyy-MM-ddTHH:mm:ssZZZZ)',
+        description: 'Most recent modified timestamp to retrieve. Include with all requests using a time_modified.gt filter potentially returning multiple pages of CVE IDs. This will avoid issues if IDs are reserved or modified during use.<br><br> <i>Timestamp format</i> : yyyy-MM-ddTHH:mm:ssZZZZ',
         required: false,
         schema: {
           type: 'string',
@@ -265,7 +270,7 @@ const doc = {
       cveIdGetFilteredTimeModifiedGt: {
         in: 'query',
         name: 'time_modified.gt',
-        description: 'Earliest CVE ID modified timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)',
+        description: 'Earliest CVE ID modified timestamp to retrieve <br><br> <i>Timestamp format</i> : yyyy-MM-ddTHH:mm:ssZZZZ',
         required: false,
         schema: {
           type: 'string',
@@ -275,7 +280,7 @@ const doc = {
       cveRecordFilteredTimeModifiedLt: {
         in: 'query',
         name: 'time_modified.lt',
-        description: 'Most recent CVE record modified timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)',
+        description: 'Most recent CVE record modified timestamp to retrieve <br><br> <i>Timestamp format</i> : yyyy-MM-ddTHH:mm:ssZZZZ',
         required: false,
         schema: {
           type: 'string',
@@ -285,7 +290,7 @@ const doc = {
       cveRecordFilteredTimeModifiedGt: {
         in: 'query',
         name: 'time_modified.gt',
-        description: 'Earliest CVE record modified timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)',
+        description: 'Earliest CVE record modified timestamp to retrieve <br><br> <i>Timestamp format</i> : yyyy-MM-ddTHH:mm:ssZZZZ',
         required: false,
         schema: {
           type: 'string',
@@ -417,10 +422,14 @@ const doc = {
       state: {
         in: 'query',
         name: 'state',
-        description: 'The new state for the CVE ID [RESERVED, REJECTED]',
+        description: 'The new state for the CVE ID',
         required: false,
         schema: {
-          type: 'string'
+          type: 'string',
+          enum: [
+            'RESERVED',
+            'REJECTED'
+          ]
         }
       }
     },

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -69,8 +69,7 @@ const doc = {
           enum: [
             'CNA',
             'SECRETARIAT',
-            'ROOT_CNA',
-            'ADP'
+            'ROOT_CNA'
           ]
         }
       },
@@ -84,8 +83,7 @@ const doc = {
           enum: [
             'CNA',
             'SECRETARIAT',
-            'ROOT_CNA',
-            'ADP'
+            'ROOT_CNA'
           ]
         }
       },

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -375,7 +375,7 @@ const doc = {
       org: {
         in: 'query',
         name: 'org',
-        description: 'The new owning_cna for the CVE ID (shortname)',
+        description: 'The shortname of the new owning_cna for the CVE ID',
         required: false,
         schema: {
           type: 'string'

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -235,7 +235,7 @@ const doc = {
       cveIdGetFilteredTimeReservedLt: {
         in: 'query',
         name: 'time_reserved.lt',
-        description: 'Most recent reserved timestamp to retrieve. Include with all requests potentially returning multiple pages of CVE IDs to avoid issues if new IDs are reserved during use.',
+        description: 'Most recent reserved timestamp to retrieve. Include with all requests potentially returning multiple pages of CVE IDs to avoid issues if new IDs are reserved during use. (yyyy-MM-ddTHH:mm:ssZZZZ)',
         required: false,
         schema: {
           type: 'string',
@@ -245,7 +245,7 @@ const doc = {
       cveIdGetFilteredTimeReservedGt: {
         in: 'query',
         name: 'time_reserved.gt',
-        description: 'Earliest CVE ID reserved timestamp to retrieve',
+        description: 'Earliest CVE ID reserved timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)',
         required: false,
         schema: {
           type: 'string',
@@ -255,7 +255,7 @@ const doc = {
       cveIdGetFilteredTimeModifiedLt: {
         in: 'query',
         name: 'time_modified.lt',
-        description: 'Most recent modified timestamp to retrieve. Include with all requests using a time_modified.gt filter potentially returning multiple pages of CVE IDs. This will avoid issues if IDs are reserved or modified during use.',
+        description: 'Most recent modified timestamp to retrieve. Include with all requests using a time_modified.gt filter potentially returning multiple pages of CVE IDs. This will avoid issues if IDs are reserved or modified during use. (yyyy-MM-ddTHH:mm:ssZZZZ)',
         required: false,
         schema: {
           type: 'string',
@@ -265,7 +265,7 @@ const doc = {
       cveIdGetFilteredTimeModifiedGt: {
         in: 'query',
         name: 'time_modified.gt',
-        description: 'Earliest CVE ID modified timestamp to retrieve',
+        description: 'Earliest CVE ID modified timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)',
         required: false,
         schema: {
           type: 'string',
@@ -275,7 +275,7 @@ const doc = {
       cveRecordFilteredTimeModifiedLt: {
         in: 'query',
         name: 'time_modified.lt',
-        description: 'Most recent CVE record modified timestamp to retrieve',
+        description: 'Most recent CVE record modified timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)',
         required: false,
         schema: {
           type: 'string',
@@ -285,7 +285,7 @@ const doc = {
       cveRecordFilteredTimeModifiedGt: {
         in: 'query',
         name: 'time_modified.gt',
-        description: 'Earliest CVE record modified timestamp to retrieve',
+        description: 'Earliest CVE record modified timestamp to retrieve (yyyy-MM-ddTHH:mm:ssZZZZ)',
         required: false,
         schema: {
           type: 'string',
@@ -370,7 +370,7 @@ const doc = {
       org: {
         in: 'query',
         name: 'org',
-        description: 'The new owning_cna for the CVE ID',
+        description: 'The new owning_cna for the CVE ID (shortname)',
         required: false,
         schema: {
           type: 'string'
@@ -417,7 +417,7 @@ const doc = {
       state: {
         in: 'query',
         name: 'state',
-        description: 'The new state for the CVE ID',
+        description: 'The new state for the CVE ID [RESERVED, REJECTED]',
         required: false,
         schema: {
           type: 'string'

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -68,8 +68,7 @@ const doc = {
           type: 'string',
           enum: [
             'CNA',
-            'SECRETARIAT',
-            'ROOT_CNA'
+            'SECRETARIAT'
           ]
         }
       },
@@ -82,8 +81,7 @@ const doc = {
           type: 'string',
           enum: [
             'CNA',
-            'SECRETARIAT',
-            'ROOT_CNA'
+            'SECRETARIAT'
           ]
         }
       },


### PR DESCRIPTION
Closes Issue #743

# Summary
Updated swagger docs to include formats for parameters for the GET /cve, GET /cve-id, and PUT /cve-id enpoints.

# Important Changes
`swagger.js`
- Added formats for endpoint parameters

