### PR TITLE
#1159 Prevents possible toString override

### DIFF
--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -558,6 +558,7 @@ router.post('/org/:shortname/user',
   body(['name.suffix']).optional().isString().trim().isLength({ max: CONSTANTS.MAX_SUFFIX_LENGTH }).withMessage(errorMsgs.SUFFIX_LENGTH),
   body(['authority.active_roles']).optional()
     .custom(mw.isFlatStringArray)
+    .bail()
     .customSanitizer(toUpperCaseArray)
     .custom(isUserRole),
   parseError,
@@ -732,6 +733,7 @@ router.put('/org/:shortname/user/:username',
   query(['name.suffix']).optional().isString().trim().isLength({ max: CONSTANTS.MAX_SUFFIX_LENGTH }).withMessage(errorMsgs.SUFFIX_LENGTH),
   query(['active_roles.add']).optional().toArray()
     .custom(isFlatStringArray)
+    .bail()
     .customSanitizer(toUpperCaseArray)
     .custom(isUserRole).withMessage(errorMsgs.USER_ROLES),
   query(['active_roles.remove']).optional().toArray()


### PR DESCRIPTION

Closes Issue #1159

# Summary
Added `bail()` to break out of validation chain on first error for user creation and updates. 

# Important Changes
`org.controller/index.js`
- added `bail()` to PUT/POST user endpoints

