### PR TITLE
Resolves #803 - Updates Error messaging for null bytes & tests

### DIFF
--- a/src/controller/cve.controller/error.js
+++ b/src/controller/cve.controller/error.js
@@ -70,7 +70,7 @@ class CveControllerError extends idrErr.IDRError {
   unableToStoreCveRecord () { // cve
     const err = {}
     err.error = 'UNABLE_TO_STORE_CVE_RECORD'
-    err.message = 'A problem occurred while saving the CVE Record, ensure field names in x_ objects do not start with $'
+    err.message = 'A problem occurred while saving the CVE Record, ensure field names in x_ objects do not start with $ or include a null byte.'
     return err
   }
 

--- a/test/integration-tests/cve-id/getCveIdTest.js
+++ b/test/integration-tests/cve-id/getCveIdTest.js
@@ -10,7 +10,8 @@ const constants = require('../constants.js')
 const app = require('../../../src/index.js')
 
 describe('Testing Get CVE-ID endpoint', () => {
-  const RESESRVED_COUNT = 116
+  // TODO: Update this test to dynamically calculate reserved count.
+  const RESESRVED_COUNT = 120
   const YEAR_COUNT = 10
   const PUB_YEAR_COUNT = 4
   const TIME_WINDOW_COUNT = 40

--- a/test/integration-tests/cve/postCveXFieldTest.js
+++ b/test/integration-tests/cve/postCveXFieldTest.js
@@ -1,0 +1,94 @@
+/* eslint-disable no-unused-expressions */
+
+const chai = require('chai')
+chai.use(require('chai-http'))
+
+const expect = chai.expect
+
+const constants = require('../constants.js')
+const app = require('../../../src/index.js')
+
+const helpers = require('../helpers.js')
+
+const requestLength = 1
+const shortName = 'win_5'
+const cveYear = '2023'
+const batchType = 'non-sequential'
+
+describe('Testing Reserve CVE Endpoint', () => {
+  let cveId, cveIdDollar
+  beforeEach(async () => {
+    cveId = await helpers.cveIdReserveHelper(requestLength, cveYear, shortName, batchType)
+    cveIdDollar = await helpers.cveIdReserveHelper(requestLength, cveYear, shortName, batchType)
+  })
+  context('Negative Tests', () => {
+    it('Should not allow null byte ', async () => {
+      // Publish the CVE
+      await chai.request(app)
+        .post(`/api/cve/${cveId}/cna`)
+        .set(constants.nonSecretariatUserHeaders)
+        .send({
+          cnaContainer: {
+            'x_\u0000': true,
+            affected: [{
+              product: 'p',
+              vendor: 'v',
+              versions: [
+                {
+                  version: '1.2',
+                  status: 'affected'
+                }
+              ]
+            }],
+            descriptions: [{
+              lang: 'en',
+              value: 'v p 1.2 is insecure.'
+            }],
+            problemTypes: [{
+              descriptions: [{ description: 'insecurity', lang: 'en' }]
+            }],
+            references: [{ url: 'https://example.com' }]
+          }
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body.message).to.contain('A problem occurred while saving the CVE Record, ensure field names in x_ objects do not start with $ or include a null byte.')
+        })
+    })
+    it('Should not allow $ in start of x_ parameters ', async () => {
+      // Publish the CVE
+      await chai.request(app)
+        .post(`/api/cve/${cveIdDollar}/cna`)
+        .set(constants.nonSecretariatUserHeaders)
+        .send({
+          cnaContainer: {
+            $test: true,
+            affected: [{
+              product: 'p',
+              vendor: 'v',
+              versions: [
+                {
+                  version: '1.2',
+                  status: 'affected'
+                }
+              ]
+            }],
+            descriptions: [{
+              lang: 'en',
+              value: 'v p 1.2 is insecure.'
+            }],
+            problemTypes: [{
+              descriptions: [{ description: 'insecurity', lang: 'en' }]
+            }],
+            references: [{ url: 'https://example.com' }]
+          }
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body.message).to.contain('CVE cnaContainer JSON schema validation FAILED.')
+        })
+    })
+  })
+})


### PR DESCRIPTION
Closes Issue #803 

# Summary
Updates the returned error message to a user when they try to upload a CNA container that contains a null byte in the name of an x_ field.

# Important Changes
- `src/controller/cve.controller/error.js`


# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run the following command `npm run test:integration`
