### PR TITLE
Fixes #1051, change openapi.yml /schemas refs to ../schemas

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -61,7 +61,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/cve-id/list-cve-ids-response.json"
+                  "$ref": "../schemas/cve-id/list-cve-ids-response.json"
                 }
               }
             }
@@ -71,7 +71,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -81,7 +81,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -91,7 +91,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -101,7 +101,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -111,7 +111,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -154,7 +154,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/cve-id/create-cve-ids-response.json"
+                  "$ref": "../schemas/cve-id/create-cve-ids-response.json"
                 }
               }
             }
@@ -164,7 +164,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/cve-id/create-cve-ids-partial-response.json"
+                  "$ref": "../schemas/cve-id/create-cve-ids-partial-response.json"
                 }
               }
             }
@@ -174,7 +174,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -184,7 +184,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -194,7 +194,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -204,7 +204,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -214,7 +214,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -256,7 +256,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/cve-id/get-cve-id-response.json"
+                  "$ref": "../schemas/cve-id/get-cve-id-response.json"
                 }
               }
             }
@@ -266,7 +266,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -276,7 +276,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -286,7 +286,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -296,7 +296,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -306,7 +306,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -316,7 +316,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -362,7 +362,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/cve-id/update-cve-id-response.json"
+                  "$ref": "../schemas/cve-id/update-cve-id-response.json"
                 }
               }
             }
@@ -372,7 +372,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -382,7 +382,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -392,7 +392,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -402,7 +402,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -412,7 +412,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -457,7 +457,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -467,7 +467,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -477,7 +477,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -487,7 +487,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -497,7 +497,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -532,10 +532,10 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "/schemas/cve/get-cve-record-response.json"
+                      "$ref": "../schemas/cve/get-cve-record-response.json"
                     },
                     {
-                      "$ref": "/schemas/cve/create-cve-record-rejection-response.json"
+                      "$ref": "../schemas/cve/create-cve-record-rejection-response.json"
                     }
                   ]
                 },
@@ -555,7 +555,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -565,7 +565,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -575,7 +575,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -585,7 +585,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -595,7 +595,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -635,7 +635,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/cve/create-cve-record-response.json"
+                  "$ref": "../schemas/cve/create-cve-record-response.json"
                 }
               }
             }
@@ -645,7 +645,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -655,7 +655,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -665,7 +665,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -675,7 +675,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -685,7 +685,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -696,7 +696,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "/schemas/cve/create-full-cve-record-request.json"
+                "$ref": "../schemas/cve/create-full-cve-record-request.json"
               }
             }
           }
@@ -735,7 +735,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/cve/update-full-cve-record-response.json"
+                  "$ref": "../schemas/cve/update-full-cve-record-response.json"
                 }
               }
             }
@@ -745,7 +745,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -755,7 +755,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -765,7 +765,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -775,7 +775,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -785,7 +785,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -796,7 +796,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "/schemas/cve/create-full-cve-record-request.json"
+                "$ref": "../schemas/cve/create-full-cve-record-request.json"
               }
             }
           }
@@ -842,10 +842,10 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "/schemas/cve/list-cve-records-response.json"
+                      "$ref": "../schemas/cve/list-cve-records-response.json"
                     },
                     {
-                      "$ref": "/schemas/cve/create-cve-record-rejection-response.json"
+                      "$ref": "../schemas/cve/create-cve-record-rejection-response.json"
                     }
                   ]
                 }
@@ -857,7 +857,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -870,7 +870,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -880,7 +880,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -890,7 +890,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -932,7 +932,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/cve/create-cve-record-response.json"
+                  "$ref": "../schemas/cve/create-cve-record-response.json"
                 }
               }
             }
@@ -942,7 +942,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -952,7 +952,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -962,7 +962,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -972,7 +972,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -982,7 +982,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -994,7 +994,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "/schemas/cve/cve-record-minimum-request.json"
+                "$ref": "../schemas/cve/cve-record-minimum-request.json"
               }
             }
           }
@@ -1033,7 +1033,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/cve/update-full-cve-record-response.json"
+                  "$ref": "../schemas/cve/update-full-cve-record-response.json"
                 }
               }
             }
@@ -1043,7 +1043,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -1053,7 +1053,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1063,7 +1063,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1073,7 +1073,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1083,7 +1083,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1095,7 +1095,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "/schemas/cve/cve-record-minimum-request.json"
+                "$ref": "../schemas/cve/cve-record-minimum-request.json"
               }
             }
           }
@@ -1136,7 +1136,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/cve/create-cve-record-rejection-response.json"
+                  "$ref": "../schemas/cve/create-cve-record-rejection-response.json"
                 }
               }
             }
@@ -1146,7 +1146,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -1156,7 +1156,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1166,7 +1166,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1176,7 +1176,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1186,7 +1186,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1198,7 +1198,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "/schemas/cve/create-cve-record-rejection-request.json"
+                "$ref": "../schemas/cve/create-cve-record-rejection-request.json"
               }
             }
           }
@@ -1237,7 +1237,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/cve/update-cve-record-rejection-response.json"
+                  "$ref": "../schemas/cve/update-cve-record-rejection-response.json"
                 }
               }
             }
@@ -1247,7 +1247,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -1257,7 +1257,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1267,7 +1267,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1277,7 +1277,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1287,7 +1287,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1299,7 +1299,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "/schemas/cve/update-cve-record-rejection-request.json"
+                "$ref": "../schemas/cve/update-cve-record-rejection-request.json"
               }
             }
           }
@@ -1334,7 +1334,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/org/list-orgs-response.json"
+                  "$ref": "../schemas/org/list-orgs-response.json"
                 }
               }
             }
@@ -1344,7 +1344,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -1354,7 +1354,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1364,7 +1364,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1374,7 +1374,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1384,7 +1384,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1415,7 +1415,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/org/create-org-response.json"
+                  "$ref": "../schemas/org/create-org-response.json"
                 }
               }
             }
@@ -1425,7 +1425,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -1435,7 +1435,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1445,7 +1445,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1455,7 +1455,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1465,7 +1465,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1476,7 +1476,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "/schemas/org/create-org-request.json"
+                "$ref": "../schemas/org/create-org-request.json"
               }
             }
           }
@@ -1517,7 +1517,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/org/get-org-response.json"
+                  "$ref": "../schemas/org/get-org-response.json"
                 }
               }
             }
@@ -1527,7 +1527,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -1537,7 +1537,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1547,7 +1547,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1557,7 +1557,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1567,7 +1567,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1624,7 +1624,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/org/update-org-response.json"
+                  "$ref": "../schemas/org/update-org-response.json"
                 }
               }
             }
@@ -1634,7 +1634,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -1644,7 +1644,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1654,7 +1654,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1664,7 +1664,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1674,7 +1674,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1716,7 +1716,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/org/get-org-quota-response.json"
+                  "$ref": "../schemas/org/get-org-quota-response.json"
                 }
               }
             }
@@ -1726,7 +1726,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -1736,7 +1736,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1746,7 +1746,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1756,7 +1756,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1766,7 +1766,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1811,7 +1811,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/user/list-users-response.json"
+                  "$ref": "../schemas/user/list-users-response.json"
                 }
               }
             }
@@ -1821,7 +1821,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -1831,7 +1831,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1841,7 +1841,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1851,7 +1851,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1861,7 +1861,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1903,7 +1903,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/user/create-user-response.json"
+                  "$ref": "../schemas/user/create-user-response.json"
                 }
               }
             }
@@ -1913,7 +1913,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -1923,7 +1923,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1933,7 +1933,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1943,7 +1943,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1953,7 +1953,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -1964,7 +1964,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "/schemas/user/create-user-request.json"
+                "$ref": "../schemas/user/create-user-request.json"
               }
             }
           }
@@ -2014,7 +2014,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/user/get-user-response.json"
+                  "$ref": "../schemas/user/get-user-response.json"
                 }
               }
             }
@@ -2024,7 +2024,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -2034,7 +2034,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2044,7 +2044,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2054,7 +2054,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2064,7 +2064,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2140,7 +2140,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/user/update-user-response.json"
+                  "$ref": "../schemas/user/update-user-response.json"
                 }
               }
             }
@@ -2150,7 +2150,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -2160,7 +2160,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2170,7 +2170,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2180,7 +2180,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2190,7 +2190,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2241,7 +2241,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/user/reset-secret-response.json"
+                  "$ref": "../schemas/user/reset-secret-response.json"
                 }
               }
             }
@@ -2251,7 +2251,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -2261,7 +2261,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2271,7 +2271,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2281,7 +2281,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2291,7 +2291,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2327,7 +2327,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/user/list-users-response.json"
+                  "$ref": "../schemas/user/list-users-response.json"
                 }
               }
             }
@@ -2337,7 +2337,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/bad-request.json"
+                  "$ref": "../schemas/errors/bad-request.json"
                 }
               }
             }
@@ -2347,7 +2347,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2357,7 +2357,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2367,7 +2367,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2377,7 +2377,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "/schemas/errors/generic.json"
+                  "$ref": "../schemas/errors/generic.json"
                 }
               }
             }
@@ -2931,3 +2931,4 @@
     }
   }
 }
+

--- a/src/controller/cve-id.controller/index.js
+++ b/src/controller/cve-id.controller/index.js
@@ -39,7 +39,7 @@ router.get('/cve-id',
     description: 'A filtered list of information about CVE IDs owned by the organization, along with pagination fields if results span multiple pages of data',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/cve-id/list-cve-ids-response.json' }
+        schema: { $ref: '../schemas/cve-id/list-cve-ids-response.json' }
       }
     }
   }
@@ -47,7 +47,7 @@ router.get('/cve-id',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -55,7 +55,7 @@ router.get('/cve-id',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -63,7 +63,7 @@ router.get('/cve-id',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -71,7 +71,7 @@ router.get('/cve-id',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -79,7 +79,7 @@ router.get('/cve-id',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -121,7 +121,7 @@ router.post('/cve-id',
     description: 'A list of the newly reserved CVE IDs',
     content: {
       'application/json': {
-        schema: { $ref: '/schemas/cve-id/create-cve-ids-response.json' }
+        schema: { $ref: '../schemas/cve-id/create-cve-ids-response.json' }
       }
     }
   }
@@ -129,7 +129,7 @@ router.post('/cve-id',
     description: 'A partial list of the CVE IDs the IDR service managed to reserve before encountering a case where no more CVE IDs could be reserved',
     content: {
       'application/json': {
-        schema: { $ref: '/schemas/cve-id/create-cve-ids-partial-response.json' }
+        schema: { $ref: '../schemas/cve-id/create-cve-ids-partial-response.json' }
       }
     }
   }
@@ -137,7 +137,7 @@ router.post('/cve-id',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -145,7 +145,7 @@ router.post('/cve-id',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -153,7 +153,7 @@ router.post('/cve-id',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -161,7 +161,7 @@ router.post('/cve-id',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -169,7 +169,7 @@ router.post('/cve-id',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -208,7 +208,7 @@ router.get('/cve-id/:id',
     description: 'The requested CVE ID information is returned',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/cve-id/get-cve-id-response.json' }
+        schema: { $ref: '../schemas/cve-id/get-cve-id-response.json' }
       }
     }
   }
@@ -216,7 +216,7 @@ router.get('/cve-id/:id',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -224,7 +224,7 @@ router.get('/cve-id/:id',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -232,7 +232,7 @@ router.get('/cve-id/:id',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -240,7 +240,7 @@ router.get('/cve-id/:id',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -248,7 +248,7 @@ router.get('/cve-id/:id',
     description: 'Too Many Requests',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -256,7 +256,7 @@ router.get('/cve-id/:id',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -291,7 +291,7 @@ router.put('/cve-id/:id',
     description: 'The updated CVE ID information is returned',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/cve-id/update-cve-id-response.json' }
+        schema: { $ref: '../schemas/cve-id/update-cve-id-response.json' }
       }
     }
   }
@@ -299,7 +299,7 @@ router.put('/cve-id/:id',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -307,7 +307,7 @@ router.put('/cve-id/:id',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -315,7 +315,7 @@ router.put('/cve-id/:id',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -323,7 +323,7 @@ router.put('/cve-id/:id',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -331,7 +331,7 @@ router.put('/cve-id/:id',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -375,7 +375,7 @@ router.post('/cve-id-range/:year',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -383,7 +383,7 @@ router.post('/cve-id-range/:year',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -391,7 +391,7 @@ router.post('/cve-id-range/:year',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -399,7 +399,7 @@ router.post('/cve-id-range/:year',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -407,7 +407,7 @@ router.post('/cve-id-range/:year',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -27,13 +27,13 @@ router.get('/cve/:id',
       "application/json": {
         schema: {
             oneOf: [
-                { $ref: '/schemas/cve/get-cve-record-response.json' },
-                {$ref: '/schemas/cve/create-cve-record-rejection-response.json'}
+                { $ref: '../schemas/cve/get-cve-record-response.json' },
+                { $ref: '../schemas/cve/create-cve-record-rejection-response.json' }
             ]
         },
         examples: {
-            'Published Record': {$ref: '#/components/examples/publishedRecord'},
-            'Rejected Record': {$ref: '#/components/examples/rejectedRecord'}
+            'Published Record': { $ref: '#/components/examples/publishedRecord' },
+            'Rejected Record': { $ref: '#/components/examples/rejectedRecord' }
         }
       }
     }
@@ -43,7 +43,7 @@ router.get('/cve/:id',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -51,7 +51,7 @@ router.get('/cve/:id',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -59,7 +59,7 @@ router.get('/cve/:id',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -67,7 +67,7 @@ router.get('/cve/:id',
     description: 'Too Many Requests',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -75,7 +75,7 @@ router.get('/cve/:id',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -111,8 +111,8 @@ router.get('/cve',
       "application/json": {
         schema: {
             oneOf: [
-                { $ref: '/schemas/cve/list-cve-records-response.json' },
-                {$ref: '/schemas/cve/create-cve-record-rejection-response.json'}
+                { $ref: '../schemas/cve/list-cve-records-response.json' },
+                { $ref: '../schemas/cve/create-cve-record-rejection-response.json' }
             ]
         },
       }
@@ -123,7 +123,7 @@ router.get('/cve',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -131,7 +131,7 @@ router.get('/cve',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -139,7 +139,7 @@ router.get('/cve',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -147,7 +147,7 @@ router.get('/cve',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -186,7 +186,7 @@ router.post('/cve/:id',
     required: true,
     content: {
       "application/json": {
-        schema:{ $ref: '/schemas/cve/create-full-cve-record-request.json' }
+        schema:{ $ref: '../schemas/cve/create-full-cve-record-request.json' }
       }
     }
   }
@@ -194,7 +194,7 @@ router.post('/cve/:id',
     description: 'The CVE Record created',
     content: {
       "application/json": {
-        schema: {$ref: '/schemas/cve/create-cve-record-response.json'}
+        schema: { $ref: '../schemas/cve/create-cve-record-response.json' }
       }
     }
   }
@@ -202,7 +202,7 @@ router.post('/cve/:id',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -210,7 +210,7 @@ router.post('/cve/:id',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -218,7 +218,7 @@ router.post('/cve/:id',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -226,7 +226,7 @@ router.post('/cve/:id',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -234,7 +234,7 @@ router.post('/cve/:id',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -269,7 +269,7 @@ router.put('/cve/:id',
     required: true,
     content: {
       "application/json": {
-        schema:{ $ref: '/schemas/cve/create-full-cve-record-request.json' }
+        schema:{ $ref: '../schemas/cve/create-full-cve-record-request.json' }
       }
     }
   }
@@ -277,7 +277,7 @@ router.put('/cve/:id',
     description: 'The updated CVE Record',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/cve/update-full-cve-record-response.json' }
+        schema: { $ref: '../schemas/cve/update-full-cve-record-response.json' }
       }
     }
   }
@@ -285,7 +285,7 @@ router.put('/cve/:id',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -293,7 +293,7 @@ router.put('/cve/:id',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -301,7 +301,7 @@ router.put('/cve/:id',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -309,7 +309,7 @@ router.put('/cve/:id',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -317,7 +317,7 @@ router.put('/cve/:id',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -354,7 +354,7 @@ router.post('/cve/:id/cna',
     required: true,
     content: {
       "application/json": {
-        schema:{ $ref: '/schemas/cve/cve-record-minimum-request.json' }
+        schema:{ $ref: '../schemas/cve/cve-record-minimum-request.json' }
       }
     }
   }
@@ -362,7 +362,7 @@ router.post('/cve/:id/cna',
     description: 'The CVE Record created',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/cve/create-cve-record-response.json' }
+        schema: { $ref: '../schemas/cve/create-cve-record-response.json' }
       }
     }
   }
@@ -370,7 +370,7 @@ router.post('/cve/:id/cna',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -378,7 +378,7 @@ router.post('/cve/:id/cna',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -386,7 +386,7 @@ router.post('/cve/:id/cna',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -394,7 +394,7 @@ router.post('/cve/:id/cna',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -402,7 +402,7 @@ router.post('/cve/:id/cna',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -439,7 +439,7 @@ router.put('/cve/:id/cna',
     required: true,
     content: {
       "application/json": {
-        schema:{ $ref: '/schemas/cve/cve-record-minimum-request.json' }
+        schema:{ $ref: '../schemas/cve/cve-record-minimum-request.json' }
       }
     }
   }
@@ -447,7 +447,7 @@ router.put('/cve/:id/cna',
     description: 'The updated CVE Record',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/cve/update-full-cve-record-response.json' }
+        schema: { $ref: '../schemas/cve/update-full-cve-record-response.json' }
       }
     }
   }
@@ -455,7 +455,7 @@ router.put('/cve/:id/cna',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -463,7 +463,7 @@ router.put('/cve/:id/cna',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -471,7 +471,7 @@ router.put('/cve/:id/cna',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -479,7 +479,7 @@ router.put('/cve/:id/cna',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -487,7 +487,7 @@ router.put('/cve/:id/cna',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -524,7 +524,7 @@ router.post('/cve/:id/reject',
     required: true,
     content: {
       "application/json": {
-        schema:{ $ref: '/schemas/cve/create-cve-record-rejection-request.json' }
+        schema:{ $ref: '../schemas/cve/create-cve-record-rejection-request.json' }
       }
     }
   }
@@ -532,7 +532,7 @@ router.post('/cve/:id/reject',
     description: 'The rejected CVE Record',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/cve/create-cve-record-rejection-response.json' }
+        schema: { $ref: '../schemas/cve/create-cve-record-rejection-response.json' }
       }
     }
   }
@@ -540,7 +540,7 @@ router.post('/cve/:id/reject',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -548,7 +548,7 @@ router.post('/cve/:id/reject',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -556,7 +556,7 @@ router.post('/cve/:id/reject',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -564,7 +564,7 @@ router.post('/cve/:id/reject',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -572,7 +572,7 @@ router.post('/cve/:id/reject',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -610,7 +610,7 @@ router.put('/cve/:id/reject',
     required: true,
     content: {
       "application/json": {
-        schema:{ $ref: '/schemas/cve/update-cve-record-rejection-request.json' }
+        schema:{ $ref: '../schemas/cve/update-cve-record-rejection-request.json' }
       }
     }
   }
@@ -618,7 +618,7 @@ router.put('/cve/:id/reject',
     description: 'The rejected CVE Record',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/cve/update-cve-record-rejection-response.json' }
+        schema: { $ref: '../schemas/cve/update-cve-record-rejection-response.json' }
       }
     }
   }
@@ -626,7 +626,7 @@ router.put('/cve/:id/reject',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -634,7 +634,7 @@ router.put('/cve/:id/reject',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -642,7 +642,7 @@ router.put('/cve/:id/reject',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -650,7 +650,7 @@ router.put('/cve/:id/reject',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -658,7 +658,7 @@ router.put('/cve/:id/reject',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -29,7 +29,7 @@ router.get('/org',
     description: 'Returns information about all organizations, along with pagination fields if results span multiple pages of data',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/org/list-orgs-response.json' }
+        schema: { $ref: '../schemas/org/list-orgs-response.json' }
       }
     }
   }
@@ -37,7 +37,7 @@ router.get('/org',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -45,7 +45,7 @@ router.get('/org',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -53,7 +53,7 @@ router.get('/org',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -61,7 +61,7 @@ router.get('/org',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -69,7 +69,7 @@ router.get('/org',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -101,7 +101,7 @@ router.post('/org',
     required: true,
     content: {
       'application/json': {
-        schema: { $ref: '/schemas/org/create-org-request.json' }
+        schema: { $ref: '../schemas/org/create-org-request.json' }
       }
     }
   }
@@ -109,7 +109,7 @@ router.post('/org',
     description: 'Returns information about the organization created',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/org/create-org-response.json' }
+        schema: { $ref: '../schemas/org/create-org-response.json' }
       }
     }
   }
@@ -117,7 +117,7 @@ router.post('/org',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -125,7 +125,7 @@ router.post('/org',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -133,7 +133,7 @@ router.post('/org',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -141,7 +141,7 @@ router.post('/org',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -149,7 +149,7 @@ router.post('/org',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -187,7 +187,7 @@ router.get('/org/:identifier',
     description: 'Returns the organization information',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/org/get-org-response.json' }
+        schema: { $ref: '../schemas/org/get-org-response.json' }
       }
     }
   }
@@ -195,7 +195,7 @@ router.get('/org/:identifier',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -203,7 +203,7 @@ router.get('/org/:identifier',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -211,7 +211,7 @@ router.get('/org/:identifier',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -219,7 +219,7 @@ router.get('/org/:identifier',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -227,7 +227,7 @@ router.get('/org/:identifier',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -262,7 +262,7 @@ router.put('/org/:shortname',
     description: 'Returns information about the organization updated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/org/update-org-response.json' }
+        schema: { $ref: '../schemas/org/update-org-response.json' }
       }
     }
   }
@@ -270,7 +270,7 @@ router.put('/org/:shortname',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -278,7 +278,7 @@ router.put('/org/:shortname',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -286,7 +286,7 @@ router.put('/org/:shortname',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -294,7 +294,7 @@ router.put('/org/:shortname',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -302,7 +302,7 @@ router.put('/org/:shortname',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -346,7 +346,7 @@ router.get('/org/:shortname/id_quota',
     description: 'Returns the CVE ID quota for an organization',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/org/get-org-quota-response.json' }
+        schema: { $ref: '../schemas/org/get-org-quota-response.json' }
       }
     }
   }
@@ -354,7 +354,7 @@ router.get('/org/:shortname/id_quota',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -362,7 +362,7 @@ router.get('/org/:shortname/id_quota',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -370,7 +370,7 @@ router.get('/org/:shortname/id_quota',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -378,7 +378,7 @@ router.get('/org/:shortname/id_quota',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -386,7 +386,7 @@ router.get('/org/:shortname/id_quota',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -418,7 +418,7 @@ router.get('/org/:shortname/users',
     description: 'Returns all users for the organization, along with pagination fields if results span multiple pages of data',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/user/list-users-response.json' }
+        schema: { $ref: '../schemas/user/list-users-response.json' }
       }
     }
   }
@@ -426,7 +426,7 @@ router.get('/org/:shortname/users',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -434,7 +434,7 @@ router.get('/org/:shortname/users',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -442,7 +442,7 @@ router.get('/org/:shortname/users',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -450,7 +450,7 @@ router.get('/org/:shortname/users',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -458,7 +458,7 @@ router.get('/org/:shortname/users',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -490,7 +490,7 @@ router.post('/org/:shortname/user',
     required: true,
     content: {
       'application/json': {
-        schema: { $ref: '/schemas/user/create-user-request.json' },
+        schema: { $ref: '../schemas/user/create-user-request.json' },
       }
     }
   }
@@ -498,7 +498,7 @@ router.post('/org/:shortname/user',
     description: 'Returns the new user information (with the secret)',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/user/create-user-response.json' },
+        schema: { $ref: '../schemas/user/create-user-response.json' },
       }
     }
   }
@@ -506,7 +506,7 @@ router.post('/org/:shortname/user',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -514,7 +514,7 @@ router.post('/org/:shortname/user',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -522,7 +522,7 @@ router.post('/org/:shortname/user',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -530,7 +530,7 @@ router.post('/org/:shortname/user',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -538,7 +538,7 @@ router.post('/org/:shortname/user',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -583,7 +583,7 @@ router.get('/org/:shortname/user/:username',
     description: 'Returns information about the specified user',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/user/get-user-response.json' }
+        schema: { $ref: '../schemas/user/get-user-response.json' }
       }
     }
   }
@@ -591,7 +591,7 @@ router.get('/org/:shortname/user/:username',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -599,7 +599,7 @@ router.get('/org/:shortname/user/:username',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -607,7 +607,7 @@ router.get('/org/:shortname/user/:username',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -615,7 +615,7 @@ router.get('/org/:shortname/user/:username',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -623,7 +623,7 @@ router.get('/org/:shortname/user/:username',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -666,7 +666,7 @@ router.put('/org/:shortname/user/:username',
     description: 'Returns the updated user information',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/user/update-user-response.json' }
+        schema: { $ref: '../schemas/user/update-user-response.json' }
       }
     }
   }
@@ -674,7 +674,7 @@ router.put('/org/:shortname/user/:username',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -682,7 +682,7 @@ router.put('/org/:shortname/user/:username',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -690,7 +690,7 @@ router.put('/org/:shortname/user/:username',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -698,7 +698,7 @@ router.put('/org/:shortname/user/:username',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -706,7 +706,7 @@ router.put('/org/:shortname/user/:username',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -760,7 +760,7 @@ router.put('/org/:shortname/user/:username/reset_secret',
     description: 'Returns the new API key',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/user/reset-secret-response.json' }
+        schema: { $ref: '../schemas/user/reset-secret-response.json' }
       }
     }
   }
@@ -768,7 +768,7 @@ router.put('/org/:shortname/user/:username/reset_secret',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -776,7 +776,7 @@ router.put('/org/:shortname/user/:username/reset_secret',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -784,7 +784,7 @@ router.put('/org/:shortname/user/:username/reset_secret',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -792,7 +792,7 @@ router.put('/org/:shortname/user/:username/reset_secret',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -800,7 +800,7 @@ router.put('/org/:shortname/user/:username/reset_secret',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }

--- a/src/controller/user.controller/index.js
+++ b/src/controller/user.controller/index.js
@@ -27,7 +27,7 @@ router.get('/users',
     description: 'Returns all users, along with pagination fields if results span multiple pages of data.',
     content:{
       "application/json":{
-        schema: { $ref: '/schemas/user/list-users-response.json' }
+        schema: { $ref: '../schemas/user/list-users-response.json' }
       }
     }
   }
@@ -35,7 +35,7 @@ router.get('/users',
     description: 'Bad Request',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/bad-request.json' }
+        schema: { $ref: '../schemas/errors/bad-request.json' }
       }
     }
   }
@@ -43,7 +43,7 @@ router.get('/users',
     description: 'Not Authenticated',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' },
+        schema: { $ref: '../schemas/errors/generic.json' },
       }
     }
   }
@@ -51,7 +51,7 @@ router.get('/users',
     description: 'Forbidden',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -59,7 +59,7 @@ router.get('/users',
     description: 'Not Found',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }
@@ -67,7 +67,7 @@ router.get('/users',
     description: 'Internal Server Error',
     content: {
       "application/json": {
-        schema: { $ref: '/schemas/errors/generic.json' }
+        schema: { $ref: '../schemas/errors/generic.json' }
       }
     }
   }


### PR DESCRIPTION
Fixes #1051

# Summary
This commit changes openapi.yml so `swagger-codegen` can succeed when creating a sample client library.

# Important Changes
`api-docs/openapi.yml`
Change all: "$ref": "/schemas/blah.json" items to be "$ref": "../schemas/blah.json" 

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) See #1051

# Notes
- Coordinated previously w/ @slubar and @jdaigneau5 
