### PR TITLE
Resolves #1092 updated insertADP container response message

### DIFF
--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -730,7 +730,7 @@ async function insertAdp (req, res, next) {
 
     await cveRepo.updateByCveId(id, cveModel)
 
-    const outcome = id + ' record had ' + dupeStatus + ' ADP container ' + adpCount + ' successfully inserted. This submission should appear on ' + url + ' within 15 minutes.'
+    const outcome = id + ' record had ' + dupeStatus + ' ADP container for org ' + req.ctx.org + ' successfully inserted. This submission should appear on ' + url + ' within 15 minutes.'
     const responseMessage = {
       message: outcome,
       updated: cveModel.cve

--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -690,7 +690,6 @@ async function insertAdp (req, res, next) {
 
     const providerMetadata = createProviderMetadata(orgUuid, req.ctx.org, dateUpdated)
     adpContainer.providerMetadata = providerMetadata
-    let adpCount = 0
     let dupeFound = 0
     let dupeIndex = -1
     let dupeStatus = 'new'
@@ -704,14 +703,9 @@ async function insertAdp (req, res, next) {
         }
       })
 
-      adpCount = cveRecord.containers.adp.length + 1
-      if (dupeFound === 1) {
-        adpCount = adpCount - 1
-      }
       logger.info('Number of ADP containers already: ' + cveRecord.containers.adp.length)
     } else {
       logger.info('There were previously zero ADP containers.')
-      adpCount = 1
       cveRecord.containers.adp = []
     }
 

--- a/test/integration-tests/cve/insertAdpTest.js
+++ b/test/integration-tests/cve/insertAdpTest.js
@@ -41,7 +41,7 @@ describe('Testing ADP insert Endpoint', () => {
     it('Reserve ADP ', async () => {
       await reserveAdp(cveId, constants.nonSecretariatUserHeaders, constants.testAdp).then((res, err) => {
         expect(err).to.be.undefined
-        const resMessage = cveId + ' record had new ADP container ' + adpLength + ' successfully inserted'
+        const resMessage = cveId + ' record had new ADP container for org ' + shortName + ' successfully inserted'
         expect(res.body.message).to.include(resMessage)
         expect(res.body.updated.containers.adp).to.have.length(adpLength)
 

--- a/test/unit-tests/cve/insertAdpTest.js
+++ b/test/unit-tests/cve/insertAdpTest.js
@@ -135,7 +135,7 @@ describe('Testing insertAdp function', () => {
     it('Should add an ADP container to an existing CVE record', async () => {
       const adpCount = cveCopy.containers.adp.length
 
-      const resMessage = cveIdPublished5 + ' record had new ADP container ' + (adpCount + 1) + ' successfully inserted'
+      const resMessage = cveIdPublished5 + ' record had new ADP container for org ' + stubAdpOrg.short_name + ' successfully inserted'
       await CVE_INSERT_ADP(req, res, next)
 
       expect(status.args[0][0]).to.equal(200)
@@ -172,7 +172,7 @@ describe('Testing insertAdp function', () => {
       }
 
       const adpCount = cveCopy.containers.adp.length
-      const resMessage = cveIdPublished5 + ' record had replacement ADP container ' + adpCount + ' successfully inserted'
+      const resMessage = cveIdPublished5 + ' record had replacement ADP container for org ' + stubAdpOrg.short_name + ' successfully inserted'
       await CVE_INSERT_ADP(req, res, next)
 
       expect(status.args[0][0]).to.equal(200)


### PR DESCRIPTION
Closes Issue #1092

## Summary
The PUT `/cve/{id}/adp` previously returned a response message that was confusing. This was updated to specify the org short name that inserted/updated the ADP container.

### Important Changes
`cve.controller.js`
- Updated `insertAdp()` function response message.

### Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run `npm run test:unit-tests` and `npm run test:integration`

