### PR TITLE
#1158 Added type check to `validateDatePublic`

### DIFF
--- a/datadump/pre-population/cve-ids-range.json
+++ b/datadump/pre-population/cve-ids-range.json
@@ -1,363 +1,363 @@
 [
     {
-      "cve_year": 1999,
-      "ranges": {
-          "priority": {
-              "top_id": 5000,
-              "start": 5000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 1999,
+        "ranges": {
+            "priority": {
+                "top_id": 5000,
+                "start": 5000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2000,
-      "ranges": {
-          "priority": {
-              "top_id": 5000,
-              "start": 5000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2000,
+        "ranges": {
+            "priority": {
+                "top_id": 5000,
+                "start": 5000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2001,
-      "ranges": {
-          "priority": {
-              "top_id": 5000,
-              "start": 5000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2001,
+        "ranges": {
+            "priority": {
+                "top_id": 5000,
+                "start": 5000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2002,
-      "ranges": {
-          "priority": {
-              "top_id": 5000,
-              "start": 5000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2002,
+        "ranges": {
+            "priority": {
+                "top_id": 5000,
+                "start": 5000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2003,
-      "ranges": {
-          "priority": {
-              "top_id": 5000,
-              "start": 5000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2003,
+        "ranges": {
+            "priority": {
+                "top_id": 5000,
+                "start": 5000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2004,
-      "ranges": {
-          "priority": {
-              "top_id": 10000,
-              "start": 10000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2004,
+        "ranges": {
+            "priority": {
+                "top_id": 10000,
+                "start": 10000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2005,
-      "ranges": {
-          "priority": {
-              "top_id": 10000,
-              "start": 10000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2005,
+        "ranges": {
+            "priority": {
+                "top_id": 10000,
+                "start": 10000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2006,
-      "ranges": {
-          "priority": {
-              "top_id": 10000,
-              "start": 10000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2006,
+        "ranges": {
+            "priority": {
+                "top_id": 10000,
+                "start": 10000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2007,
-      "ranges": {
-          "priority": {
-              "top_id": 10000,
-              "start": 10000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2007,
+        "ranges": {
+            "priority": {
+                "top_id": 10000,
+                "start": 10000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2008,
-      "ranges": {
-          "priority": {
-              "top_id": 10000,
-              "start": 10000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2008,
+        "ranges": {
+            "priority": {
+                "top_id": 10000,
+                "start": 10000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2009,
-      "ranges": {
-          "priority": {
-              "top_id": 10000,
-              "start": 10000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2009,
+        "ranges": {
+            "priority": {
+                "top_id": 10000,
+                "start": 10000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2010,
-      "ranges": {
-          "priority": {
-              "top_id": 10000,
-              "start": 10000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2010,
+        "ranges": {
+            "priority": {
+                "top_id": 10000,
+                "start": 10000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2011,
-      "ranges": {
-          "priority": {
-              "top_id": 10000,
-              "start": 10000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2011,
+        "ranges": {
+            "priority": {
+                "top_id": 10000,
+                "start": 10000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2012,
-      "ranges": {
-          "priority": {
-              "top_id": 10000,
-              "start": 10000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2012,
+        "ranges": {
+            "priority": {
+                "top_id": 10000,
+                "start": 10000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2013,
-      "ranges": {
-          "priority": {
-              "top_id": 10000,
-              "start": 10000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2013,
+        "ranges": {
+            "priority": {
+                "top_id": 10000,
+                "start": 10000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2014,
-      "ranges": {
-          "priority": {
-              "top_id": 125000,
-              "start": 125000,
-              "end": 125000
-          },
-          "general": {
-              "top_id": 125000,
-              "start": 125000,
-              "end": 450000
-          }
-      }
+        "cve_year": 2014,
+        "ranges": {
+            "priority": {
+                "top_id": 125000,
+                "start": 125000,
+                "end": 125000
+            },
+            "general": {
+                "top_id": 125000,
+                "start": 125000,
+                "end": 450000
+            }
+        }
     },
     {
-      "cve_year": 2015,
-      "ranges": {
-          "priority": {
-              "top_id": 10000,
-              "start": 10000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 999999
-          }
-      }
+        "cve_year": 2015,
+        "ranges": {
+            "priority": {
+                "top_id": 10000,
+                "start": 10000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 999999
+            }
+        }
     },
     {
-      "cve_year": 2016,
-      "ranges": {
-          "priority": {
-              "top_id": 15000,
-              "start": 15000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 550000
-          }
-      }
+        "cve_year": 2016,
+        "ranges": {
+            "priority": {
+                "top_id": 15000,
+                "start": 15000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 550000
+            }
+        }
     },
     {
-      "cve_year": 2017,
-      "ranges": {
-          "priority": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 999999
-          }
-      }
+        "cve_year": 2017,
+        "ranges": {
+            "priority": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 999999
+            }
+        }
     },
     {
-      "cve_year": 2018,
-      "ranges": {
-          "priority": {
-              "top_id": 25000,
-              "start": 25000,
-              "end": 25000
-          },
-          "general": {
-              "top_id": 25000,
-              "start": 25000,
-              "end": 550000
-          }
-      }
+        "cve_year": 2018,
+        "ranges": {
+            "priority": {
+                "top_id": 25000,
+                "start": 25000,
+                "end": 25000
+            },
+            "general": {
+                "top_id": 25000,
+                "start": 25000,
+                "end": 550000
+            }
+        }
     },
     {
-      "cve_year": 2019,
-      "ranges": {
-          "priority": {
-              "top_id": 25000,
-              "start": 25000,
-              "end": 25000
-          },
-          "general": {
-              "top_id": 25000,
-              "start": 25000,
-              "end": 999999
-          }
-      }
+        "cve_year": 2019,
+        "ranges": {
+            "priority": {
+                "top_id": 25000,
+                "start": 25000,
+                "end": 25000
+            },
+            "general": {
+                "top_id": 25000,
+                "start": 25000,
+                "end": 999999
+            }
+        }
     },
     {
-      "cve_year": 2020,
-      "ranges": {
-          "priority": {
-              "top_id": 35000,
-              "start": 35000,
-              "end": 35000
-          },
-          "general": {
-              "top_id": 35000,
-              "start": 35000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2020,
+        "ranges": {
+            "priority": {
+                "top_id": 35000,
+                "start": 35000,
+                "end": 35000
+            },
+            "general": {
+                "top_id": 35000,
+                "start": 35000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2021,
-      "ranges": {
-          "priority": {
-              "top_id": 3000,
-              "start": 3000,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2021,
+        "ranges": {
+            "priority": {
+                "top_id": 3000,
+                "start": 3000,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
-      "cve_year": 2022,
-      "ranges": {
-          "priority": {
-              "top_id": 0,
-              "start": 0,
-              "end": 20000
-          },
-          "general": {
-              "top_id": 20000,
-              "start": 20000,
-              "end": 50000000
-          }
-      }
+        "cve_year": 2022,
+        "ranges": {
+            "priority": {
+                "top_id": 0,
+                "start": 0,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
     },
     {
         "cve_year": 2023,
@@ -373,6 +373,20 @@
                 "end": 50000000
             }
         }
-      }
-  ]
-  
+    },
+    {
+        "cve_year": 2024,
+        "ranges": {
+            "priority": {
+                "top_id": 0,
+                "start": 0,
+                "end": 20000
+            },
+            "general": {
+                "top_id": 20000,
+                "start": 20000,
+                "end": 50000000
+            }
+        }
+    }
+]

--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -156,7 +156,7 @@ function validateCveCnaContainerJsonSchema (req, res, next) {
  */
 function validateDatePublic (dateIndex) {
   // Check if datePublic is a future date
-  return body(dateIndex).optional({ nullable: true }).custom((datePublic) => {
+  return body(dateIndex).isString().withMessage('DatePublic must be a date string').optional({ nullable: true }).bail().custom((datePublic) => {
     if (datePublicHelper(datePublic)) {
       return true
     }


### PR DESCRIPTION

Closes Issue #1158

# Summary
Added validation to ensure type `string` to the `validateDatePublic` middleware. 

# Important Changes
`cve.middleware.js`
- Added `isString()` check to `validateDatePublic`
- Added `bail()` to `validateDatePublic` validation chain to break the chain if `isString()` is failed

