### PR TITLE
Resolves #1176 For GET /cve-id, redacts `requested_by.user` value for situations when cve-ids changes orgs, and when users change orgs

### DIFF
--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -122,7 +122,7 @@ async function getFilteredCveId (req, res, next) {
       cve_ids: pg.itemsList.map((i) => {
         const cnaid = i.requested_by.cna
         i.requested_by.cna = orgMap[cnaid].shortname
-        i.requested_by.user = orgMap[cnaid].users[i.requested_by.user]
+        i.requested_by.user = orgMap[cnaid].users[i.requested_by.user] ? orgMap[cnaid].users[i.requested_by.user] : 'REDACTED'
         i.owning_cna = orgMap[i.owning_cna].shortname
         return i
       })

--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -42,11 +42,14 @@ async function getFilteredCveId (req, res, next) {
     const users = await userRepo.getAllUsers()
 
     const orgMap = {}
+    const userMap = {}
+
     orgs.forEach(org => {
       orgMap[org.UUID] = { shortname: org.short_name, users: {} }
     })
 
     users.forEach(user => {
+      userMap[user.UUID] = user.username
       if (!orgMap[user.org_UUID]) {
         orgMap[user.org_UUID] = { shortname: `MISSING ORG ${user.org_UUID}`, users: {} }
       }
@@ -122,7 +125,31 @@ async function getFilteredCveId (req, res, next) {
       cve_ids: pg.itemsList.map((i) => {
         const cnaid = i.requested_by.cna
         i.requested_by.cna = orgMap[cnaid].shortname
-        i.requested_by.user = orgMap[cnaid].users[i.requested_by.user] ? orgMap[cnaid].users[i.requested_by.user] : 'REDACTED'
+
+        // User value is redacted in certain cases
+        // Checks if requested_by.user is in requested_by.cna org
+        if (!orgMap[cnaid].users[i.requested_by.user]) {
+          // Never redact for secretariat users
+          if (isSecretariat) {
+            i.requested_by.user = userMap[i.requested_by.user]
+          } else {
+            // Redact because requested_by.user is not in requested_by.cna org
+            i.requested_by.user = 'REDACTED'
+          }
+          // Check is current owning_cna is also requested_by.cna (if a CVE-ID changes orgs)
+        } else if (cnaid !== i.owning_cna) {
+          // Never redact for secretariat
+          if (isSecretariat) {
+            i.requested_by.user = userMap[i.requested_by.user]
+          } else {
+            // Redact because current owner is not requested_by.cna and shouldn't see requested_by.user
+            i.requested_by.user = 'REDACTED'
+          }
+        } else {
+          // No redaction, original requested_by.user is in requested_by.cna and owning_cna
+          i.requested_by.user = orgMap[cnaid].users[i.requested_by.user]
+        }
+
         i.owning_cna = orgMap[i.owning_cna].shortname
         return i
       })

--- a/test/integration-tests/constants.js
+++ b/test/integration-tests/constants.js
@@ -11,6 +11,18 @@ const nonSecretariatUserHeaders = {
   'CVE-API-USER': 'jasminesmith@win_5.com'
 }
 
+const nonSecretariatUserHeaders2 = {
+  'CVE-API-ORG': 'win_5',
+  'CVE-API-Key': 'TCF25YM-39C4H6D-KA32EGF-V5XSHN3',
+  'CVE-API-USER': 'win_5_admin@win_5.com'
+}
+
+const nonSecretariatUserHeaders3 = {
+  'CVE-API-ORG': 'evidence_15',
+  'CVE-API-Key': 'TCF25YM-39C4H6D-KA32EGF-V5XSHN3',
+  'CVE-API-USER': 'timothymyers@evidence_15.com'
+}
+
 const nonSecretariatUserHeadersWithAdp2 = {
   'CVE-API-ORG': 'range_4',
   'CVE-API-Key': 'TCF25YM-39C4H6D-KA32EGF-V5XSHN3',
@@ -272,6 +284,8 @@ const existingOrg = {
 module.exports = {
   headers,
   nonSecretariatUserHeaders,
+  nonSecretariatUserHeaders2,
+  nonSecretariatUserHeaders3,
   badNonSecretariatUserHeaders,
   nonSecretariatUserHeadersWithAdp2,
   testCve,

--- a/test/integration-tests/cve-id/getCveIdTest.js
+++ b/test/integration-tests/cve-id/getCveIdTest.js
@@ -7,6 +7,7 @@ const _ = require('lodash')
 const expect = chai.expect
 
 const constants = require('../constants.js')
+const helpers = require('../helpers.js')
 const app = require('../../../src/index.js')
 
 describe('Testing Get CVE-ID endpoint', () => {
@@ -107,6 +108,27 @@ describe('Testing Get CVE-ID endpoint', () => {
         .then((res, err) => {
           expect(err).to.be.undefined
           expect(res).to.have.status(200)
+        })
+    })
+    it('Should redact requested_by.user values not in requested_by.cna org', async () => {
+      const cveId = await helpers.cveIdReserveHelper(1, '2023', constants.nonSecretariatUserHeaders['CVE-API-ORG'], 'non-sequential')
+
+      // change users org for testing
+      await helpers.userOrgUpdateAsSecHelper(constants.nonSecretariatUserHeaders['CVE-API-USER'], constants.nonSecretariatUserHeaders['CVE-API-ORG'], 'mitre')
+
+      await chai.request(app)
+        .get('/api/cve-id?state=RESERVED')
+        .set(constants.headers)
+        .then(async (res, err) => {
+          const cveIdObject = _.find(res.body.cve_ids, obj => {
+            return obj.cve_id === cveId
+          })
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(cveIdObject.requested_by.user).to.equal('REDACTED')
+
+          // Reset user to original org
+          await helpers.userOrgUpdateAsSecHelper(constants.nonSecretariatUserHeaders['CVE-API-USER'], 'mitre', 'win_5')
         })
     })
   })

--- a/test/integration-tests/cve-id/getCveIdTest.js
+++ b/test/integration-tests/cve-id/getCveIdTest.js
@@ -110,7 +110,46 @@ describe('Testing Get CVE-ID endpoint', () => {
           expect(res).to.have.status(200)
         })
     })
-    it('Should redact requested_by.user values not in requested_by.cna org', async () => {
+    it('For non Secretariat users, should redact requested_by.user values not in requested_by.cna org', async () => {
+      const cveId = await helpers.cveIdReserveHelper(1, '2023', constants.nonSecretariatUserHeaders['CVE-API-ORG'], 'non-sequential')
+
+      // change users org for testing
+      await helpers.userOrgUpdateAsSecHelper(constants.nonSecretariatUserHeaders['CVE-API-USER'], constants.nonSecretariatUserHeaders['CVE-API-ORG'], 'mitre')
+
+      await chai.request(app)
+        .get('/api/cve-id?state=RESERVED')
+        .set(constants.nonSecretariatUserHeaders2)
+        .then(async (res, err) => {
+          const cveIdObject = _.find(res.body.cve_ids, obj => {
+            return obj.cve_id === cveId
+          })
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(cveIdObject.requested_by.user).to.equal('REDACTED')
+
+          // Reset user to original org
+          await helpers.userOrgUpdateAsSecHelper(constants.nonSecretariatUserHeaders['CVE-API-USER'], 'mitre', 'win_5')
+        })
+    })
+    it('For non Secretariat users, should redact requested_by.user values when requested_by.cna is not owning_cna', async () => {
+      const cveId = await helpers.cveIdReserveHelper(1, '2023', constants.nonSecretariatUserHeaders['CVE-API-ORG'], 'non-sequential')
+
+      // change cve-id's owning_org for testing
+      await helpers.updateOwningOrgAsSecHelper(cveId, constants.nonSecretariatUserHeaders3['CVE-API-ORG'])
+
+      await chai.request(app)
+        .get('/api/cve-id?state=RESERVED')
+        .set(constants.nonSecretariatUserHeaders3)
+        .then(async (res, err) => {
+          const cveIdObject = _.find(res.body.cve_ids, obj => {
+            return obj.cve_id === cveId
+          })
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(cveIdObject.requested_by.user).to.equal('REDACTED')
+        })
+    })
+    it('For Secretariat users, should redact requested_by.user values not in requested_by.cna org', async () => {
       const cveId = await helpers.cveIdReserveHelper(1, '2023', constants.nonSecretariatUserHeaders['CVE-API-ORG'], 'non-sequential')
 
       // change users org for testing
@@ -125,10 +164,28 @@ describe('Testing Get CVE-ID endpoint', () => {
           })
           expect(err).to.be.undefined
           expect(res).to.have.status(200)
-          expect(cveIdObject.requested_by.user).to.equal('REDACTED')
+          expect(cveIdObject.requested_by.user).to.equal(constants.nonSecretariatUserHeaders['CVE-API-USER'])
 
           // Reset user to original org
           await helpers.userOrgUpdateAsSecHelper(constants.nonSecretariatUserHeaders['CVE-API-USER'], 'mitre', 'win_5')
+        })
+    })
+    it('For Secretariat users, should redact requested_by.user values when requested_by.cna is not owning_cna', async () => {
+      const cveId = await helpers.cveIdReserveHelper(1, '2023', constants.nonSecretariatUserHeaders['CVE-API-ORG'], 'non-sequential')
+
+      // change cve-id's owning_org for testing
+      await helpers.updateOwningOrgAsSecHelper(cveId, constants.nonSecretariatUserHeaders3['CVE-API-ORG'])
+
+      await chai.request(app)
+        .get('/api/cve-id?state=RESERVED')
+        .set(constants.headers)
+        .then(async (res, err) => {
+          const cveIdObject = _.find(res.body.cve_ids, obj => {
+            return obj.cve_id === cveId
+          })
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(cveIdObject.requested_by.user).to.equal(constants.nonSecretariatUserHeaders['CVE-API-USER'])
         })
     })
   })

--- a/test/integration-tests/helpers.js
+++ b/test/integration-tests/helpers.js
@@ -96,6 +96,16 @@ async function cveUpdateAsCnaHelperWithAdpContainer (cveId, adpContainer) {
     })
 }
 
+async function userOrgUpdateAsSecHelper (userName, orgShortName, newOrgShortName) {
+  await chai.request(app)
+    .put(`/api/org/${orgShortName}/user/${userName}?org_short_name=${newOrgShortName}`)
+    .set(constants.headers)
+    .then((res, err) => {
+      // Safety Expect
+      expect(res).to.have.status(200)
+    })
+}
+
 module.exports = {
   cveIdReserveHelper,
   cveIdBulkReserveHelper,
@@ -104,5 +114,6 @@ module.exports = {
   cveRequestAsSecHelper,
   cveUpdatetAsCnaHelperWithCnaContainer,
   cveUpdateAsSecHelper,
-  cveUpdateAsCnaHelperWithAdpContainer
+  cveUpdateAsCnaHelperWithAdpContainer,
+  userOrgUpdateAsSecHelper
 }

--- a/test/integration-tests/helpers.js
+++ b/test/integration-tests/helpers.js
@@ -106,6 +106,16 @@ async function userOrgUpdateAsSecHelper (userName, orgShortName, newOrgShortName
     })
 }
 
+async function updateOwningOrgAsSecHelper (cveId, newOrgShortName) {
+  await chai.request(app)
+    .put(`/api/cve-id/${cveId}?org=${newOrgShortName}`)
+    .set(constants.headers)
+    .then((res, err) => {
+      // Safety Expect
+      expect(res).to.have.status(200)
+    })
+}
+
 module.exports = {
   cveIdReserveHelper,
   cveIdBulkReserveHelper,
@@ -115,5 +125,6 @@ module.exports = {
   cveUpdatetAsCnaHelperWithCnaContainer,
   cveUpdateAsSecHelper,
   cveUpdateAsCnaHelperWithAdpContainer,
-  userOrgUpdateAsSecHelper
+  userOrgUpdateAsSecHelper,
+  updateOwningOrgAsSecHelper
 }


### PR DESCRIPTION
Closes Issue #1176

# Summary
When calling the GET `/cve-id` endpoint as a non Secretariat user,  in the returned cve-id data, the`requested_by.user` value is now redacted when that user is not in the `requested_by.cna` organization. Also, the same value is redacted when the `owning_cna` is not the same organization as the `requested_by.cna` organization. 

# Important Changes
`cve-id.controller.js`
- Modified `getFiliteredCveId()` to check if `requested_by.user` is not part of `requested_by.cna` org .
- Modified `getFilteredCveId()` to check `owning_cna` is not the same org as `requested_by.cna` org.
- Added `REDACTED` value for the above situations.
- Added integration tests 

# Testing

Run `npm run test:integration` for automated testing.

Steps to manually test updated functionality, if possible
- [ ] 1) Substantial test data needs to be created for manual testing:
        - Create two test organizations: testOrgA and testOrgB
        - Create two users in testOrgA, and one user in testOrgB
        - Reserve 1 Cve-Id as user1 in testOrgA, and 1 Cve-Id as user2 in testOrgA
 - [ ]  2) As a Secretariat user, move user1 from testOrgA to testOrgB
 - [ ] 3) As user2 in testOrgA, call GET `/cve-id`. Both reserved Cve-ids should be shown, but one will have `requested_by.user`: `REDACTED`.
 - [ ] 4) As a Secretariat user, call PUT `/cve-id` on the second reserved Cve-id, and updating the org to testOrgB.
 - [ ] 5) As user1 in **testOrgB**, call GET `/cve-id`, one reserved Cve-Id should be returned with `requested_by.user` : `REDACTED` 

