### PR TITLE
Resolves #1036 - cve-id/:id state parameter checks

### DIFF
--- a/test/integration-tests/cve-id/cveIdUpdateTest.js
+++ b/test/integration-tests/cve-id/cveIdUpdateTest.js
@@ -1,0 +1,47 @@
+/* eslint-disable no-unused-expressions */
+
+const chai = require('chai')
+chai.use(require('chai-http'))
+const expect = chai.expect
+
+const constants = require('../constants.js')
+const app = require('../../../src/index.js')
+const helpers = require('../helpers.js')
+
+const shortName = 'win_5'
+
+describe('Text PUT CVE-ID/:id', () => {
+  let cveId
+  before(async () => {
+    cveId = await helpers.cveIdReserveHelper(1, '2023', shortName, 'non-sequential')
+  })
+  context('State parameter Tests', () => {
+    it('Endpoint should return a 400 when state org is set to published', async () => {
+      await chai.request(app)
+        .put(`/api/cve-id/${cveId}?state=PUBLISHED`)
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+        })
+    })
+    it('Endpoint should allow the state parameter to be set to reserved', async () => {
+      await chai.request(app)
+        .put(`/api/cve-id/${cveId}?state=REJECTED`)
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+        })
+    })
+    it('Endpoint should still not allow a REJECTED endpoint to be set to published', async () => {
+      await chai.request(app)
+        .put(`/api/cve-id/${cveId}?state=PUBLISHED`)
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+        })
+    })
+  })
+})


### PR DESCRIPTION
Closes Issue #1036 

# Summary
After review, it was found that there is middleware already attached to the endpoint that only allows state to be set to `REJECTED` or `RESERVED`. When state is set to `PUBLISHED`, a 400 error is returned.  This PR provides tests to confirm this case.

No non testing code was added.

# Important Changes
- `test/integration-tests/cve-id/cveIdUpdateTest.js`

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) run the following command: `npm run test:integration`

