### PR TITLE
Closes issue 577 - Automatic reservation of new year within 90 days

### DIFF
--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -455,9 +455,22 @@ async function priorityReservation (year, amount, shortName, orgShortName, reque
 
   // Cve Id Range for 'year' does not exists
   if (!result) {
-    logger.info({ uuid: req.ctx.uuid, message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
-    res.header(CONSTANTS.QUOTA_HEADER, availableIds)
-    return res.status(403).json(error.cannotReserveForYear(year))
+    // If there are less than or equal to 90 days until the end of the year, auto reserve it and move on.
+    // Otherwise throw failure
+    if (daysUntilYear(year) <= 90) {
+      // Auto reserve the year
+      const successfullyReservedYear = await reserveYear(year, req)
+      if (!successfullyReservedYear) {
+        logger.info({ uuid: req.ctx.uuid, message: 'CVE IDs for year ' + year + ' failed to be automatically reserved at this time.' })
+        res.header(CONSTANTS.QUOTA_HEADER, availableIds)
+        return res.status(403).json(error.cannotReserveForYear(year))
+      }
+      result = await cveIdRangeRepo.findOne({ cve_year: year })
+    } else {
+      logger.info({ uuid: req.ctx.uuid, message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
+      res.header(CONSTANTS.QUOTA_HEADER, availableIds)
+      return res.status(403).json(error.cannotReserveForYear(year))
+    }
   }
 
   const endRange = parseInt(result.ranges.priority.end)
@@ -531,9 +544,22 @@ async function sequentialReservation (year, amount, shortName, orgShortName, req
 
   // Cve Id Range for 'year' does not exists
   if (!result) {
-    logger.info({ uuid: req.ctx.uuid, message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
-    res.header(CONSTANTS.QUOTA_HEADER, availableIds)
-    return res.status(403).json(error.cannotReserveForYear(year))
+    // If there are less than or equal to 90 days until the end of the year, auto reserve it and move on.
+    // Otherwise throw failure
+    if (daysUntilYear(year) <= 90) {
+      // Auto reserve the year
+      const successfullyReservedYear = await reserveYear(year, req)
+      if (!successfullyReservedYear) {
+        logger.info({ uuid: req.ctx.uuid, message: 'CVE IDs for year ' + year + ' failed to be automatically reserved at this time.' })
+        res.header(CONSTANTS.QUOTA_HEADER, availableIds)
+        return res.status(403).json(error.cannotReserveForYear(year))
+      }
+      result = await cveIdRangeRepo.findOne({ cve_year: year })
+    } else {
+      logger.info({ uuid: req.ctx.uuid, message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
+      res.header(CONSTANTS.QUOTA_HEADER, availableIds)
+      return res.status(403).json(error.cannotReserveForYear(year))
+    }
   }
 
   const topId = parseInt(result.ranges.general.top_id)
@@ -627,9 +653,22 @@ async function nonSequentialReservation (year, amount, shortName, orgShortName, 
 
   // Cve Id Range for 'year' does not exists
   if (!result) {
-    logger.info({ uuid: req.ctx.uuid, message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
-    res.header(CONSTANTS.QUOTA_HEADER, availableIds)
-    return res.status(403).json(error.cannotReserveForYear(year))
+    // If there are less than or equal to 90 days until the end of the year, auto reserve it and move on.
+    // Otherwise throw failure
+    if (daysUntilYear(year) <= 90) {
+      // Auto reserve the year
+      const successfullyReservedYear = await reserveYear(year, req)
+      if (!successfullyReservedYear) {
+        logger.info({ uuid: req.ctx.uuid, message: 'CVE IDs for year ' + year + ' failed to be automatically reserved at this time.' })
+        res.header(CONSTANTS.QUOTA_HEADER, availableIds)
+        return res.status(403).json(error.cannotReserveForYear(year))
+      }
+      result = await cveIdRangeRepo.findOne({ cve_year: year })
+    } else {
+      logger.info({ uuid: req.ctx.uuid, message: 'CVE IDs for year ' + year + ' cannot be reserved at this time.' })
+      res.header(CONSTANTS.QUOTA_HEADER, availableIds)
+      return res.status(403).json(error.cannotReserveForYear(year))
+    }
   }
 
   available = await cveIdRepo.find({ cve_year: year, state: 'AVAILABLE' }, { limit: availableLimit }) // get available ids
@@ -942,6 +981,36 @@ function setMinAggregateObj (query) {
       }
     }
   ]
+}
+
+function daysUntilYear (targetYear) {
+  // Get today's date
+  const today = new Date()
+
+  // Create a date object for January 1st of the target year
+  const targetDate = new Date(targetYear, 0, 1) // Month is 0-indexed, so 0 is January
+
+  // Calculate the difference in milliseconds
+  const differenceInMilliseconds = targetDate - today
+
+  // Convert milliseconds to days
+  const millisecondsPerDay = 1000 * 60 * 60 * 24
+  const differenceInDays = Math.ceil(differenceInMilliseconds / millisecondsPerDay)
+
+  return differenceInDays
+}
+
+async function reserveYear (targetYear, req) {
+  try {
+    const CONSTANTS = getConstants()
+    const cveIdRangeRepo = req.ctx.repositories.getCveIdRangeRepository()
+    const defaultDoc = CONSTANTS.DEFAULT_CVE_ID_RANGE
+    defaultDoc.cve_year = targetYear
+    await cveIdRangeRepo.findOneAndUpdate({ cve_year: targetYear }, defaultDoc, { upsert: true })
+    return true
+  } catch (err) {
+    return false
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
Closes Issue #577 

# Summary

If a reservation is requested for a year that is not activated, cve services will now activate the new year if we are within 90 days of the year. 

A secretariat can still activate the year manually through their endpoint. 

