### PR TITLE
Resolves issue 1378, creates new /cve_count endpoint

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -1190,6 +1190,70 @@
         }
       }
     },
+    "/cve_count": {
+      "get": {
+        "tags": [
+          "CVE Record"
+        ],
+        "summary": "Retrieves the count of all the CVE Records after applying the query parameters as filters (accessible to all users)",
+        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p>Retrieves the count of all CVE records for all organizations</p>",
+        "operationId": "cveGetFilteredCount",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/cveState"
+          },
+          {
+            "$ref": "#/components/parameters/countOnly"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A count of the total number of filtered CVE records",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "../schemas/cve/get-cve-record-count.json"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/cve_cursor": {
       "get": {
         "tags": [

--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -1201,9 +1201,6 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/cveState"
-          },
-          {
-            "$ref": "#/components/parameters/countOnly"
           }
         ],
         "responses": {

--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -1209,11 +1209,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "oneOf": [
-                    {
-                      "$ref": "../schemas/cve/get-cve-record-count.json"
-                    }
-                  ]
+                  "$ref": "../schemas/cve/get-cve-record-count.json"
                 }
               }
             }

--- a/schemas/cve/get-cve-record-count.json
+++ b/schemas/cve/get-cve-record-count.json
@@ -1,0 +1,3 @@
+{
+    "totalCount": 0
+}

--- a/schemas/cve/get-cve-record-count.json
+++ b/schemas/cve/get-cve-record-count.json
@@ -1,3 +1,10 @@
 {
-    "totalCount": 0
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "type": "object",
+    "properties": {
+        "totalCount": {
+            "type": "integer",
+            "format": "int32"
+        }
+    }
 }

--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -35,11 +35,11 @@ async function getCve (req, res, next) {
 async function getFilteredCveCount (req, res, next) {
   try {
     req.ctx.query.count_only = '1'
-    const result = await getFilteredCves(req,res,next)
+    const result = await getFilteredCves(req, res, next)
     return result
   } catch (err) {
-  next(err)
-}
+    next(err)
+  }
 }
 
 // Called by GET /cve

--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -32,6 +32,17 @@ async function getCve (req, res, next) {
 }
 
 // Called by GET /cve
+async function getFilteredCveCount (req, res, next) {
+  try {
+    req.ctx.query.count_only = '1'
+    const result = await getFilteredCves(req,res,next)
+    return result
+  } catch (err) {
+  next(err)
+}
+}
+
+// Called by GET /cve
 async function getFilteredCves (req, res, next) {
   const CONSTANTS = getConstants()
   const options = CONSTANTS.PAGINATOR_OPTIONS
@@ -916,6 +927,7 @@ module.exports = {
   CVE_GET_SINGLE: getCve,
   CVE_GET_FILTERED: getFilteredCves,
   CVE_GET_FILTERED_CURSOR: getFilteredCvesCursor,
+  CVE_GET_FILTERED_COUNT: getFilteredCveCount,
   CVE_SUBMIT: submitCve,
   CVE_UPDATE_SINGLE: updateCve,
   CVE_SUBMIT_CNA: submitCna,

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -274,6 +274,66 @@ router.get('/cve',
   parseGetParams,
   controller.CVE_GET_FILTERED)
 
+router.get('/cve_count',
+ /*
+  #swagger.tags = ['CVE Record']
+  #swagger.operationId = 'cveGetFilteredCount'
+  #swagger.summary = "Retrieves the count of all the CVE Records after applying the query parameters as filters (accessible to all users)"
+  #swagger.description = "
+        <h2>Access Control</h2>
+        <p>Endpoint is accessible to all</p>
+        <h2>Expected Behavior</h2>
+        <p>Retrieves the count of all CVE records for all organizations</p>"
+  #swagger.parameters['$ref'] = [
+    '#/components/parameters/cveState',
+    '#/components/parameters/countOnly',
+  ]
+  #swagger.responses[200] = {
+    description: 'A count of the total number of filtered CVE records',
+    content: {
+      "application/json": {
+        schema: {
+            oneOf: [
+                { $ref: '../schemas/cve/get-cve-record-count.json' }
+            ]
+        },
+      }
+    }
+  }
+  #swagger.responses[400] = {
+    description: 'Bad Request',
+    content: {
+      "application/json": {
+        schema: { $ref: '../schemas/errors/bad-request.json' }
+      }
+    }
+  }
+  #swagger.responses[404] = {
+    description: 'Not Found',
+    content: {
+      "application/json": {
+        schema: { $ref: '../schemas/errors/generic.json' }
+      }
+    }
+  }
+  #swagger.responses[500] = {
+    description: 'Internal Server Error',
+    content: {
+      "application/json": {
+        schema: { $ref: '../schemas/errors/generic.json' }
+      }
+    }
+  }
+  
+  */
+  query().custom((query) => { return mw.validateQueryParameterNames(query, ['state', 'count_only']) }),
+  query(['state']).optional().isString().trim().customSanitizer(val => { return val.toUpperCase() }).isIn(CHOICES).withMessage(errorMsgs.CVE_FILTERED_STATES),
+  query(['count_only']).optional().isBoolean({ loose: true }).withMessage(errorMsgs.COUNT_ONLY),
+  parseError,
+  parseGetParams,
+  controller.CVE_GET_FILTERED)
+
+
 router.get('/cve_cursor',
   /*
   #swagger.tags = ['CVE Record']

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -275,7 +275,7 @@ router.get('/cve',
   controller.CVE_GET_FILTERED)
 
 router.get('/cve_count',
- /*
+  /*
   #swagger.tags = ['CVE Record']
   #swagger.operationId = 'cveGetFilteredCount'
   #swagger.summary = "Retrieves the count of all the CVE Records after applying the query parameters as filters (accessible to all users)"
@@ -319,14 +319,12 @@ router.get('/cve_count',
       }
     }
   }
-  
   */
   query().custom((query) => { return mw.validateQueryParameterNames(query, ['state', 'count_only']) }),
   query(['state']).optional().isString().trim().customSanitizer(val => { return val.toUpperCase() }).isIn(CHOICES).withMessage(errorMsgs.CVE_FILTERED_STATES),
   parseError,
   parseGetParams,
   controller.CVE_GET_FILTERED_COUNT)
-
 
 router.get('/cve_cursor',
   /*

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -320,7 +320,7 @@ router.get('/cve_count',
     }
   }
   */
-  query().custom((query) => { return mw.validateQueryParameterNames(query, ['state', 'count_only']) }),
+  query().custom((query) => { return mw.validateQueryParameterNames(query, ['state']) }),
   query(['state']).optional().isString().trim().customSanitizer(val => { return val.toUpperCase() }).isIn(CHOICES).withMessage(errorMsgs.CVE_FILTERED_STATES),
   parseError,
   parseGetParams,

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -326,12 +326,11 @@ router.get('/cve_count',
   }
   
   */
-  query().custom((query) => { return mw.validateQueryParameterNames(query, ['state', 'count_only']) }),
+  query().custom((query) => { return mw.validateQueryParameterNames(query, ['state']) }),
   query(['state']).optional().isString().trim().customSanitizer(val => { return val.toUpperCase() }).isIn(CHOICES).withMessage(errorMsgs.CVE_FILTERED_STATES),
-  query(['count_only']).optional().isBoolean({ loose: true }).withMessage(errorMsgs.COUNT_ONLY),
   parseError,
   parseGetParams,
-  controller.CVE_GET_FILTERED)
+  controller.CVE_GET_FILTERED_COUNT)
 
 
 router.get('/cve_cursor',

--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -286,17 +286,12 @@ router.get('/cve_count',
         <p>Retrieves the count of all CVE records for all organizations</p>"
   #swagger.parameters['$ref'] = [
     '#/components/parameters/cveState',
-    '#/components/parameters/countOnly',
   ]
   #swagger.responses[200] = {
     description: 'A count of the total number of filtered CVE records',
     content: {
       "application/json": {
-        schema: {
-            oneOf: [
-                { $ref: '../schemas/cve/get-cve-record-count.json' }
-            ]
-        },
+        schema: { $ref: '../schemas/cve/get-cve-record-count.json' }
       }
     }
   }
@@ -326,7 +321,7 @@ router.get('/cve_count',
   }
   
   */
-  query().custom((query) => { return mw.validateQueryParameterNames(query, ['state']) }),
+  query().custom((query) => { return mw.validateQueryParameterNames(query, ['state', 'count_only']) }),
   query(['state']).optional().isString().trim().customSanitizer(val => { return val.toUpperCase() }).isIn(CHOICES).withMessage(errorMsgs.CVE_FILTERED_STATES),
   parseError,
   parseGetParams,

--- a/src/controller/schemas.controller/index.js
+++ b/src/controller/schemas.controller/index.js
@@ -20,6 +20,7 @@ router.get('/cve/create-cve-record-cna-request.json', controller.getCnaFullSchem
 router.get('/cve/create-adp-record-adp-request.json', controller.getAdpFullSchema)
 router.get('/cve/create-cve-record-secretariat-request.json', controller.getCnaSecretariatFullSchema)
 router.get('/cve/cna-minimum-request.json', controller.getCnaMinSchema)
+router.get('/cve/get-cve-record-count.json', controller.getCveCountResponseSchema)
 
 // Schemas relating to CVE IDs
 router.get('/cve-id/create-cve-ids-response.json', controller.getCreateCveIdsResponseSchema)

--- a/src/controller/schemas.controller/schemas.controller.js
+++ b/src/controller/schemas.controller/schemas.controller.js
@@ -222,6 +222,12 @@ async function getUpdateUserResponseSchema (req, res) {
   res.status(200)
 }
 
+async function getCveCountResponseSchema (req, res) {
+  const cveCountResponseSchema = require('../../../schemas/cve/get-cve-record-count.json')
+  res.json(cveCountResponseSchema)
+  res.status(200)
+}
+
 module.exports = {
   getBadRequestSchema: getBadRequestSchema,
   getCreateCveRecordResponseSchema: getCreateCveRecordResponseSchema,
@@ -258,5 +264,6 @@ module.exports = {
   getCnaFullSchema: getCnaFullSchema,
   getAdpFullSchema: getAdpFullSchema,
   getCnaSecretariatFullSchema: getCnaSecretariatFullSchema,
-  getCnaMinSchema: getCnaMinSchema
+  getCnaMinSchema: getCnaMinSchema,
+  getCveCountResponseSchema: getCveCountResponseSchema
 }

--- a/test/README.md
+++ b/test/README.md
@@ -1,7 +1,7 @@
 
 
 # CVE-API-Unit-Tests
-In order to Run Tests, make sure you configure a DB connection in the config/config.json under the `test` environment.
+In order to Run Tests, make sure you configure a DB connection in the config/default.json under the `test` environment.
 
 ## Dependencies
 
@@ -14,11 +14,16 @@ This project uses or depends on software from
 - Mocha https://mochajs.org/
 - Chai https://www.chaijs.com/
 
+In order to pre-populate a new database for testing, run the following command:
+
+```sh
+npm run populate:test
+```
 
 In order to run unit tests, use the following command:
 
 ```sh
-npm run start:test
+npm run test
 ```
 
 ## Notes

--- a/test/integration-tests/cve/getCveCount.js
+++ b/test/integration-tests/cve/getCveCount.js
@@ -15,7 +15,7 @@ describe('Test get /cve_count for CVE records', () => {
         .then((res, err) => {
           expect(err).to.be.undefined
           expect(res).to.have.status(200)
-          expect(res.body).to.have.property('totalCount').that.is.a('number');
+          expect(res.body).to.have.property('totalCount').that.is.a('number')
         })
     })
     it('Get /cve_count should allow privledged user to get count also', async () => {
@@ -25,7 +25,7 @@ describe('Test get /cve_count for CVE records', () => {
         .then((res, err) => {
           expect(err).to.be.undefined
           expect(res).to.have.status(200)
-          expect(res.body).to.have.property('totalCount').that.is.a('number');
+          expect(res.body).to.have.property('totalCount').that.is.a('number')
         })
     })
     it('Get /cve_count should return count with valid parameters', async () => {
@@ -35,7 +35,7 @@ describe('Test get /cve_count for CVE records', () => {
         .then((res, err) => {
           expect(err).to.be.undefined
           expect(res).to.have.status(200)
-          expect(res.body).to.have.property('totalCount').that.is.a('number');
+          expect(res.body).to.have.property('totalCount').that.is.a('number')
         })
     })
   })
@@ -58,7 +58,7 @@ describe('Test get /cve_count for CVE records', () => {
           expect(res.body.message).to.contain('Parameters were invalid')
         })
     })
-    it('Get /cve_count should fail if it is passed invalid parameters', async () => {
+    it('Get /cve_count should fail if it is `state` parameter value is invalid ', async () => {
       await chai.request(app)
         .get('/api/cve_count?state=SUCESS')
         .set(constants.headers)

--- a/test/integration-tests/cve/getCveCount.js
+++ b/test/integration-tests/cve/getCveCount.js
@@ -1,0 +1,72 @@
+/* eslint-disable no-unused-expressions */
+
+const chai = require('chai')
+chai.use(require('chai-http'))
+const expect = chai.expect
+
+const constants = require('../constants.js')
+const app = require('../../../src/index.js')
+
+describe('Test get /cve_count for CVE records', () => {
+  context('Positive Tests', () => {
+    it('Get /cve_count should allow any user to get count', async () => {
+      await chai.request(app)
+        .get('/api/cve_count')
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body).to.have.property('totalCount').that.is.a('number');
+        })
+    })
+    it('Get /cve_count should allow privledged user to get count also', async () => {
+      await chai.request(app)
+        .get('/api/cve_count')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body).to.have.property('totalCount').that.is.a('number');
+        })
+    })
+    it('Get /cve_count should return count with valid parameters', async () => {
+      await chai.request(app)
+        .get('/api/cve_count?state=PUBLISHED')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body).to.have.property('totalCount').that.is.a('number');
+        })
+    })
+  })
+  context('Negative Tests', () => {
+    it('Get /cve should NOT allow any user to get count', async () => {
+      await chai.request(app)
+        .get('/api/cve?count_only=1')
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+        })
+    })
+    it('Get /cve_count should fail if it is passed invalid parameters', async () => {
+      await chai.request(app)
+        .get('/api/cve_count?time_modified.gt=2022-13-01T00:00:00Z')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body.message).to.contain('Parameters were invalid')
+        })
+    })
+    it('Get /cve_count should fail if it is passed invalid parameters', async () => {
+      await chai.request(app)
+        .get('/api/cve_count?state=SUCESS')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body.message).to.contain('Parameters were invalid')
+        })
+    })
+  })
+})


### PR DESCRIPTION
Closes Issue [1378](https://github.com/CVEProject/cve-services/issues/1378)

# Summary
- Adds new /cve_count endpoint
- Returns the totalCount of all CVE records
- Allows any user to access the endpoint
- Does not require any parameters
- Allows for optional parameters: "countOnly" and "state"
- updated Swagger Doc:
![image](https://github.com/user-attachments/assets/a13bac20-8dde-4f9b-a2a4-d8036f57dbe6)


# Important Changes
`src/controller/cve.controller/index.js`
- Adds the new enpoint

`src/controller/cve.controller/cve.controller.js`
- Reuses the /cve endpoint to calculate the totalCount

# Testing

# Notes
- Some additional notes about this MR.
