### PR TITLE
Resolved dr_1080 - Adds Unit test to check quota after CNA removal

### DIFF
--- a/test/integration-tests/cve/adpUserQuotaTest.js
+++ b/test/integration-tests/cve/adpUserQuotaTest.js
@@ -1,0 +1,55 @@
+const chai = require('chai')
+chai.use(require('chai-http'))
+const expect = chai.expect
+
+const constants = require('../constants.js')
+const app = require('../../../src/index.js')
+
+describe('Testing that a user maintains their quota if the cna role is removed', () => {
+  context('Positive Test', () => {
+    it.only('User should still have quota after cna role removal', async () => {
+      // Get the org ID since it is remade every run
+      let orgUuid, quota
+      await chai.request(app)
+        .get('/api/org/win_5/users')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          orgUuid = res.body.users[0].org_UUID
+        })
+      // Check to make sure ORG has the role.
+      await chai.request(app)
+        .get(`/api/org/${orgUuid}`)
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.authority.active_roles).to.include('ADP')
+          expect(res.body.policies.id_quota).to.exist
+          quota = res.body.policies.id_quota
+        })
+      // Remove the role from the user. & check the quota and active roles
+      await chai.request(app)
+        .put('/api/org/win_5?active_roles.remove=CNA')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.updated.authority.active_roles).to.not.include('CNA')
+          expect(res.body.updated.policies.id_quota).to.be.equal(quota)
+        })
+    })
+  })
+  // Give the user the role back incase it is used by another test
+  afterEach(async () => {
+    await chai.request(app)
+      .put('/api/org/win_5?active_roles.add=CNA')
+      .set(constants.headers)
+      .then((res, err) => {
+        expect(err).to.be.undefined
+        expect(res).to.have.status(200)
+        expect(res.body.updated.authority.active_roles).to.include('CNA')
+      })
+  })
+})

--- a/test/integration-tests/cve/adpUserQuotaTest.js
+++ b/test/integration-tests/cve/adpUserQuotaTest.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 const chai = require('chai')
 chai.use(require('chai-http'))
 const expect = chai.expect

--- a/test/integration-tests/cve/adpUserQuotaTest.js
+++ b/test/integration-tests/cve/adpUserQuotaTest.js
@@ -7,7 +7,7 @@ const app = require('../../../src/index.js')
 
 describe('Testing that a user maintains their quota if the cna role is removed', () => {
   context('Positive Test', () => {
-    it.only('User should still have quota after cna role removal', async () => {
+    it('User should still have quota after cna role removal', async () => {
       // Get the org ID since it is remade every run
       let orgUuid, quota
       await chai.request(app)


### PR DESCRIPTION
Closes Issue #1080 

# Summary
This MR adds a unit test to check that the org quota stays the same if the CNA role is removed.

# Important Changes
`adpUserQuotaTest.js`

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) run the following command: `npm run test:integration` 

