### PR TITLE
Resolves #1121 - Rate limiting return codes

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,8 @@
 PORT = 3000
 LOCAL_KEY=TCF25YM-39C4H6D-KA32EGF-V5XSHN3
+# The duration of the rate limiting window in seconds.
+# This defines the time frame for which the rate limit is applied.
 RATE_LIMIT_WINDOW_SECONDS=60
+# The maximum number of connections allowed within the rate limiting window.
+# This sets the threshold for how many requests can be made in the specified time frame.
 RATE_LIMIT_MAX_CONNECTIONS=1000


### PR DESCRIPTION

Closes Issue #1121 

# Summary
Adds documentation for the rate limiting Vars in the .env

In addition, a request has gone out to @shaneficorilli to update the AWS WAF to return 429 instead of 403 for AWS based rejections. 