### PR TITLE
Resolves issue #1157 - Fixes incorrect implementation of character length limitations. 

### DIFF
--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -726,10 +726,10 @@ router.put('/org/:shortname/user/:username',
   query(['active']).optional().isBoolean({ loose: true }),
   query(['new_username']).optional().isString().trim().notEmpty().custom(isValidUsername),
   query(['org_short_name']).optional().isString().trim().notEmpty().isLength({ min: CONSTANTS.MIN_SHORTNAME_LENGTH, max: CONSTANTS.MAX_SHORTNAME_LENGTH }),
-  body(['name.first']).optional().isString().trim().isLength({ max: CONSTANTS.MAX_FIRSTNAME_LENGTH }).withMessage(errorMsgs.FIRSTNAME_LENGTH),
-  body(['name.last']).optional().isString().trim().isLength({ max: CONSTANTS.MAX_LASTNAME_LENGTH }).withMessage(errorMsgs.LASTNAME_LENGTH),
-  body(['name.middle']).optional().isString().trim().isLength({ max: CONSTANTS.MAX_MIDDLENAME_LENGTH }).withMessage(errorMsgs.MIDDLENAME_LENGTH),
-  body(['name.suffix']).optional().isString().trim().isLength({ max: CONSTANTS.MAX_SUFFIX_LENGTH }).withMessage(errorMsgs.SUFFIX_LENGTH),
+  query(['name.first']).optional().isString().trim().isLength({ max: CONSTANTS.MAX_FIRSTNAME_LENGTH }).withMessage(errorMsgs.FIRSTNAME_LENGTH),
+  query(['name.last']).optional().isString().trim().isLength({ max: CONSTANTS.MAX_LASTNAME_LENGTH }).withMessage(errorMsgs.LASTNAME_LENGTH),
+  query(['name.middle']).optional().isString().trim().isLength({ max: CONSTANTS.MAX_MIDDLENAME_LENGTH }).withMessage(errorMsgs.MIDDLENAME_LENGTH),
+  query(['name.suffix']).optional().isString().trim().isLength({ max: CONSTANTS.MAX_SUFFIX_LENGTH }).withMessage(errorMsgs.SUFFIX_LENGTH),
   query(['active_roles.add']).optional().toArray()
     .custom(isFlatStringArray)
     .customSanitizer(toUpperCaseArray)

--- a/test/integration-tests/user/updateUserTest.js
+++ b/test/integration-tests/user/updateUserTest.js
@@ -29,5 +29,41 @@ describe('Testing Edit user endpoint', () => {
           expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
         })
     })
+    it('Should not allow a first name of more than 100 characters', async () => {
+      await chai.request(app)
+        .put('/api/org/win_5/user/jasminesmith@win_5.com?name.first=1:1234567,2:1234567,3:1234567,4:1234567,5:1234567,6:1234567,7:1234567,8:1234567,9:1234567,10:1234567,11:1234567')
+        .set(constants.nonSecretariatUserHeaders)
+        .then((res, err) => {
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.contain('BAD_INPUT')
+        })
+    })
+    it('Should not allow a middle name of more than 100 characters', async () => {
+      await chai.request(app)
+        .put('/api/org/win_5/user/jasminesmith@win_5.com?name.middle=1:1234567,2:1234567,3:1234567,4:1234567,5:1234567,6:1234567,7:1234567,8:1234567,9:1234567,10:1234567,11:1234567')
+        .set(constants.nonSecretariatUserHeaders)
+        .then((res, err) => {
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.contain('BAD_INPUT')
+        })
+    })
+    it('Should not allow a last name of more than 100 characters', async () => {
+      await chai.request(app)
+        .put('/api/org/win_5/user/jasminesmith@win_5.com?name.last=1:1234567,2:1234567,3:1234567,4:1234567,5:1234567,6:1234567,7:1234567,8:1234567,9:1234567,10:1234567,11:1234567')
+        .set(constants.nonSecretariatUserHeaders)
+        .then((res, err) => {
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.contain('BAD_INPUT')
+        })
+    })
+    it('Should not allow a suffix of more than 100 characters', async () => {
+      await chai.request(app)
+        .put('/api/org/win_5/user/jasminesmith@win_5.com?name.suffix=1:1234567,2:1234567,3:1234567,4:1234567,5:1234567,6:1234567,7:1234567,8:1234567,9:1234567,10:1234567,11:1234567')
+        .set(constants.nonSecretariatUserHeaders)
+        .then((res, err) => {
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.contain('BAD_INPUT')
+        })
+    })
   })
 })


### PR DESCRIPTION
Closes Issue #1157 

# Summary

Previously (by me), character length limitations were implemented on the PUT body and not the PUT query parameters. In addition, tests were mistakenly only written for the POST endpoint. 

This has been fixed, and now correctly applied to the PUT query parameters, and correct tests have been implemented.

# Important Changes
`src/controller/org.controller/index.js`
`test/integration-tests/user/updateUserTest.js`

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run the following command: `npm run test:integration`
