### PR TITLE
Removes calls to validateDatePublic

### DIFF
--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -149,6 +149,8 @@ function validateCveCnaContainerJsonSchema (req, res, next) {
 
 /**
  * Checks that datePublic field is not a future date
+ * Note: As of 01/10/24, this is not utilized. Further discussion is needed to agree on an
+ * implementation that will be less disruptive but still prevents invalid data.
  *
  * @param {String} dateIndex
  * @returns true

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -4,7 +4,7 @@ const mw = require('../../middleware/middleware')
 const errorMsgs = require('../../middleware/errorMessages')
 const controller = require('./cve.controller')
 const { body, param, query } = require('express-validator')
-const { parseGetParams, parsePostParams, parseError, validateCveCnaContainerJsonSchema, validateCveAdpContainerJsonSchema, validateRejectBody, validateUniqueEnglishEntry, validateDescription, validateDatePublic } = require('./cve.middleware')
+const { parseGetParams, parsePostParams, parseError, validateCveCnaContainerJsonSchema, validateCveAdpContainerJsonSchema, validateRejectBody, validateUniqueEnglishEntry, validateDescription } = require('./cve.middleware')
 const getConstants = require('../../constants').getConstants
 const CONSTANTS = getConstants()
 const CHOICES = [CONSTANTS.CVE_STATES.REJECTED, CONSTANTS.CVE_STATES.PUBLISHED]
@@ -442,7 +442,6 @@ router.post('/cve/:id',
   // the lang key to check depends on the state, so pass both
   validateUniqueEnglishEntry(['containers.cna.descriptions', 'containers.cna.rejectedReasons']),
   validateDescription(['containers.cna.rejectedReasons', 'containers.cna.descriptions', 'containers.cna.problemTypes[0].descriptions']),
-  validateDatePublic(['containers.cna.datePublic']),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
@@ -527,7 +526,6 @@ router.put('/cve/:id',
   // the lang key to check depends on the state, so pass both
   validateUniqueEnglishEntry(['containers.cna.descriptions', 'containers.cna.rejectedReasons']),
   validateDescription(['containers.cna.rejectedReasons', 'containers.cna.descriptions', 'containers.cna.problemTypes[0].descriptions']),
-  validateDatePublic(['containers.cna.datePublic']),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
@@ -613,7 +611,6 @@ router.post('/cve/:id/cna',
   validateCveCnaContainerJsonSchema,
   validateUniqueEnglishEntry('cnaContainer.descriptions'),
   validateDescription(['cnaContainer.descriptions', 'cnaContainer.problemTypes[0].descriptions']),
-  validateDatePublic(['cnaContainer.datePublic']),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
@@ -700,7 +697,6 @@ router.put('/cve/:id/cna',
   validateCveCnaContainerJsonSchema,
   validateUniqueEnglishEntry('cnaContainer.descriptions'),
   validateDescription(['cnaContainer.descriptions', 'cnaContainer.problemTypes[0].descriptions']),
-  validateDatePublic(['cnaContainer.datePublic']),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,
@@ -959,7 +955,6 @@ router.put('/cve/:id/adp',
   mw.validateUser,
   mw.onlyAdps,
   validateCveAdpContainerJsonSchema,
-  validateDatePublic(['adpContainer.datePublic']),
   param(['id']).isString().matches(CONSTANTS.CVE_ID_REGEX),
   parseError,
   parsePostParams,


### PR DESCRIPTION

# Summary
Removed calls to `validateDatePublic` as the current implementation is more disruptive than expected. Needs to be reworked based on future discussions.

