### PR TITLE
Bulkdownload redaction

### DIFF
--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -149,8 +149,14 @@ async function getFilteredCveId (req, res, next) {
           // No redaction, original requested_by.user is in requested_by.cna and owning_cna
           i.requested_by.user = orgMap[cnaid].users[i.requested_by.user]
         }
-
         i.owning_cna = orgMap[i.owning_cna].shortname
+        // Finally, if the user is bulk download, redact the entire requested by object and owning cna
+        if (isBulkDownload) {
+          i.owning_cna = 'REDACTED'
+          i.requested_by.user = 'REDACTED'
+          i.requested_by.cna = 'REDACTED'
+        }
+
         return i
       })
     }


### PR DESCRIPTION
# Summary
The CVE-ID repository will now redact information correctly if pulled with the bulkdownload user

