### PR TITLE
Update workflow to no longer use unsupported action/upload-artifact

### DIFF
--- a/.github/workflows/test-http.yml
+++ b/.github/workflows/test-http.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         docker compose --file test-http/docker/docker-compose.yml exec -T demon pytest src/ | tee test-http/src/testOutput.txt
     - name: Archive Test Results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: test-results
         path: test-http/src/testOutput.txt


### PR DESCRIPTION
# Summary
actions/upload-artifact@v2 is no longer supported and is crashing PRs. This updates to the newest, v4.

# Important Changes
`.github/workflows/test-http.yml`
- Updated action version.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Check to see if pipeline passes.

