### PR TITLE
Resolves issue #958 and #957 - Move away from validate-date to luxon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
                 "JSONStream": "^1.3.5",
                 "kleur": "^4.1.4",
                 "lodash": "^4.17.21",
+                "luxon": "^3.4.4",
                 "mongo-cursor-pagination": "^8.1.3",
                 "mongoose": "^5.13.20",
                 "mongoose-aggregate-paginate-v2": "1.0.6",
@@ -36,7 +37,6 @@
                 "swagger-autogen": "^2.19.0",
                 "swagger-ui-express": "^4.3.0",
                 "uuid": "^8.3.2",
-                "validate-date": "^2.0.0",
                 "validator": ">=13.7.0",
                 "winston": "^3.2.1",
                 "yamljs": "^0.3.0"
@@ -5673,6 +5673,14 @@
                 "yallist": "^3.0.2"
             }
         },
+        "node_modules/luxon": {
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+            "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -9837,11 +9845,6 @@
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
             "dev": true
-        },
-        "node_modules/validate-date": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/validate-date/-/validate-date-2.0.0.tgz",
-            "integrity": "sha512-DmRIajI6qR/j3JibfDaQsar2IYIUdRUPRBgo/M/kcl6CR5aWb3CsNTX2tdgu2KD3oAMpfXfuJncP30Z3xNHAJg=="
         },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
@@ -14584,6 +14587,11 @@
                 "yallist": "^3.0.2"
             }
         },
+        "luxon": {
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+            "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA=="
+        },
         "make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -17703,11 +17711,6 @@
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
             "dev": true
-        },
-        "validate-date": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/validate-date/-/validate-date-2.0.0.tgz",
-            "integrity": "sha512-DmRIajI6qR/j3JibfDaQsar2IYIUdRUPRBgo/M/kcl6CR5aWb3CsNTX2tdgu2KD3oAMpfXfuJncP30Z3xNHAJg=="
         },
         "validate-npm-package-license": {
             "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "JSONStream": "^1.3.5",
         "kleur": "^4.1.4",
         "lodash": "^4.17.21",
+        "luxon": "^3.4.4",
         "mongo-cursor-pagination": "^8.1.3",
         "mongoose": "^5.13.20",
         "mongoose-aggregate-paginate-v2": "1.0.6",
@@ -54,7 +55,6 @@
         "swagger-autogen": "^2.19.0",
         "swagger-ui-express": "^4.3.0",
         "uuid": "^8.3.2",
-        "validate-date": "^2.0.0",
         "validator": ">=13.7.0",
         "winston": "^3.2.1",
         "yamljs": "^0.3.0"

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,7 +1,7 @@
 const Org = require('../model/org')
 const User = require('../model/user')
 const getConstants = require('../constants').getConstants
-const validateDate = require('validate-date')
+const { DateTime } = require('luxon')
 
 async function getOrgUUID (shortName) {
   const org = await Org.findOne().byShortName(shortName)
@@ -140,16 +140,13 @@ function toDate (val) {
   if (value) {
     const dateStr = value[0]
     // Make sure that the string passed is a valid date
-    // eslint doesn't like that responseType is not defined, but it is needed as is
-    /* eslint-disable-next-line */
-    const valid = validateDate(dateStr.toString().substring(0, 10), responseType = 'boolean')
-    if (valid) {
+    if (DateTime.fromISO(dateStr.toString()).isValid) {
       result = new Date(dateStr)
     }
   } else {
     value = val.match(/^\d{4}-\d{2}-\d{2}$/)
     /* eslint-disable-next-line */
-    if ((value) && (validateDate(value.toString().substring(0, 10), responseType = 'boolean'))) {
+    if ((value) && DateTime.fromISO(dateStr.toString()).isValid) {
       result = new Date(`${value[0]}T00:00:00.000+00:00`)
     }
   }

--- a/test/integration-tests/cve-id/getCveIdTest.js
+++ b/test/integration-tests/cve-id/getCveIdTest.js
@@ -100,5 +100,26 @@ describe('Testing Get CVE-ID endpoint', () => {
           expect(res.body.cve_ids).to.have.length(PUB_YEAR_COUNT)
         })
     })
+    it('Z format should be be valid', async () => {
+      await chai.request(app)
+        .get('/api/cve-id?time_modified.gt=2024-01-15T00:00:01-02:00')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+        })
+    })
+  })
+  context('negative tests', () => {
+    it('Feb 29 2100 should not be valid', async () => {
+      await chai.request(app)
+        .get('/api/cve-id?time_modified.gt=2100-02-29T00:00:00Z')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.contain('BAD_INPUT')
+        })
+    })
   })
 })


### PR DESCRIPTION
Closes Issue #958 and #957 

# Summary
Moves away from `validate-date` (1600 downloads a week)  to more popular heavily developed `luxon` (~7 million weekly downloads).

# Important Changes
`src/utils/utils.js`
`package.json`

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run the integrations tests: `npm run test:integration`
