### PR TITLE
Resolves #808 Updated docs to warn of possible race condition

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -1489,7 +1489,7 @@
           }
         },
         "requestBody": {
-          "description": "<h3>Notes:</h3>  <ul>  <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>  <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>  </ul>",
+          "description": "<h3>Notes:</h3>  <ul>  <li>When updating a rejected record to published, it is recommended to confirm that both the Cve-Id and CVE record are in the REJECTED state after calling this endpoint. Though very unlikely, a race condition can occur causing the two states to be out of sync. </li>  <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>  <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>  </ul>",
           "required": true,
           "content": {
             "application/json": {

--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -1693,7 +1693,7 @@
           }
         },
         "requestBody": {
-          "description": "<h3>Notes:</h3>  <ul>  <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>  <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>  </ul>",
+          "description": "<h3>Notes:</h3>  <ul>  <li>It is recommended to confirm that both the Cve-Id and CVE record are in the REJECTED state after calling this endpoint. Though very unlikely, a race condition can occur causing the two states to be out of sync. </li>  <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>  <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>  </ul>",
           "required": true,
           "content": {
             "application/json": {

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -643,6 +643,7 @@ router.put('/cve/:id/cna',
   #swagger.requestBody = {
      description: '<h3>Notes:</h3>
                   <ul>
+                    <li>When updating a rejected record to published, it is recommended to confirm that both the Cve-Id and CVE record are in the correct state after calling this endpoint. Though very unlikely, a race condition can occur causing the two states to be out of sync. </li>
                     <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>
                     <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>
                   </ul>',

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -824,11 +824,12 @@ router.put('/cve/:id/reject',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.requestBody = {
-     description: '<h3>Notes:</h3>
+     description: "<h3>Notes:</h3>
                   <ul>
+                    <li>It is recommended to confirm that both the Cve-Id and CVE record are in the REJECTED state after calling this endpoint. Though very unlikely, a race condition can occur causing the two states to be out of sync. </li>
                     <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>
                     <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>
-                  </ul>',
+                  </ul>",
     required: true,
     content: {
       "application/json": {


### PR DESCRIPTION

Closes Issue #808 

# Summary
Added documentation warning of possible race condition to PUT `/cve/{id}/cna` and PUT `/cve/{id}reject` docs in Swagger docs.

# Important Changes
`cve.controller/index.js`
- Added the above documentation.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Ensure Swagger docs correctly show new updates.

