### PR TITLE
Resolves #1006 added specific error handler for $ in x_fields

### DIFF
--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -588,13 +588,14 @@ async function updateCna (req, res, next) {
       return res.status(400).json(error.invalidCnaContainerJsonSchema(result.errors))
     }
 
-    await cveRepo.updateByCveId(id, cveModel)
-    // change cve id state to publish
-    if (cveId.state === CONSTANTS.CVE_STATES.REJECTED) {
-      result = await cveIdRepo.updateByCveId(id, { state: CONSTANTS.CVE_STATES.PUBLISHED })
-      if (!result) {
-        return res.status(500).json(error.serverError())
+    try {
+      await cveRepo.updateByCveId(id, cveModel)
+      // change cve id state to publish
+      if (cveId.state === CONSTANTS.CVE_STATES.REJECTED) {
+        await cveIdRepo.updateByCveId(id, { state: CONSTANTS.CVE_STATES.PUBLISHED })
       }
+    } catch (err) {
+      return res.status(400).json(error.unableToStoreCveRecord())
     }
 
     const responseMessage = {

--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -592,7 +592,11 @@ async function updateCna (req, res, next) {
       await cveRepo.updateByCveId(id, cveModel)
       // change cve id state to publish
       if (cveId.state === CONSTANTS.CVE_STATES.REJECTED) {
-        await cveIdRepo.updateByCveId(id, { state: CONSTANTS.CVE_STATES.PUBLISHED })
+        result = await cveIdRepo.updateByCveId(id, { state: CONSTANTS.CVE_STATES.PUBLISHED })
+
+        if (!result) {
+          return res.status(400).json(error.unableToStoreCveRecord())
+        }
       }
     } catch (err) {
       return res.status(400).json(error.unableToStoreCveRecord())

--- a/test/unit-tests/cve/cveCnaContainerUpdateTest.js
+++ b/test/unit-tests/cve/cveCnaContainerUpdateTest.js
@@ -238,9 +238,9 @@ describe('Testing the PUT /cve/:id/cna endpoint in Cve Controller', () => {
             done(err)
           }
 
-          expect(res).to.have.status(500)
+          expect(res).to.have.status(400)
           expect(res).to.have.property('body').and.to.be.a('object')
-          const errObj = error.serverError()
+          const errObj = error.unableToStoreCveRecord()
           expect(res.body.error).to.equal(errObj.error)
           expect(res.body.message).to.equal(errObj.message)
           done()

--- a/test/unit-tests/cve/cveCnaContainerUpdateTest.js
+++ b/test/unit-tests/cve/cveCnaContainerUpdateTest.js
@@ -228,7 +228,7 @@ describe('Testing the PUT /cve/:id/cna endpoint in Cve Controller', () => {
         })
     })
 
-    it('should return 500 when fails to update cve id state', (done) => {
+    it('should return 400 when fails to update cve id state', (done) => {
       chai.request(app)
         .put(`/cve-cna-negative-tests/${cveIdPublished5}`)
         .set(cveFixtures.secretariatHeader)


### PR DESCRIPTION
Closes #1006

# Summary
Added error handler and specific error message to handle `$` in `x_` fields, because these aren't allowed in DocDB and need to be handled.

# Important Changes
`cve.controller.js`
- added `Try...Catch` in `updateCna` function to throw a 400 for `$`s  .

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Ensure the correct error is thrown when `$` are in a `x_` field in the cnaContainer. 

# Notes
- This is only an error with DocDB and will not occur running with MongoDB locally.
