### PR TITLE
Resolves issue #836 - Update access management workflow in updateUser

### DIFF
--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -544,7 +544,6 @@ async function updateUser (req, res, next) {
     const shortName = req.ctx.params.shortname
     const newUser = new User()
     let newOrgShortName = null
-    let changesRequirePrivilegedRole = false // Set variable to true if protected fields are being modified
     const removeRoles = []
     const addRoles = []
     const userRepo = req.ctx.repositories.getUserRepository()
@@ -584,15 +583,33 @@ async function updateUser (req, res, next) {
     newUser.name.middle = user.name.middle
     newUser.name.suffix = user.name.suffix
 
+    const queryParameterPermissions = {
+      new_username: true,
+      org_short_name: true,
+      'name.first': false,
+      'name.last': false,
+      'name.middle': false,
+      'name.suffix': false,
+      active: true,
+      'active_roles.add': true,
+      'active_roles.remove': true
+
+    }
+
+    // Check to ensure that the user has the right permissions to edit the fields tha they are requesting to edit, and fail fast if they do not.
+    if (Object.keys(req.ctx.query).length > 0 && Object.keys(req.ctx.query).some((key) => { return queryParameterPermissions[key] }) && !(isAdmin || isSecretariat)) {
+      logger.info({ uuid: req.ctx.uuid, message: 'The user could not be updated because ' + requesterUsername + ' user is not Org Admin or Secretariat to modify these fields.' })
+      console.log('in failed admin')
+      return res.status(403).json(error.notOrgAdminOrSecretariatUpdate())
+    }
+
     for (const k in req.ctx.query) {
       const key = k.toLowerCase()
 
       if (key === 'new_username') {
         newUser.username = req.ctx.query.new_username
-        changesRequirePrivilegedRole = true
       } else if (key === 'org_short_name') {
         newOrgShortName = req.ctx.query.org_short_name
-        changesRequirePrivilegedRole = true
         if (!isSecretariat) {
           logger.info({ uuid: req.ctx.uuid, message: 'The user could not be updated because ' + requesterUsername + ' is an Org Admin and tried to reassign the organization.' })
           return res.status(403).json(error.notAllowedToChangeOrganization())
@@ -607,13 +624,11 @@ async function updateUser (req, res, next) {
         newUser.name.suffix = req.ctx.query['name.suffix']
       } else if (key === 'active') {
         newUser.active = booleanIsTrue(req.ctx.query.active)
-        changesRequirePrivilegedRole = true
       } else if (key === 'active_roles.add') {
         if (Array.isArray(req.ctx.query['active_roles.add'])) {
           req.ctx.query['active_roles.add'].forEach(r => {
             addRoles.push(r)
           })
-          changesRequirePrivilegedRole = true
         }
       } else if (key === 'active_roles.remove') {
         if (Array.isArray(req.ctx.query['active_roles.remove'])) {
@@ -624,15 +639,8 @@ async function updateUser (req, res, next) {
             }
             removeRoles.push(r)
           }
-          changesRequirePrivilegedRole = true
         }
       }
-    }
-
-    // Check for correct privileges if the requested changes require them
-    if (changesRequirePrivilegedRole && !(isAdmin || isSecretariat)) {
-      logger.info({ uuid: req.ctx.uuid, message: 'The user could not be updated because ' + requesterUsername + ' user is not Org Admin or Secretariat to modify these fields.' })
-      return res.status(403).json(error.notOrgAdminOrSecretariatUpdate())
     }
 
     // check if the new org exist

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -596,6 +596,12 @@ async function updateUser (req, res, next) {
 
     }
 
+    // Specific check for org_short_name
+    if (Object.keys(req.ctx.query).length > 0 && Object.keys(req.ctx.query).includes('org_short_name') && !(isSecretariat)) {
+      logger.info({ uuid: req.ctx.uuid, message: 'The user could not be updated because ' + requesterUsername + ' is an Org Admin and tried to reassign the organization.' })
+      return res.status(403).json(error.notAllowedToChangeOrganization())
+    }
+
     // Check to ensure that the user has the right permissions to edit the fields tha they are requesting to edit, and fail fast if they do not.
     if (Object.keys(req.ctx.query).length > 0 && Object.keys(req.ctx.query).some((key) => { return queryParameterPermissions[key] }) && !(isAdmin || isSecretariat)) {
       logger.info({ uuid: req.ctx.uuid, message: 'The user could not be updated because ' + requesterUsername + ' user is not Org Admin or Secretariat to modify these fields.' })
@@ -610,10 +616,6 @@ async function updateUser (req, res, next) {
         newUser.username = req.ctx.query.new_username
       } else if (key === 'org_short_name') {
         newOrgShortName = req.ctx.query.org_short_name
-        if (!isSecretariat) {
-          logger.info({ uuid: req.ctx.uuid, message: 'The user could not be updated because ' + requesterUsername + ' is an Org Admin and tried to reassign the organization.' })
-          return res.status(403).json(error.notAllowedToChangeOrganization())
-        }
       } else if (key === 'name.first') {
         newUser.name.first = req.ctx.query['name.first']
       } else if (key === 'name.last') {

--- a/test-http/src/test/org_user_tests/regular_users.py
+++ b/test-http/src/test/org_user_tests/regular_users.py
@@ -75,19 +75,6 @@ def test_regular_user_cannot_update_duplicate_user_with_new_username(reg_user_he
     response_contains_json(res, 'error', 'NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
 
 
-def test_regular_user_cannot_update_organization_with_new_shortname(reg_user_headers):
-    """ regular users cannot update organization """
-    user = reg_user_headers['CVE-API-USER']
-    org1 = reg_user_headers['CVE-API-ORG']
-    org2 = str(uuid.uuid4())[:MAX_SHORTNAME_LENGTH]
-    res = requests.put(
-        f'{env.AWG_BASE_URL}{ORG_URL}/{org1}/user/{user}?org_short_name={org2}',
-        headers=reg_user_headers
-    )
-    assert res.status_code == 403
-    response_contains_json(res, 'error', 'NOT_ALLOWED_TO_CHANGE_ORGANIZATION')
-
-
 def test_regular_user_cannot_update_active_state(reg_user_headers):
     """ regular user cannot change its own active state """
     org = reg_user_headers['CVE-API-ORG']

--- a/test-http/src/test/org_user_tests/regular_users.py
+++ b/test-http/src/test/org_user_tests/regular_users.py
@@ -75,6 +75,19 @@ def test_regular_user_cannot_update_duplicate_user_with_new_username(reg_user_he
     response_contains_json(res, 'error', 'NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
 
 
+def test_regular_user_cannot_update_organization_with_new_shortname(reg_user_headers):
+    """ regular users cannot update organization """
+    user = reg_user_headers['CVE-API-USER']
+    org1 = reg_user_headers['CVE-API-ORG']
+    org2 = str(uuid.uuid4())[:MAX_SHORTNAME_LENGTH]
+    res = requests.put(
+        f'{env.AWG_BASE_URL}{ORG_URL}/{org1}/user/{user}?org_short_name={org2}',
+        headers=reg_user_headers
+    )
+    assert res.status_code == 403
+    response_contains_json(res, 'error', 'NOT_ALLOWED_TO_CHANGE_ORGANIZATION')
+
+
 def test_regular_user_cannot_update_active_state(reg_user_headers):
     """ regular user cannot change its own active state """
     org = reg_user_headers['CVE-API-ORG']

--- a/test/integration-tests/user/createUserTest.js
+++ b/test/integration-tests/user/createUserTest.js
@@ -21,6 +21,20 @@ const body = {
     active_roles: ['Admin']
   }
 }
+
+const nonAdminBody = {
+  username: 'nonAdminUser',
+  active: 'true',
+  name: {
+    first: 'TestCnaAdmin',
+    last: 'test',
+    middle: 'N',
+    suffix: 'I'
+  },
+  authority: {
+  }
+}
+
 describe('Testing create user endpoint', () => {
   it('Should return 200 and new user', (done) => {
     chai.request(app)
@@ -31,6 +45,19 @@ describe('Testing create user endpoint', () => {
         expect(err).to.be.null
         expect(res.body).to.have.property('created')
         expect(res.body.created.username).to.equal(body.username)
+        expect(res).to.have.status(200)
+        done()
+      })
+  })
+  it('Should return 200 and create a non admin user', (done) => {
+    chai.request(app)
+      .post('/api/org/range_4/user')
+      .set(constants.headers)
+      .send(nonAdminBody)
+      .end((err, res) => {
+        expect(err).to.be.null
+        expect(res.body).to.have.property('created')
+        expect(res.body.created.username).to.equal(nonAdminBody.username)
         expect(res).to.have.status(200)
         done()
       })

--- a/test/integration-tests/user/updateUserTest.js
+++ b/test/integration-tests/user/updateUserTest.js
@@ -1,0 +1,33 @@
+/* eslint-disable no-unused-expressions */
+
+const chai = require('chai')
+chai.use(require('chai-http'))
+
+const expect = chai.expect
+
+const constants = require('../constants.js')
+const app = require('../../../src/index.js')
+
+describe('Testing Edit user endpoint', () => {
+  context('User edit tests', () => {
+    it('Should return 200 when only name changes are done', async () => {
+      await chai.request(app)
+        .put('/api/org/win_5/user/jasminesmith@win_5.com?name.first=NewName')
+        .set(constants.nonSecretariatUserHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+        })
+    })
+    it('Should return an error when admin is required', async () => {
+      await chai.request(app)
+        .put('/api/org/win_5/user/jasminesmith@win_5.com?new_username=NewUsername')
+        .set(constants.nonSecretariatUserHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
+        })
+    })
+  })
+})


### PR DESCRIPTION
Closes Issue #836 

# Summary
This PR updates the authentication workflow in the userUpdate function to fail fast if the user is trying to make changes to fields that are protected. 

# Important Changes
- `src/controller/org.controller/org.controller.js`
- `test/integration-tests/user/updateUserTest.js`

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) run the integration tests: `npm run test:integration`
