### PR TITLE
Resolves #1059 Added basic user creation integration test

### DIFF
--- a/test/integration-tests/user/createUserTest.js
+++ b/test/integration-tests/user/createUserTest.js
@@ -1,0 +1,38 @@
+/* eslint-disable no-unused-expressions */
+
+const chai = require('chai')
+chai.use(require('chai-http'))
+
+const expect = chai.expect
+
+const constants = require('../constants.js')
+const app = require('../../../src/index.js')
+
+const body = {
+  username: 'adpUser',
+  active: 'true',
+  name: {
+    first: 'TestCnaAdmin',
+    last: 'test',
+    middle: 'N',
+    suffix: 'I'
+  },
+  authority: {
+    active_roles: ['Admin']
+  }
+}
+describe('Testing create user endpoint', () => {
+  it('Should return 200 and new user', (done) => {
+    chai.request(app)
+      .post('/api/org/range_4/user')
+      .set(constants.headers)
+      .send(body)
+      .end((err, res) => {
+        expect(err).to.be.null
+        expect(res.body).to.have.property('created')
+        expect(res.body.created.username).to.equal(body.username)
+        expect(res).to.have.status(200)
+        done()
+      })
+  })
+})


### PR DESCRIPTION

Closes Issue #1059 

# Summary
Added integration test to test that a user can be created in an Org with the ADP role.

# Important Changes
`createUserTest.js`
- Implemented user creation test

# Testing

Steps to manually test updated functionality, if possible
- [x] 1) Run `npm run test:integration`.
