### PR TITLE
Resolves #1114 - Fixes bugs with new parameters

### DIFF
--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -87,18 +87,38 @@ async function getFilteredCves (req, res, next) {
       }
     })
 
+    if (cnaModified && !(timeModifiedGtDateObject || timeModifiedLtDateObject)) {
+      return res.status(400).json(error.badUsageOfCnaModified())
+    }
+
     const query = {}
 
     if (timeModified.timeStamp.length > 0) {
-      query['time.modified'] = {}
+      if (!cnaModified) { query['time.modified'] = {} }
 
       for (let i = 0; i < timeModified.timeStamp.length; i++) {
         if (timeModified.dateOperator[i] === 'lt') {
-          query['time.modified'].$lt = timeModified.timeStamp[i]
+          if (cnaModified) {
+            query['cve.containers.cna.providerMetadata.dateUpdated'] = {}
+            // Due to this not being the mongo created date object, we need to actually check the "ISO String" version of this _NOT_ the date object that is being created in the middleware
+            query['cve.containers.cna.providerMetadata.dateUpdated'].$lt = timeModifiedLtDateObject.toISOString()
+          } else {
+            query['time.modified'].$lt = timeModified.timeStamp[i]
+          }
         } else {
-          query['time.modified'].$gt = timeModified.timeStamp[i]
+          if (cnaModified) {
+            query['cve.containers.cna.providerMetadata.dateUpdated'] = {}
+            // Due to this not being the mongo created date object, we need to actually check the "ISO String" version of this _NOT_ the date object that is being created in the middleware
+            query['cve.containers.cna.providerMetadata.dateUpdated'].$gt = timeModifiedGtDateObject.toISOString()
+          } else {
+            query['time.modified'].$gt = timeModified.timeStamp[i]
+          }
         }
       }
+    }
+
+    if (adpShortName) {
+      query['cve.containers.adp.providerMetadata.shortName'] = adpShortName
     }
 
     if (state) {
@@ -146,62 +166,7 @@ async function getFilteredCves (req, res, next) {
 
     const pg = await cveRepo.aggregatePaginate(agt, options)
     const payload = {
-      cveRecords: pg.itemsList.map(val => { return val.cve }).filter((val) => {
-        // If cnaModified AND adpShortName are false, return all values, no filtering to be done.
-        if (!cnaModified && !adpShortName) {
-          return true
-        }
-
-        // cnaModified and adpShortName are treated as an AND if they are both set
-        if (cnaModified) {
-          if (val.containers.cna.providerMetadata?.dateUpdated) {
-            // If the time modified gt flag is set, and the dateUpdated date is less than the flag
-            if ((timeModifiedGtDateObject && timeModifiedGtDateObject > toDate(val.containers.cna.providerMetadata?.dateUpdated))) {
-              return false
-            }
-            // if the time modified lt flag is set, and the dateUpdated date is greater than the flag
-            if ((timeModifiedLtDateObject && timeModifiedLtDateObject < toDate(val.containers.cna.providerMetadata?.dateUpdated))) {
-              return false
-            }
-          } else {
-            // if cnaModified was set, but there is no value
-            return false
-          }
-        }
-        if (adpShortName) {
-          // Check to make sure we want to filter ADPs and that the CVE has an ADP container
-          if (val.containers?.adp && val.containers?.adp?.length) {
-          // Check all adp containers and if ANY of them have what we are searching for, return them
-            let adpMatchFound = false
-            for (const element of val.containers.adp) {
-              // If shortname is defined AND no dates are set, only check for the short name
-              if (element.providerMetadata.shortName === adpShortName) {
-                if (!timeModifiedGtDateObject && !timeModifiedLtDateObject) {
-                  adpMatchFound = true
-                  break
-                } else {
-                // otherwise we need to check the dates for a match
-                  if ((timeModifiedGtDateObject && timeModifiedGtDateObject < toDate(element.providerMetadata?.dateUpdated))) {
-                    adpMatchFound = true
-                    break
-                  }
-                  if (timeModifiedLtDateObject && timeModifiedLtDateObject > toDate(element.providerMetadata?.dateUpdated)) {
-                    adpMatchFound = true
-                    break
-                  }
-                }
-              }
-            }
-            if (!adpMatchFound) {
-              return false
-            }
-          } else {
-            // if adpShortName was set, BUT we didn't find anything
-            return false
-          }
-        }
-        return true
-      })
+      cveRecords: pg.itemsList.map(val => { return val.cve })
     }
 
     if (pg.itemCount >= CONSTANTS.PAGINATOR_OPTIONS.limit) {

--- a/src/controller/cve.controller/error.js
+++ b/src/controller/cve.controller/error.js
@@ -98,6 +98,13 @@ class CveControllerError extends idrErr.IDRError {
     return err
   }
 
+  badUsageOfCnaModified () {
+    const err = {}
+    err.error = 'BAD_USAGE_CNA_MODIFIED'
+    err.message = 'cna_modified must be used with the time modified parameter'
+    return err
+  }
+
   badAdpFormat () { // cve
     const err = {}
     err.error = 'BAD_ADP_FORMAT'

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -199,7 +199,7 @@ const doc = {
       adpShortName: {
         in: 'query',
         name: 'adp_short_name',
-        description: 'Only get CVE records that have an adpContainer owned by this org and that has been modified/created within the set time_modified range. Requires at least one time_modified parameter set',
+        description: 'Only get CVE records that have an adpContainer owned by this org.',
         required: false,
         schema: {
           type: 'string'

--- a/test/integration-tests/cve/getCveCnaModifiedTest.js
+++ b/test/integration-tests/cve/getCveCnaModifiedTest.js
@@ -18,28 +18,6 @@ describe('Test cna_modified parameter for get CVE', () => {
     await helpers.cveRequestAsCnaHelper(cveId)
   })
   context('Positive Test', () => {
-    it('CVE should be returned with cna_modified true as it has been created', async () => {
-      await chai.request(app)
-        .get('/api/cve/?cna_modified=true')
-        .set(constants.headers)
-        .then((res, err) => {
-          expect(err).to.be.undefined
-          expect(res).to.have.status(200)
-          expect(_.some(res.body.cveRecords, { cveMetadata: { cveId: cveId } })).to.be.true
-        })
-    })
-    it('Get CVE with cna_modified set to true should be returned after being edited', async () => {
-      // Edit the CNA container
-      await helpers.cveUpdatetAsCnaHelperWithCnaContainer(cveId, constants.testCveEdited)
-      await chai.request(app)
-        .get('/api/cve/?cna_modified=true')
-        .set(constants.headers)
-        .then((res, err) => {
-          expect(err).to.be.undefined
-          expect(res).to.have.status(200)
-          expect(_.some(res.body.cveRecords, { cveMetadata: { cveId: cveId } })).to.be.true
-        })
-    })
     it('Get CVE with cna_modified set to true AND date.gt should return when searched with a known earlier than date', async () => {
       await chai.request(app)
         .get('/api/cve/?time_modified.gt=2022-01-01T00:00:00&cna_modified=true')
@@ -79,6 +57,28 @@ describe('Test cna_modified parameter for get CVE', () => {
           expect(err).to.be.undefined
           expect(res).to.have.status(200)
           expect(_.some(res.body.cveRecords, { cveMetadata: { cveId: cveId } })).to.be.false
+        })
+    })
+  })
+  context('Negative Tests', () => {
+    it('CVE should be returned with cna_modified true as it has been created', async () => {
+      await chai.request(app)
+        .get('/api/cve/?cna_modified=true')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+        })
+    })
+    it('Get CVE with cna_modified set to true should be returned after being edited', async () => {
+      // Edit the CNA container
+      await helpers.cveUpdatetAsCnaHelperWithCnaContainer(cveId, constants.testCveEdited)
+      await chai.request(app)
+        .get('/api/cve/?cna_modified=true')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
         })
     })
   })


### PR DESCRIPTION
Closes Issue #1114 

# Summary
The previous implementation of the adp_short_name and cna_modified parameters would filter _after_ pagination. Therefore all pages would be returned, and a vast majority would be empty. This fix now filters _pre_ pagination.

This implementation allows for the adp_short_name parameter to no longer require a time specified. 

# Important Changes
`src/controller/cve.controller/cve.controller.js`

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) run the following command `npm run test:integration`

