### PR TITLE
Resolves #1053 Added temporary description validator to check for one non-whitespace character

### DIFF
--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -94,6 +94,24 @@ function hasSingleEnglishEntry (langsArr) {
   return true
 }
 
+/**
+ * Temporary description validator that ensures description fields have at least 1 non-whitespace character
+ *
+ * @param {String} descIndex
+ * @returns true
+ * @throws Error
+ */
+function validateDescription (descIndex) {
+  // For each index, check if it exists, then apply custom validator
+  return body(descIndex).optional({ nullable: true }).isArray().custom((descriptions, { req, path }) => {
+    // For each array of descriptions, check if at least one non-whitespace character
+    for (const desc of descriptions) {
+      // Some descriptions use 'value' for field name, problemTypes uses 'description'
+      return (!!desc.value?.trim().length || !!desc.description?.trim().length)
+    }
+  })
+}
+
 function validateRejectBody (req, res, next) {
   const rejectBody = req.body
   const result = validateRejected(rejectBody) // validate function is based on custom schema
@@ -136,5 +154,6 @@ module.exports = {
   validateCveCnaContainerJsonSchema,
   validateUniqueEnglishEntry,
   hasSingleEnglishEntry,
+  validateDescription,
   validateRejectBody
 }

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -4,7 +4,7 @@ const mw = require('../../middleware/middleware')
 const errorMsgs = require('../../middleware/errorMessages')
 const controller = require('./cve.controller')
 const { body, param, query } = require('express-validator')
-const { parseGetParams, parsePostParams, parseError, validateCveCnaContainerJsonSchema, validateRejectBody, validateUniqueEnglishEntry } = require('./cve.middleware')
+const { parseGetParams, parsePostParams, parseError, validateCveCnaContainerJsonSchema, validateRejectBody, validateUniqueEnglishEntry, validateDescription } = require('./cve.middleware')
 const getConstants = require('../../constants').getConstants
 const CONSTANTS = getConstants()
 const CHOICES = [CONSTANTS.CVE_STATES.REJECTED, CONSTANTS.CVE_STATES.PUBLISHED]
@@ -244,6 +244,7 @@ router.post('/cve/:id',
   mw.validateCveJsonSchema,
   // the lang key to check depends on the state, so pass both
   validateUniqueEnglishEntry(['containers.cna.descriptions', 'containers.cna.rejectedReasons']),
+  validateDescription(['containers.cna.rejectedReasons', 'containers.cna.descriptions', 'containers.cna.problemTypes[0].descriptions']),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
@@ -327,6 +328,7 @@ router.put('/cve/:id',
   mw.validateCveJsonSchema,
   // the lang key to check depends on the state, so pass both
   validateUniqueEnglishEntry(['containers.cna.descriptions', 'containers.cna.rejectedReasons']),
+  validateDescription(['containers.cna.rejectedReasons', 'containers.cna.descriptions', 'containers.cna.problemTypes[0].descriptions']),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
@@ -411,6 +413,7 @@ router.post('/cve/:id/cna',
   mw.onlyCnas,
   validateCveCnaContainerJsonSchema,
   validateUniqueEnglishEntry('cnaContainer.descriptions'),
+  validateDescription(['cnaContainer.descriptions', 'cnaContainer.problemTypes[0].descriptions']),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
@@ -496,6 +499,7 @@ router.put('/cve/:id/cna',
   mw.onlyCnas,
   validateCveCnaContainerJsonSchema,
   validateUniqueEnglishEntry('cnaContainer.descriptions'),
+  validateDescription(['cnaContainer.descriptions', 'cnaContainer.problemTypes[0].descriptions']),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
@@ -581,6 +585,7 @@ router.post('/cve/:id/reject',
   mw.onlyCnas,
   validateRejectBody,
   validateUniqueEnglishEntry(['cnaContainer.rejectedReasons']),
+  validateDescription(['cnaContainer.rejectedReasons']),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   body(['cnaContainer.replacedBy']).optional().isArray(),
   parseError,
@@ -667,6 +672,7 @@ router.put('/cve/:id/reject',
   mw.onlyCnas,
   validateRejectBody,
   validateUniqueEnglishEntry('cnaContainer.rejectedReasons'),
+  validateDescription(['cnaContainer.rejectedReasons']),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   body(['cnaContainer.replacedBy']).optional().isArray(),
   parseError,


### PR DESCRIPTION

Closes Issue #1053 

# Summary
Added middleware express validation function the checks descriptions in `cna.container.descriptions` , `cna.container.problemTypes`, `cna.container.rejectReasons` for at least one non whitespace character, ensuring the field is not empty. This should be removed once this case is handled by the schema.

# Important Changes
`cve.middleware.js`
- Added `validateDescription()` middleware function

`cve.controller/index.js`
- Added new middleware function to POST/PUT /cve, POST/PUT /cve/cna , POST/PUT /cve/id/reject
- 
# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Ensure description fields in CVE json is validated 

