### PR TITLE
Registry swagger updates

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -21,7 +21,7 @@
           "CVE ID"
         ],
         "summary": "Retrieves information about CVE IDs after applying the query parameters as filters (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves filtered CVE IDs owned by the user's organization</p>  <p><b>Secretariat:</b> Retrieves filtered CVE IDs owned by any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular, CNA & Admin Users:</b> Retrieves filtered CVE IDs owned by the user's organization</p>\r  <p><b>Secretariat:</b> Retrieves filtered CVE IDs owned by any organization</p>",
         "operationId": "cveIdGetFiltered",
         "parameters": [
           {
@@ -130,7 +130,7 @@
           "CVE ID"
         ],
         "summary": "Reserves CVE IDs for the organization provided in the short_name query parameter (accessible to CNAs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Reserves CVE IDs for the CNA</p>  <p><b>Secretariat:</b> Reserves CVE IDs for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>CNA:</b> Reserves CVE IDs for the CNA</p>\r  <p><b>Secretariat:</b> Reserves CVE IDs for any organization</p>",
         "operationId": "cveIdReserve",
         "parameters": [
           {
@@ -242,7 +242,7 @@
           "CVE ID"
         ],
         "summary": "Retrieves information about the specified CVE ID (accessible to all users)",
-        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users: </b>Retrieves full information about a CVE ID owned by their organization; partial information about a CVE ID owned by other organizations</p>  <p><b>Unauthenticated Users: </b>Retrieves partial information about a CVE ID  <p><b>Secretariat: </b>Retrieves full information about a CVE ID owned by any organization</p>  <p><i><b>Note - </b>The owning organization of RESERVED CVE IDs is redacted for all users other than those in the owning organization or Secretariat</i></p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Endpoint is accessible to all</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular, CNA & Admin Users: </b>Retrieves full information about a CVE ID owned by their organization; partial information about a CVE ID owned by other organizations</p>\r  <p><b>Unauthenticated Users: </b>Retrieves partial information about a CVE ID\r  <p><b>Secretariat: </b>Retrieves full information about a CVE ID owned by any organization</p>\r  <p><i><b>Note - </b>The owning organization of RESERVED CVE IDs is redacted for all users other than those in the owning organization or Secretariat</i></p>",
         "operationId": "cveIdGetSingle",
         "parameters": [
           {
@@ -524,7 +524,7 @@
           "CVE ID"
         ],
         "summary": "Updates information related to the specified CVE ID (accessible to CNAs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Updates information related to a CVE ID owned by the CNA</p>  <p><b>Secretariat:</b> Updates a CVE ID owned by any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>CNA:</b> Updates information related to a CVE ID owned by the CNA</p>\r  <p><b>Secretariat:</b> Updates a CVE ID owned by any organization</p>",
         "operationId": "cveIdUpdateSingle",
         "parameters": [
           {
@@ -629,7 +629,7 @@
           "CVE ID"
         ],
         "summary": "Creates a CVE-ID-Range for the specified year (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates a CVE-ID-Range for the specified year</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Creates a CVE-ID-Range for the specified year</p>",
         "operationId": "cveIdRangeCreate",
         "parameters": [
           {
@@ -721,7 +721,7 @@
           "CVE Record"
         ],
         "summary": "Returns a CVE Record by CVE ID (accessible to all users)",
-        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p><b>All users:</b> Retrieves the CVE Record specified</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Endpoint is accessible to all</p>\r  <h2>Expected Behavior</h2>\r  <p><b>All users:</b> Retrieves the CVE Record specified</p>",
         "operationId": "cveGetSingle",
         "parameters": [
           {
@@ -921,7 +921,7 @@
           "CVE Record"
         ],
         "summary": "Creates a CVE Record from full CVE Record JSON for the specified ID (accessible to Secretariat.)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates a CVE Record for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Creates a CVE Record for any organization</p>",
         "operationId": "cveSubmit",
         "parameters": [
           {
@@ -1028,7 +1028,7 @@
           "CVE Record"
         ],
         "summary": "Updates a CVE Record from full CVE Record JSON for the specified ID (accessible to Secretariat.)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Updates a CVE Record for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Updates a CVE Record for any organization</p>",
         "operationId": "cveUpdateSingle",
         "parameters": [
           {
@@ -1137,7 +1137,7 @@
           "CVE Record"
         ],
         "summary": "Retrieves all CVE Records after applying the query parameters as filters (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves all CVE records for all organizations</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Retrieves all CVE records for all organizations</p>",
         "operationId": "cveGetFiltered",
         "parameters": [
           {
@@ -1245,7 +1245,7 @@
           "CVE Record"
         ],
         "summary": "Retrieves the count of all the CVE Records after applying the query parameters as filters (accessible to all users)",
-        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p>Retrieves the count of all CVE records for all organizations</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Endpoint is accessible to all</p>\r  <h2>Expected Behavior</h2>\r  <p>Retrieves the count of all CVE records for all organizations</p>",
         "operationId": "cveGetFilteredCount",
         "parameters": [
           {
@@ -1302,7 +1302,7 @@
           "CVE Record"
         ],
         "summary": "Retrieves all CVE Records after applying the query parameters as filters. Uses cursor pagination to paginate results (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves all CVE records for all organizations</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Retrieves all CVE records for all organizations</p>",
         "operationId": "cveGetFilteredCursor",
         "parameters": [
           {
@@ -1416,7 +1416,7 @@
           "CVE Record"
         ],
         "summary": "Creates a CVE Record from CNA Container JSON for the specified ID (accessible to CNAs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Creates CVE Record for a CVE ID owned by their organization</p>  <p><b>Secretariat:</b> Creates CVE Record for CVE IDs owned by any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>CNA:</b> Creates CVE Record for a CVE ID owned by their organization</p>\r  <p><b>Secretariat:</b> Creates CVE Record for CVE IDs owned by any organization</p>",
         "operationId": "cveCnaCreateSingle",
         "parameters": [
           {
@@ -1511,7 +1511,7 @@
           }
         },
         "requestBody": {
-          "description": "<h3>Notes:</h3>  <ul>  <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>  <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>  </ul>",
+          "description": "<h3>Notes:</h3>   <ul>   <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>   <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>   </ul>",
           "required": true,
           "content": {
             "application/json": {
@@ -1535,7 +1535,7 @@
           "CVE Record"
         ],
         "summary": "Updates the CVE Record from CNA Container JSON for the specified ID (accessible to CNAs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Updates a CVE Record for records that are owned by their organization</p>  <p><b>Secretariat:</b> Updates a CVE Record for records that are owned by any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>CNA:</b> Updates a CVE Record for records that are owned by their organization</p>\r  <p><b>Secretariat:</b> Updates a CVE Record for records that are owned by any organization</p>",
         "operationId": "cveCnaUpdateSingle",
         "parameters": [
           {
@@ -1630,7 +1630,7 @@
           }
         },
         "requestBody": {
-          "description": "<h3>Notes:</h3>  <ul>  <li>When updating a rejected record to published, it is recommended to confirm that both the Cve-Id and CVE record are in the correct state after calling this endpoint. Though very unlikely, a race condition can occur causing the two states to be out of sync. </li>  <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>  <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>  </ul>",
+          "description": "<h3>Notes:</h3>   <ul>   <li>When updating a rejected record to published, it is recommended to confirm that both the Cve-Id and CVE record are in the correct state after calling this endpoint. Though very unlikely, a race condition can occur causing the two states to be out of sync. </li>   <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>   <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>   </ul>",
           "required": true,
           "content": {
             "application/json": {
@@ -1656,7 +1656,7 @@
           "CVE Record"
         ],
         "summary": "Creates a rejected CVE Record for the specified ID if no record yet exists (accessible to CNAs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Creates a rejected CVE Record for a record owned by their organization</p>  <p><b>Secretariat:</b> Creates a rejected CVE Record for a record owned by any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>CNA:</b> Creates a rejected CVE Record for a record owned by their organization</p>\r  <p><b>Secretariat:</b> Creates a rejected CVE Record for a record owned by any organization</p>",
         "operationId": "cveCnaCreateReject",
         "parameters": [
           {
@@ -1748,7 +1748,7 @@
           }
         },
         "requestBody": {
-          "description": "<h3>Notes:</h3>  <ul>  <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>  <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>  </ul>",
+          "description": "<h3>Notes:</h3>   <ul>   <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>   <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>   </ul>",
           "required": true,
           "content": {
             "application/json": {
@@ -1764,7 +1764,7 @@
           "CVE Record"
         ],
         "summary": "Updates an existing CVE Record with a rejected record for the specified ID (accessible to CNAs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Updates a rejected CVE Record for a record owned by their organization</p>  <p><b>Secretariat:</b> Updates a rejected CVE Record for a record owned by any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>CNA:</b> Updates a rejected CVE Record for a record owned by their organization</p>\r  <p><b>Secretariat:</b> Updates a rejected CVE Record for a record owned by any organization</p>",
         "operationId": "cveCnaUpdateReject",
         "parameters": [
           {
@@ -1856,7 +1856,7 @@
           }
         },
         "requestBody": {
-          "description": "<h3>Notes:</h3>  <ul>  <li>It is recommended to confirm that both the Cve-Id and CVE record are in the REJECTED state after calling this endpoint. Though very unlikely, a race condition can occur causing the two states to be out of sync. </li>  <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>  <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>  </ul>",
+          "description": "<h3>Notes:</h3>   <ul>   <li>It is recommended to confirm that both the Cve-Id and CVE record are in the REJECTED state after calling this endpoint. Though very unlikely, a race condition can occur causing the two states to be out of sync. </li>   <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>   <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>   </ul>",
           "required": true,
           "content": {
             "application/json": {
@@ -1874,7 +1874,7 @@
           "CVE Record"
         ],
         "summary": "Updates the CVE Record from ADP Container JSON for the specified ID (accessible to ADPs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>ADP</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>ADP:</b> Updates a CVE Record for records that are owned by any organization</p>  <p><b>Secretariat:</b> Updates a CVE Record for records that are owned by any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>ADP</b> or <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>ADP:</b> Updates a CVE Record for records that are owned by any organization</p>\r  <p><b>Secretariat:</b> Updates a CVE Record for records that are owned by any organization</p>",
         "operationId": "cveAdpUpdateSingle",
         "parameters": [
           {
@@ -1984,18 +1984,14 @@
           "Organization"
         ],
         "summary": "Retrieves all organizations (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves information about all organizations</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Retrieves information about all organizations</p>",
         "operationId": "orgAll",
         "parameters": [
           {
-            "name": "registry",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/pageQuery"
           },
           {
-            "$ref": "#/components/parameters/pageQuery"
+            "$ref": "#/components/parameters/registry"
           },
           {
             "$ref": "#/components/parameters/apiEntityHeader"
@@ -2013,7 +2009,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/org/list-orgs-response.json"
+                  "oneOf": [
+                    {
+                      "$ref": "../schemas/org/list-orgs-response.json"
+                    },
+                    {
+                      "$ref": "../schemas/registry-org/list-registry-orgs-response.json"
+                    }
+                  ]
                 }
               }
             }
@@ -2075,15 +2078,11 @@
           "Organization"
         ],
         "summary": "Creates an organization as specified in the request body (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates an organization</p>  ",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Creates an organization</p>\r  ",
         "operationId": "orgCreateSingle",
         "parameters": [
           {
-            "name": "registry",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/registry"
           },
           {
             "$ref": "#/components/parameters/apiEntityHeader"
@@ -2101,7 +2100,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/org/create-org-response.json"
+                  "oneOf": [
+                    {
+                      "$ref": "../schemas/org/create-org-response.json"
+                    },
+                    {
+                      "$ref": "../schemas/registry-org/create-registry-org-response.json"
+                    }
+                  ]
                 }
               }
             }
@@ -2162,7 +2168,14 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "../schemas/org/create-org-request.json"
+                "oneOf": [
+                  {
+                    "$ref": "../schemas/org/create-org-request.json"
+                  },
+                  {
+                    "$ref": "../schemas/registry-org/create-registry-org-request.json"
+                  }
+                ]
               }
             }
           }
@@ -2175,7 +2188,7 @@
           "Organization"
         ],
         "summary": "Retrieves information about the organization specified by short name or UUID (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves organization record for the specified shortname or UUID if it is the user's organization</p>  <p><b>Secretariat:</b> Retrieves information about any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular, CNA & Admin Users:</b> Retrieves organization record for the specified shortname or UUID if it is the user's organization</p>\r  <p><b>Secretariat:</b> Retrieves information about any organization</p>",
         "operationId": "orgSingle",
         "parameters": [
           {
@@ -2188,11 +2201,7 @@
             "description": "The shortname or UUID of the organization"
           },
           {
-            "name": "registry",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/registry"
           },
           {
             "$ref": "#/components/parameters/apiEntityHeader"
@@ -2210,7 +2219,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/org/get-org-response.json"
+                  "oneOf": [
+                    {
+                      "$ref": "../schemas/org/get-org-response.json"
+                    },
+                    {
+                      "$ref": "../schemas/registry-org/get-registry-org-response.json"
+                    }
+                  ]
                 }
               }
             }
@@ -2265,16 +2281,6 @@
               }
             }
           }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "../schemas/org/create-org-request.json"
-              }
-            }
-          }
         }
       }
     },
@@ -2284,7 +2290,7 @@
           "Organization"
         ],
         "summary": "Updates information about the organization specified by short name (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Updates any organization's information</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Updates any organization's information</p>",
         "operationId": "orgUpdateSingle",
         "parameters": [
           {
@@ -2295,13 +2301,6 @@
               "type": "string"
             },
             "description": "The shortname of the organization"
-          },
-          {
-            "name": "registry",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
           },
           {
             "$ref": "#/components/parameters/id_quota"
@@ -2319,6 +2318,9 @@
             "$ref": "#/components/parameters/active_roles_remove"
           },
           {
+            "$ref": "#/components/parameters/registry"
+          },
+          {
             "$ref": "#/components/parameters/apiEntityHeader"
           },
           {
@@ -2334,7 +2336,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/org/update-org-response.json"
+                  "oneOf": [
+                    {
+                      "$ref": "../schemas/org/update-org-response.json"
+                    },
+                    {
+                      "$ref": "../schemas/registry-org/update-registry-org-response.json"
+                    }
+                  ]
                 }
               }
             }
@@ -2389,16 +2398,6 @@
               }
             }
           }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "../schemas/org/create-org-request.json"
-              }
-            }
-          }
         }
       }
     },
@@ -2408,7 +2407,7 @@
           "Organization"
         ],
         "summary": "Retrieves an organization's CVE ID quota (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves the CVE ID quota for the user's organization</p>  <p><b>Secretariat:</b> Retrieves the CVE ID quota for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular, CNA & Admin Users:</b> Retrieves the CVE ID quota for the user's organization</p>\r  <p><b>Secretariat:</b> Retrieves the CVE ID quota for any organization</p>",
         "operationId": "orgIdQuota",
         "parameters": [
           {
@@ -2421,11 +2420,7 @@
             "description": "The shortname of the organization"
           },
           {
-            "name": "registry",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/registry"
           },
           {
             "$ref": "#/components/parameters/apiEntityHeader"
@@ -2443,7 +2438,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/org/get-org-quota-response.json"
+                  "oneOf": [
+                    {
+                      "$ref": "../schemas/org/get-org-quota-response.json"
+                    },
+                    {
+                      "$ref": "../schemas/registry-org/get-registry-org-quota-response.json"
+                    }
+                  ]
                 }
               }
             }
@@ -2498,16 +2500,6 @@
               }
             }
           }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "../schemas/org/create-org-request.json"
-              }
-            }
-          }
         }
       }
     },
@@ -2517,7 +2509,7 @@
           "Users"
         ],
         "summary": "Retrieves all users for the organization with the specified short name (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about users in the same organization</p>  <p><b>Secretariat:</b> Retrieves all user information for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about users in the same organization</p>\r  <p><b>Secretariat:</b> Retrieves all user information for any organization</p>",
         "operationId": "userOrgAll",
         "parameters": [
           {
@@ -2530,14 +2522,10 @@
             "description": "The shortname of the organization"
           },
           {
-            "name": "registry",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/pageQuery"
           },
           {
-            "$ref": "#/components/parameters/pageQuery"
+            "$ref": "#/components/parameters/registry"
           },
           {
             "$ref": "#/components/parameters/apiEntityHeader"
@@ -2555,7 +2543,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/user/list-users-response.json"
+                  "oneOf": [
+                    {
+                      "$ref": "../schemas/user/list-users-response.json"
+                    },
+                    {
+                      "$ref": "../schemas/registry-user/list-registry-users-response.json"
+                    }
+                  ]
                 }
               }
             }
@@ -2610,16 +2605,6 @@
               }
             }
           }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "../schemas/org/create-org-request.json"
-              }
-            }
-          }
         }
       }
     },
@@ -2629,7 +2614,7 @@
           "Users"
         ],
         "summary": "Create a user with the provided short name as the owning organization (accessible to Admins and Secretariats)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>  <h2>Expected Behavior</h2>  <p><b>Admin User:</b> Creates a user for the Admin's organization</p>  <p><b>Secretariat:</b> Creates a user for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Admin User:</b> Creates a user for the Admin's organization</p>\r  <p><b>Secretariat:</b> Creates a user for any organization</p>",
         "operationId": "userCreateSingle",
         "parameters": [
           {
@@ -2642,11 +2627,7 @@
             "description": "The shortname of the organization"
           },
           {
-            "name": "registry",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/registry"
           },
           {
             "$ref": "#/components/parameters/apiEntityHeader"
@@ -2664,7 +2645,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/user/create-user-response.json"
+                  "oneOf": [
+                    {
+                      "$ref": "../schemas/user/create-user-response.json"
+                    },
+                    {
+                      "$ref": "../schemas/registry-user/create-registry-user-response.json"
+                    }
+                  ]
                 }
               }
             }
@@ -2725,7 +2713,14 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "../schemas/user/create-user-request.json"
+                "oneOf": [
+                  {
+                    "$ref": "../schemas/user/create-user-request.json"
+                  },
+                  {
+                    "$ref": "../schemas/registry-user/create-registry-user-request.json"
+                  }
+                ]
               }
             }
           }
@@ -2738,7 +2733,7 @@
           "Users"
         ],
         "summary": "Retrieves information about a user for the specified username and organization short name (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about a user in the same organization</p>  <p><b>Secretariat:</b> Retrieves any user's information</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about a user in the same organization</p>\r  <p><b>Secretariat:</b> Retrieves any user's information</p>",
         "operationId": "userSingle",
         "parameters": [
           {
@@ -2760,11 +2755,7 @@
             "description": "The username of the user"
           },
           {
-            "name": "registry",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/registry"
           },
           {
             "$ref": "#/components/parameters/apiEntityHeader"
@@ -2782,7 +2773,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/user/get-user-response.json"
+                  "oneOf": [
+                    {
+                      "$ref": "../schemas/user/get-user-response.json"
+                    },
+                    {
+                      "$ref": "../schemas/registry-user/get-registry-user-response.json"
+                    }
+                  ]
                 }
               }
             }
@@ -2837,16 +2835,6 @@
               }
             }
           }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "../schemas/org/create-org-request.json"
-              }
-            }
-          }
         }
       },
       "put": {
@@ -2854,7 +2842,7 @@
           "Users"
         ],
         "summary": "Updates information about a user for the specified username and organization shortname (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular User:</b> Updates the user's own information. Only name fields may be changed.</p>  <p><b>Admin User:</b> Updates information about a user in the Admin's organization. Allowed to change all fields except org_short_name. </p>  <p><b>Secretariat:</b> Updates information about a user in any organization. Allowed to change all fields.</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular User:</b> Updates the user's own information. Only name fields may be changed.</p>\r  <p><b>Admin User:</b> Updates information about a user in the Admin's organization. Allowed to change all fields except org_short_name. </p>\r  <p><b>Secretariat:</b> Updates information about a user in any organization. Allowed to change all fields.</p>",
         "operationId": "userUpdateSingle",
         "parameters": [
           {
@@ -2874,13 +2862,6 @@
               "type": "string"
             },
             "description": "The username of the user"
-          },
-          {
-            "name": "registry",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
           },
           {
             "$ref": "#/components/parameters/active"
@@ -2910,6 +2891,9 @@
             "$ref": "#/components/parameters/orgShortname"
           },
           {
+            "$ref": "#/components/parameters/registry"
+          },
+          {
             "$ref": "#/components/parameters/apiEntityHeader"
           },
           {
@@ -2925,7 +2909,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/user/update-user-response.json"
+                  "oneOf": [
+                    {
+                      "$ref": "../schemas/user/update-user-response.json"
+                    },
+                    {
+                      "$ref": "../schemas/registry-user/update-registry-user-response.json"
+                    }
+                  ]
                 }
               }
             }
@@ -2980,16 +2971,6 @@
               }
             }
           }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "../schemas/org/create-org-request.json"
-              }
-            }
-          }
         }
       }
     },
@@ -2999,7 +2980,7 @@
           "Users"
         ],
         "summary": "Reset the API key for a user (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular User:</b> Resets user's own API secret</p>  <p><b>Admin User:</b> Resets any user's API secret in the Admin's organization</p>  <p><b>Secretariat:</b> Resets any user's API secret</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular User:</b> Resets user's own API secret</p>\r  <p><b>Admin User:</b> Resets any user's API secret in the Admin's organization</p>\r  <p><b>Secretariat:</b> Resets any user's API secret</p>",
         "operationId": "userResetSecret",
         "parameters": [
           {
@@ -3098,16 +3079,6 @@
               }
             }
           }
-        },
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "../schemas/org/create-org-request.json"
-              }
-            }
-          }
         }
       }
     },
@@ -3117,18 +3088,14 @@
           "Users"
         ],
         "summary": "Retrieves information about all registered users (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p> User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves information about all users for all organizations</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p> User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Retrieves information about all users for all organizations</p>",
         "operationId": "userAll",
         "parameters": [
           {
-            "name": "registry",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
+            "$ref": "#/components/parameters/pageQuery"
           },
           {
-            "$ref": "#/components/parameters/pageQuery"
+            "$ref": "#/components/parameters/registry"
           },
           {
             "$ref": "#/components/parameters/apiEntityHeader"
@@ -3146,7 +3113,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/user/list-users-response.json"
+                  "oneOf": [
+                    {
+                      "$ref": "../schemas/user/list-users-response.json"
+                    },
+                    {
+                      "$ref": "../schemas/registry-user/list-registry-users-response.json"
+                    }
+                  ]
                 }
               }
             }
@@ -3210,7 +3184,7 @@
           "Utilities"
         ],
         "summary": "Checks that the system is running (accessible to all users)",
-        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p>Returns a 200 response code when CVE Services are running</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Endpoint is accessible to all</p>\r  <h2>Expected Behavior</h2>\r  <p>Returns a 200 response code when CVE Services are running</p>",
         "operationId": "healthCheck",
         "responses": {
           "200": {
@@ -3225,7 +3199,7 @@
           "Registry Organization"
         ],
         "summary": "Retrieves information about all registry organizations (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves a list of all registry organizations</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Retrieves a list of all registry organizations</p>",
         "operationId": "getAllRegistryOrgs",
         "parameters": [
           {
@@ -3306,7 +3280,7 @@
           "Registry Organization"
         ],
         "summary": "Creates a new registry organization (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates a new registry organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Creates a new registry organization</p>",
         "operationId": "createRegistryOrg",
         "parameters": [
           {
@@ -3396,7 +3370,7 @@
           "Registry Organization"
         ],
         "summary": "Retrieves information about a specific registry organization",
-        "description": "  <h2>Access Control</h2>  <p>All authenticated users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>All Users:</b> Retrieves information about the specified registry organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All authenticated users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>All Users:</b> Retrieves information about the specified registry organization</p>",
         "operationId": "getSingleRegistryOrg",
         "parameters": [
           {
@@ -3483,7 +3457,7 @@
           "Registry Organization"
         ],
         "summary": "Deletes an existing registry organization (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Deletes an existing registry organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Deletes an existing registry organization</p>",
         "operationId": "deleteRegistryOrg",
         "parameters": [
           {
@@ -3572,7 +3546,7 @@
           "Registry Organization"
         ],
         "summary": "Updates an existing registry organization (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Updates an existing registry organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Updates an existing registry organization</p>",
         "operationId": "updateRegistryOrg",
         "parameters": [
           {
@@ -3681,7 +3655,7 @@
           "Registry User"
         ],
         "summary": "Retrieves all users for the organization with the specified short name (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about users in the same organization</p>  <p><b>Secretariat:</b> Retrieves all user information for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about users in the same organization</p>\r  <p><b>Secretariat:</b> Retrieves all user information for any organization</p>",
         "operationId": "registryUserOrgAll",
         "parameters": [
           {
@@ -3783,7 +3757,7 @@
           "Registry User"
         ],
         "summary": "Create a user with the provided short name as the owning organization (accessible to Admins and Secretariats)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>  <h2>Expected Behavior</h2>  <p><b>Admin User:</b> Creates a user for the Admin's organization</p>  <p><b>Secretariat:</b> Creates a user for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Admin User:</b> Creates a user for the Admin's organization</p>\r  <p><b>Secretariat:</b> Creates a user for any organization</p>",
         "operationId": "RegistryUserCreateSingle",
         "parameters": [
           {
@@ -3885,7 +3859,7 @@
           "Registry User"
         ],
         "summary": "Retrieves information about all registry users (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves a list of all registry users</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Retrieves a list of all registry users</p>",
         "operationId": "getAllRegistryUsers",
         "parameters": [
           {
@@ -3966,7 +3940,7 @@
           "Registry User"
         ],
         "summary": "Creates a new registry user (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates a new registry user</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Creates a new registry user</p>",
         "operationId": "createRegistryUser",
         "parameters": [
           {
@@ -4056,7 +4030,7 @@
           "Registry User"
         ],
         "summary": "Retrieves information about a specific registry user",
-        "description": "  <h2>Access Control</h2>  <p>All authenticated users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>All Users:</b> Retrieves information about the specified registry user</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All authenticated users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>All Users:</b> Retrieves information about the specified registry user</p>",
         "operationId": "getSingleRegistryUser",
         "parameters": [
           {
@@ -4143,7 +4117,7 @@
           "Registry User"
         ],
         "summary": "Updates an existing registry user (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Updates an existing registry user</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Updates an existing registry user</p>",
         "operationId": "updateRegistryUser",
         "parameters": [
           {
@@ -4250,7 +4224,7 @@
           "Registry User"
         ],
         "summary": "Deletes an existing registry user (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Deletes an existing registry user</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Deletes an existing registry user</p>",
         "operationId": "deleteRegistryUser",
         "parameters": [
           {
@@ -4744,6 +4718,15 @@
           "type": "integer",
           "format": "int32",
           "minimum": 1
+        }
+      },
+      "registry": {
+        "in": "query",
+        "name": "registry",
+        "description": "When set to true, the endpoint will expect request data to conform to the applicable User Registry schema, and will provide response data conforming to the applicable User Registry schema. Defaults to false.",
+        "required": false,
+        "schema": {
+          "type": "boolean"
         }
       },
       "short_name": {

--- a/schemas/registry-org/create-registry-org-request.json
+++ b/schemas/registry-org/create-registry-org-request.json
@@ -2,13 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://cve.mitre.org/schema/org/organization.json",
   "type": "object",
-  "title": "CVE Registry Org",
-  "description": "JSON Schema for CVE Registry Org",
+  "title": "CVE Create Registry Org Request",
+  "description": "JSON Schema for creating a CVE Registry organization",
   "properties": {
-    "UUID": {
-      "type": "string",
-      "description": "Unique identifier for the organization"
-    },
     "long_name": {
       "type": "string",
       "description": "Full name of the organization"
@@ -76,14 +72,6 @@
       "type": "string",
       "description": "List of products associated with the organization"
     },
-    "soft_quota": {
-      "type": "integer",
-      "description": "Soft quota for CVE IDs"
-    },
-    "hard_quota": {
-      "type": "integer",
-      "description": "Hard quota for CVE IDs"
-    },
     "contact_info": {
       "type": "object",
       "properties": {
@@ -125,33 +113,14 @@
         }
       },
       "required": ["poc", "poc_email", "admins", "org_email"]
-    },
-    "in_use": {
-      "type": "boolean",
-      "description": "Indicates if the organization is currently active"
-    },
-    "created": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Timestamp of when the organization was created"
-    },
-    "last_updated": {
-      "type": "string",
-      "format": "date-time",
-      "description": "Timestamp of the last update to the organization data"
     }
   },
   "required": [
-    "UUID",
-    "long_name",
     "short_name",
     "cve_program_org_function",
     "authority",
     "root_or_tlr",
     "users",
-    "contact_info",
-    "in_use",
-    "created",
-    "last_updated"
+    "contact_info"
   ]
 }

--- a/schemas/registry-org/create-registry-org-response.json
+++ b/schemas/registry-org/create-registry-org-response.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://cve.mitre.org/schema/org/organization.json",
+  "type": "object",
+  "title": "CVE Create Registry Org Response",
+  "description": "JSON Schema for CVE Create Registry Org response",
+  "properties": {
+		"message": {
+      "type": "string",
+      "description": "Success description"
+    },
+    "created": {
+      "type": "object",
+      "properties": {
+        "UUID": {
+          "type": "string",
+          "description": "Unique identifier for the organization"
+        },
+        "long_name": {
+          "type": "string",
+          "description": "Full name of the organization"
+        },
+        "short_name": {
+          "type": "string",
+          "description": "Short name or acronym of the organization"
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Alternative names or aliases for the organization"
+        },
+        "cve_program_org_function": {
+          "type": "string",
+          "enum": ["CNA", "ADP", "Root", "Secretariat"],
+          "description": "The organization's function within the CVE program"
+        },
+        "authority": {
+          "type": "object",
+          "properties": {
+            "active_roles": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["CNA", "ADP", "Root", "Secretariat"]
+              }
+            }
+          },
+          "required": ["active_roles"]
+        },
+        "reports_to": {
+          "type": ["string", "null"],
+          "description": "UUID of the parent organization, if any"
+        },
+        "oversees": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "UUIDs of organizations overseen by this organization"
+        },
+        "root_or_tlr": {
+          "type": "boolean",
+          "description": "Indicates if the organization is a root or top-level root"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "UUIDs of users associated with this organization"
+        },
+        "charter_or_scope": {
+          "type": "string",
+          "description": "Description of the organization's charter or scope"
+        },
+        "disclosure_policy": {
+          "type": "string",
+          "description": "The organization's disclosure policy"
+        },
+        "product_list": {
+          "type": "string",
+          "description": "List of products associated with the organization"
+        },
+        "soft_quota": {
+          "type": "integer",
+          "description": "Soft quota for CVE IDs"
+        },
+        "hard_quota": {
+          "type": "integer",
+          "description": "Hard quota for CVE IDs"
+        },
+        "contact_info": {
+          "type": "object",
+          "properties": {
+            "additional_contact_users": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "poc": {
+              "type": "string",
+              "description": "Point of contact name"
+            },
+            "poc_email": {
+              "type": "string",
+              "format": "email",
+              "description": "Point of contact email"
+            },
+            "poc_phone": {
+              "type": "string",
+              "description": "Point of contact phone number"
+            },
+            "admins": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "UUIDs of admin users"
+            },
+            "org_email": {
+              "type": "string",
+              "format": "email",
+              "description": "Organization's email address"
+            },
+            "website": {
+              "type": "string",
+              "format": "uri",
+              "description": "Organization's website URL"
+            }
+          },
+          "required": ["poc", "poc_email", "admins", "org_email"]
+        },
+        "in_use": {
+          "type": "boolean",
+          "description": "Indicates if the organization is currently active"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of when the organization was created"
+        },
+        "last_updated": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last update to the organization data"
+        }
+      }
+    }
+	}
+}

--- a/schemas/registry-org/get-registry-org-quota-response.json
+++ b/schemas/registry-org/get-registry-org-quota-response.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "hard_quota": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of CVE IDs the organization is allowed to have in the RESERVED state at one time."
+    },
+    "total_reserved": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The total number of CVE IDs across all years that the organization has in the RESERVED state."
+    },
+    "available": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The number of CVE IDs that can be reserved by the organization. (e.g., id_quota - total_reserved)"
+    }
+  }
+}

--- a/schemas/registry-org/list-registry-orgs-response.json
+++ b/schemas/registry-org/list-registry-orgs-response.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://cve.mitre.org/schema/org/organization.json",
+  "type": "object",
+  "title": "CVE Registry Orgs List",
+  "description": "JSON Schema for list of CVE Registry Orgs",
+  "properties": {
+		"totalCount": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "itemsPerPage": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "pageCount": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "currentPage": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "prevPage": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "nextPage": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "organizations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "UUID": {
+            "type": "string",
+            "description": "Unique identifier for the organization"
+          },
+          "long_name": {
+            "type": "string",
+            "description": "Full name of the organization"
+          },
+          "short_name": {
+            "type": "string",
+            "description": "Short name or acronym of the organization"
+          },
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Alternative names or aliases for the organization"
+          },
+          "cve_program_org_function": {
+            "type": "string",
+            "enum": ["CNA", "ADP", "Root", "Secretariat"],
+            "description": "The organization's function within the CVE program"
+          },
+          "authority": {
+            "type": "object",
+            "properties": {
+              "active_roles": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["CNA", "ADP", "Root", "Secretariat"]
+                }
+              }
+            },
+            "required": ["active_roles"]
+          },
+          "reports_to": {
+            "type": ["string", "null"],
+            "description": "UUID of the parent organization, if any"
+          },
+          "oversees": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "UUIDs of organizations overseen by this organization"
+          },
+          "root_or_tlr": {
+            "type": "boolean",
+            "description": "Indicates if the organization is a root or top-level root"
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "UUIDs of users associated with this organization"
+          },
+          "charter_or_scope": {
+            "type": "string",
+            "description": "Description of the organization's charter or scope"
+          },
+          "disclosure_policy": {
+            "type": "string",
+            "description": "The organization's disclosure policy"
+          },
+          "product_list": {
+            "type": "string",
+            "description": "List of products associated with the organization"
+          },
+          "soft_quota": {
+            "type": "integer",
+            "description": "Soft quota for CVE IDs"
+          },
+          "hard_quota": {
+            "type": "integer",
+            "description": "Hard quota for CVE IDs"
+          },
+          "contact_info": {
+            "type": "object",
+            "properties": {
+              "additional_contact_users": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "poc": {
+                "type": "string",
+                "description": "Point of contact name"
+              },
+              "poc_email": {
+                "type": "string",
+                "format": "email",
+                "description": "Point of contact email"
+              },
+              "poc_phone": {
+                "type": "string",
+                "description": "Point of contact phone number"
+              },
+              "admins": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "UUIDs of admin users"
+              },
+              "org_email": {
+                "type": "string",
+                "format": "email",
+                "description": "Organization's email address"
+              },
+              "website": {
+                "type": "string",
+                "format": "uri",
+                "description": "Organization's website URL"
+              }
+            },
+            "required": ["poc", "poc_email", "admins", "org_email"]
+          },
+          "in_use": {
+            "type": "boolean",
+            "description": "Indicates if the organization is currently active"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of when the organization was created"
+          },
+          "last_updated": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of the last update to the organization data"
+          }
+        }
+      }
+		}
+	}
+}

--- a/schemas/registry-org/update-registry-org-response.json
+++ b/schemas/registry-org/update-registry-org-response.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://cve.mitre.org/schema/org/organization.json",
+  "type": "object",
+  "title": "CVE Update Registry Org Response",
+  "description": "JSON Schema for CVE Update Registry Org response",
+  "properties": {
+		"message": {
+      "type": "string",
+      "description": "Success description"
+    },
+    "updated": {
+      "type": "object",
+      "properties": {
+        "UUID": {
+          "type": "string",
+          "description": "Unique identifier for the organization"
+        },
+        "long_name": {
+          "type": "string",
+          "description": "Full name of the organization"
+        },
+        "short_name": {
+          "type": "string",
+          "description": "Short name or acronym of the organization"
+        },
+        "aliases": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Alternative names or aliases for the organization"
+        },
+        "cve_program_org_function": {
+          "type": "string",
+          "enum": ["CNA", "ADP", "Root", "Secretariat"],
+          "description": "The organization's function within the CVE program"
+        },
+        "authority": {
+          "type": "object",
+          "properties": {
+            "active_roles": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["CNA", "ADP", "Root", "Secretariat"]
+              }
+            }
+          },
+          "required": ["active_roles"]
+        },
+        "reports_to": {
+          "type": ["string", "null"],
+          "description": "UUID of the parent organization, if any"
+        },
+        "oversees": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "UUIDs of organizations overseen by this organization"
+        },
+        "root_or_tlr": {
+          "type": "boolean",
+          "description": "Indicates if the organization is a root or top-level root"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "UUIDs of users associated with this organization"
+        },
+        "charter_or_scope": {
+          "type": "string",
+          "description": "Description of the organization's charter or scope"
+        },
+        "disclosure_policy": {
+          "type": "string",
+          "description": "The organization's disclosure policy"
+        },
+        "product_list": {
+          "type": "string",
+          "description": "List of products associated with the organization"
+        },
+        "soft_quota": {
+          "type": "integer",
+          "description": "Soft quota for CVE IDs"
+        },
+        "hard_quota": {
+          "type": "integer",
+          "description": "Hard quota for CVE IDs"
+        },
+        "contact_info": {
+          "type": "object",
+          "properties": {
+            "additional_contact_users": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "poc": {
+              "type": "string",
+              "description": "Point of contact name"
+            },
+            "poc_email": {
+              "type": "string",
+              "format": "email",
+              "description": "Point of contact email"
+            },
+            "poc_phone": {
+              "type": "string",
+              "description": "Point of contact phone number"
+            },
+            "admins": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "UUIDs of admin users"
+            },
+            "org_email": {
+              "type": "string",
+              "format": "email",
+              "description": "Organization's email address"
+            },
+            "website": {
+              "type": "string",
+              "format": "uri",
+              "description": "Organization's website URL"
+            }
+          },
+          "required": ["poc", "poc_email", "admins", "org_email"]
+        },
+        "in_use": {
+          "type": "boolean",
+          "description": "Indicates if the organization is currently active"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of when the organization was created"
+        },
+        "last_updated": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last update to the organization data"
+        }
+      }
+    }
+	}
+}

--- a/schemas/registry-user/create-registry-user-request.json
+++ b/schemas/registry-user/create-registry-user-request.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://cve.mitre.org/schema/user/registry-user.json",
+  "type": "object",
+  "title": "CVE Create Registry User Request",
+  "description": "JSON Schema for creating a CVE Registry User",
+  "properties": {
+    "user_id": {
+      "type": "string",
+      "description": "User's identifier or username"
+    },
+    "name": {
+      "type": "object",
+      "properties": {
+        "first": {
+          "type": "string",
+          "description": "User's first name"
+        },
+        "last": {
+          "type": "string",
+          "description": "User's last name"
+        },
+        "middle": {
+          "type": "string",
+          "description": "User's middle name"
+        },
+        "suffix": {
+          "type": "string",
+          "description": "User's name suffix"
+        }
+      },
+      "required": ["first", "last"]
+    },
+    "org_affiliations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "UUIDs of organizations the user is affiliated with"
+    },
+    "cve_program_org_membership": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "UUIDs of CVE program organizations the user is a member of"
+    },
+    "authority": {
+      "type": "object",
+      "properties": {
+        "active_roles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["ADMIN", "PUBLISHER"]
+          }
+        }
+      },
+      "required": ["active_roles"]
+    },
+    "contact_info": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "format": "email",
+          "description": "User's email address"
+        },
+        "phone": {
+          "type": "string",
+          "description": "User's phone number"
+        }
+      },
+      "required": ["email"]
+    }
+  },
+  "required": [
+    "user_id",
+    "name"
+  ]
+}

--- a/schemas/registry-user/create-registry-user-response.json
+++ b/schemas/registry-user/create-registry-user-response.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://cve.mitre.org/schema/user/registry-user.json",
+  "type": "object",
+  "title": "CVE Create Registry User Response",
+  "description": "JSON Schema for CVE Create Registry User response",
+  "properties": {
+		"message": {
+      "type": "string",
+      "description": "Success description"
+    },
+    "created": {
+      "type": "object",
+      "properties": {
+        "UUID": {
+          "type": "string",
+          "description": "Unique identifier for the user"
+        },
+        "user_id": {
+          "type": "string",
+          "description": "User's identifier or username"
+        },
+        "name": {
+          "type": "object",
+          "properties": {
+            "first": {
+              "type": "string",
+              "description": "User's first name"
+            },
+            "last": {
+              "type": "string",
+              "description": "User's last name"
+            },
+            "middle": {
+              "type": "string",
+              "description": "User's middle name"
+            },
+            "suffix": {
+              "type": "string",
+              "description": "User's name suffix"
+            }
+          },
+          "required": ["first", "last"]
+        },
+        "org_affiliations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "UUIDs of organizations the user is affiliated with"
+        },
+        "cve_program_org_membership": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "UUIDs of CVE program organizations the user is a member of"
+        },
+        "authority": {
+          "type": "object",
+          "properties": {
+            "active_roles": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["ADMIN", "PUBLISHER"]
+              }
+            }
+          },
+          "required": ["active_roles"]
+        },
+        "secret": {
+          "type": "string",
+          "description": "Hashed secret for user authentication"
+        },
+        "last_active": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "Timestamp of the user's last activity"
+        },
+        "deactivation_date": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "Timestamp of when the user was deactivated, if applicable"
+        },
+        "contact_info": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "User's email address"
+            },
+            "phone": {
+              "type": "string",
+              "description": "User's phone number"
+            }
+          },
+          "required": ["email"]
+        },
+        "in_use": {
+          "type": "boolean",
+          "description": "Indicates if the user account is currently active"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of when the user account was created"
+        },
+        "last_updated": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last update to the user data"
+        }
+      }
+    }
+	}
+}

--- a/schemas/registry-user/get-registry-user-response.json
+++ b/schemas/registry-user/get-registry-user-response.json
@@ -3,7 +3,7 @@
   "$id": "https://cve.mitre.org/schema/user/registry-user.json",
   "type": "object",
   "title": "CVE Registry User",
-  "description": "JSON Schema for CVE Registry User data",
+  "description": "JSON Schema for CVE Registry User",
   "properties": {
     "UUID": {
       "type": "string",
@@ -121,16 +121,5 @@
       "format": "date-time",
       "description": "Timestamp of the last update to the user data"
     }
-  },
-  "required": [
-    "UUID",
-    "user_id",
-    "name",
-    "authority",
-    "secret",
-    "contact_info",
-    "in_use",
-    "created",
-    "last_updated"
-  ]
+  }
 }

--- a/schemas/registry-user/list-registry-users-response.json
+++ b/schemas/registry-user/list-registry-users-response.json
@@ -1,0 +1,141 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://cve.mitre.org/schema/user/registry-user.json",
+  "type": "object",
+  "title": "CVE Registry Users List",
+  "description": "JSON Schema for list of CVE Registry Users",
+  "properties": {
+		"totalCount": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "itemsPerPage": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "pageCount": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "currentPage": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "prevPage": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "nextPage": {
+      "type": "integer",
+      "format": "int32"
+    },
+    "users": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "UUID": {
+            "type": "string",
+            "description": "Unique identifier for the user"
+          },
+          "user_id": {
+            "type": "string",
+            "description": "User's identifier or username"
+          },
+          "name": {
+            "type": "object",
+            "properties": {
+              "first": {
+                "type": "string",
+                "description": "User's first name"
+              },
+              "last": {
+                "type": "string",
+                "description": "User's last name"
+              },
+              "middle": {
+                "type": "string",
+                "description": "User's middle name"
+              },
+              "suffix": {
+                "type": "string",
+                "description": "User's name suffix"
+              }
+            },
+            "required": ["first", "last"]
+          },
+          "org_affiliations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "UUIDs of organizations the user is affiliated with"
+          },
+          "cve_program_org_membership": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "UUIDs of CVE program organizations the user is a member of"
+          },
+          "authority": {
+            "type": "object",
+            "properties": {
+              "active_roles": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "enum": ["ADMIN", "PUBLISHER"]
+                }
+              }
+            },
+            "required": ["active_roles"]
+          },
+          "secret": {
+            "type": "string",
+            "description": "Hashed secret for user authentication"
+          },
+          "last_active": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "Timestamp of the user's last activity"
+          },
+          "deactivation_date": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "Timestamp of when the user was deactivated, if applicable"
+          },
+          "contact_info": {
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string",
+                "format": "email",
+                "description": "User's email address"
+              },
+              "phone": {
+                "type": "string",
+                "description": "User's phone number"
+              }
+            },
+            "required": ["email"]
+          },
+          "in_use": {
+            "type": "boolean",
+            "description": "Indicates if the user account is currently active"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of when the user account was created"
+          },
+          "last_updated": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of the last update to the user data"
+          }
+        }
+      }
+		}
+	}
+}

--- a/schemas/registry-user/update-registry-user-response.json
+++ b/schemas/registry-user/update-registry-user-response.json
@@ -1,0 +1,118 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://cve.mitre.org/schema/user/registry-user.json",
+  "type": "object",
+  "title": "CVE Update Registry User Response",
+  "description": "JSON Schema for CVE Update Registry User response",
+  "properties": {
+		"message": {
+      "type": "string",
+      "description": "Success description"
+    },
+    "updated": {
+      "type": "object",
+      "properties": {
+        "UUID": {
+          "type": "string",
+          "description": "Unique identifier for the user"
+        },
+        "user_id": {
+          "type": "string",
+          "description": "User's identifier or username"
+        },
+        "name": {
+          "type": "object",
+          "properties": {
+            "first": {
+              "type": "string",
+              "description": "User's first name"
+            },
+            "last": {
+              "type": "string",
+              "description": "User's last name"
+            },
+            "middle": {
+              "type": "string",
+              "description": "User's middle name"
+            },
+            "suffix": {
+              "type": "string",
+              "description": "User's name suffix"
+            }
+          },
+          "required": ["first", "last"]
+        },
+        "org_affiliations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "UUIDs of organizations the user is affiliated with"
+        },
+        "cve_program_org_membership": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "UUIDs of CVE program organizations the user is a member of"
+        },
+        "authority": {
+          "type": "object",
+          "properties": {
+            "active_roles": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["ADMIN", "PUBLISHER"]
+              }
+            }
+          },
+          "required": ["active_roles"]
+        },
+        "secret": {
+          "type": "string",
+          "description": "Hashed secret for user authentication"
+        },
+        "last_active": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "Timestamp of the user's last activity"
+        },
+        "deactivation_date": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "Timestamp of when the user was deactivated, if applicable"
+        },
+        "contact_info": {
+          "type": "object",
+          "properties": {
+            "email": {
+              "type": "string",
+              "format": "email",
+              "description": "User's email address"
+            },
+            "phone": {
+              "type": "string",
+              "description": "User's phone number"
+            }
+          },
+          "required": ["email"]
+        },
+        "in_use": {
+          "type": "boolean",
+          "description": "Indicates if the user account is currently active"
+        },
+        "created": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of when the user account was created"
+        },
+        "last_updated": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Timestamp of the last update to the user data"
+        }
+      }
+    }
+	}
+}

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -91,7 +91,7 @@ router.get('/org',
   controller.ORG_ALL)
 
 router.post(
-  "/org",
+  '/org',
   /*
   #swagger.tags = ['Organization']
   #swagger.operationId = 'orgCreateSingle'
@@ -175,16 +175,16 @@ router.post(
     }
   }
   */
-  param(["registry"]).optional().isBoolean(),
+  param(['registry']).optional().isBoolean(),
   mw.validateUser,
   mw.onlySecretariat,
   validateCreateOrgParameters(),
   parseError,
   parsePostParams,
   controller.ORG_CREATE_SINGLE
-);
+)
 router.get(
-  "/org/:identifier",
+  '/org/:identifier',
   /*
   #swagger.tags = ['Organization']
   #swagger.operationId = 'orgSingle'
@@ -257,12 +257,12 @@ router.get(
   }
   */
   mw.validateUser,
-  param(["registry"]).optional().isBoolean(),
-  param(["identifier"]).isString().trim(),
+  param(['registry']).optional().isBoolean(),
+  param(['identifier']).isString().trim(),
   parseError,
   parseGetParams,
   controller.ORG_SINGLE
-);
+)
 router.put('/org/:shortname',
   /*
   #swagger.tags = ['Organization']

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -21,6 +21,7 @@ router.get('/org',
         <p><b>Secretariat:</b> Retrieves information about all organizations</p>"
   #swagger.parameters['$ref'] = [
     '#/components/parameters/pageQuery',
+    '#/components/parameters/registry',
     '#/components/parameters/apiEntityHeader',
     '#/components/parameters/apiUserHeader',
     '#/components/parameters/apiSecretHeader'
@@ -29,7 +30,12 @@ router.get('/org',
     description: 'Returns information about all organizations, along with pagination fields if results span multiple pages of data',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/org/list-orgs-response.json' }
+        schema: {
+          oneOf: [
+            { $ref: '../schemas/org/list-orgs-response.json' },
+            { $ref: '../schemas/registry-org/list-registry-orgs-response.json' }
+          ]
+        }
       }
     }
   }
@@ -84,7 +90,8 @@ router.get('/org',
   parseGetParams,
   controller.ORG_ALL)
 
-router.post('/org',
+router.post(
+  "/org",
   /*
   #swagger.tags = ['Organization']
   #swagger.operationId = 'orgCreateSingle'
@@ -96,6 +103,7 @@ router.post('/org',
         <p><b>Secretariat:</b> Creates an organization</p>
   "
   #swagger.parameters['$ref'] = [
+    '#/components/parameters/registry',
     '#/components/parameters/apiEntityHeader',
     '#/components/parameters/apiUserHeader',
     '#/components/parameters/apiSecretHeader'
@@ -104,7 +112,12 @@ router.post('/org',
     required: true,
     content: {
       'application/json': {
-        schema: { $ref: '../schemas/org/create-org-request.json' }
+        schema: {
+          oneOf: [
+            { $ref: '../schemas/org/create-org-request.json' },
+            { $ref: '../schemas/registry-org/create-registry-org-request.json' }
+          ]
+        }
       }
     }
   }
@@ -112,7 +125,12 @@ router.post('/org',
     description: 'Returns information about the organization created',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/org/create-org-response.json' }
+        schema: {
+          oneOf: [
+            { $ref: '../schemas/org/create-org-response.json' },
+            { $ref: '../schemas/registry-org/create-registry-org-response.json' }
+          ]
+        }
       }
     }
   }
@@ -157,14 +175,16 @@ router.post('/org',
     }
   }
   */
-  param(['registry']).optional().isBoolean(),
+  param(["registry"]).optional().isBoolean(),
   mw.validateUser,
   mw.onlySecretariat,
   validateCreateOrgParameters(),
   parseError,
   parsePostParams,
-  controller.ORG_CREATE_SINGLE)
-router.get('/org/:identifier',
+  controller.ORG_CREATE_SINGLE
+);
+router.get(
+  "/org/:identifier",
   /*
   #swagger.tags = ['Organization']
   #swagger.operationId = 'orgSingle'
@@ -177,6 +197,7 @@ router.get('/org/:identifier',
         <p><b>Secretariat:</b> Retrieves information about any organization</p>"
   #swagger.parameters['identifier'] = { description: 'The shortname or UUID of the organization' }
   #swagger.parameters['$ref'] = [
+    '#/components/parameters/registry',
     '#/components/parameters/apiEntityHeader',
     '#/components/parameters/apiUserHeader',
     '#/components/parameters/apiSecretHeader'
@@ -185,7 +206,12 @@ router.get('/org/:identifier',
     description: 'Returns the organization information',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/org/get-org-response.json' }
+        schema: {
+          oneOf: [
+            { $ref: '../schemas/org/get-org-response.json' },
+            { $ref: '../schemas/registry-org/get-registry-org-response.json' }
+          ]
+        }
       }
     }
   }
@@ -231,11 +257,12 @@ router.get('/org/:identifier',
   }
   */
   mw.validateUser,
-  param(['registry']).optional().isBoolean(),
-  param(['identifier']).isString().trim(),
+  param(["registry"]).optional().isBoolean(),
+  param(["identifier"]).isString().trim(),
   parseError,
   parseGetParams,
-  controller.ORG_SINGLE)
+  controller.ORG_SINGLE
+);
 router.put('/org/:shortname',
   /*
   #swagger.tags = ['Organization']
@@ -253,6 +280,7 @@ router.put('/org/:shortname',
     '#/components/parameters/newShortname',
     '#/components/parameters/active_roles_add',
     '#/components/parameters/active_roles_remove',
+    '#/components/parameters/registry',
     '#/components/parameters/apiEntityHeader',
     '#/components/parameters/apiUserHeader',
     '#/components/parameters/apiSecretHeader'
@@ -261,7 +289,12 @@ router.put('/org/:shortname',
     description: 'Returns information about the organization updated',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/org/update-org-response.json' }
+        schema: {
+          oneOf: [
+            { $ref: '../schemas/org/update-org-response.json' },
+            { $ref: '../schemas/registry-org/update-registry-org-response.json' }
+          ]
+        }
       }
     }
   }
@@ -326,6 +359,7 @@ router.get('/org/:shortname/id_quota',
         <p><b>Secretariat:</b> Retrieves the CVE ID quota for any organization</p>"
   #swagger.parameters['shortname'] = { description: 'The shortname of the organization' }
   #swagger.parameters['$ref'] = [
+    '#/components/parameters/registry',
     '#/components/parameters/apiEntityHeader',
     '#/components/parameters/apiUserHeader',
     '#/components/parameters/apiSecretHeader'
@@ -334,7 +368,12 @@ router.get('/org/:shortname/id_quota',
     description: 'Returns the CVE ID quota for an organization',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/org/get-org-quota-response.json' }
+        schema: {
+          oneOf: [
+            { $ref: '../schemas/org/get-org-quota-response.json' },
+            { $ref: '../schemas/registry-org/get-registry-org-quota-response.json' }
+          ]
+        }
       }
     }
   }
@@ -399,6 +438,7 @@ router.get('/org/:shortname/users',
   #swagger.parameters['shortname'] = { description: 'The shortname of the organization' }
   #swagger.parameters['$ref'] = [
     '#/components/parameters/pageQuery',
+    '#/components/parameters/registry',
     '#/components/parameters/apiEntityHeader',
     '#/components/parameters/apiUserHeader',
     '#/components/parameters/apiSecretHeader'
@@ -407,7 +447,12 @@ router.get('/org/:shortname/users',
     description: 'Returns all users for the organization, along with pagination fields if results span multiple pages of data',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/user/list-users-response.json' }
+        schema: {
+          oneOf: [
+            { $ref: '../schemas/user/list-users-response.json' },
+            { $ref: '../schemas/registry-user/list-registry-users-response.json' }
+          ]
+        }
       }
     }
   }
@@ -472,6 +517,7 @@ router.post('/org/:shortname/user',
         <p><b>Secretariat:</b> Creates a user for any organization</p>"
   #swagger.parameters['shortname'] = { description: 'The shortname of the organization' }
   #swagger.parameters['$ref'] = [
+    '#/components/parameters/registry',
     '#/components/parameters/apiEntityHeader',
     '#/components/parameters/apiUserHeader',
     '#/components/parameters/apiSecretHeader'
@@ -480,7 +526,12 @@ router.post('/org/:shortname/user',
     required: true,
     content: {
       'application/json': {
-        schema: { $ref: '../schemas/user/create-user-request.json' },
+        schema: {
+          oneOf: [
+            { $ref: '../schemas/user/create-user-request.json' },
+            { $ref: '../schemas/registry-user/create-registry-user-request.json' }
+          ]
+        },
       }
     }
   }
@@ -488,7 +539,12 @@ router.post('/org/:shortname/user',
     description: 'Returns the new user information (with the secret)',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/user/create-user-response.json' },
+        schema: {
+          oneOf: [
+            { $ref: '../schemas/user/create-user-response.json' },
+            { $ref: '../schemas/registry-user/create-registry-user-response.json' }
+          ]
+        }
       }
     }
   }
@@ -573,6 +629,7 @@ router.get('/org/:shortname/user/:username',
   #swagger.parameters['shortname'] = { description: 'The shortname of the organization' }
   #swagger.parameters['username'] = { description: 'The username of the user' }
   #swagger.parameters['$ref'] = [
+    '#/components/parameters/registry',
     '#/components/parameters/apiEntityHeader',
     '#/components/parameters/apiUserHeader',
     '#/components/parameters/apiSecretHeader'
@@ -581,7 +638,12 @@ router.get('/org/:shortname/user/:username',
     description: 'Returns information about the specified user',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/user/get-user-response.json' }
+        schema: {
+          oneOf: [
+            { $ref: '../schemas/user/get-user-response.json' },
+            { $ref: '../schemas/registry-user/get-registry-user-response.json' }
+          ]
+        }
       }
     }
   }
@@ -657,6 +719,7 @@ router.put('/org/:shortname/user/:username',
     '#/components/parameters/nameSuffix',
     '#/components/parameters/newUsername',
     '#/components/parameters/orgShortname',
+    '#/components/parameters/registry',
     '#/components/parameters/apiEntityHeader',
     '#/components/parameters/apiUserHeader',
     '#/components/parameters/apiSecretHeader'
@@ -665,7 +728,12 @@ router.put('/org/:shortname/user/:username',
     description: 'Returns the updated user information',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/user/update-user-response.json' }
+        schema: {
+          oneOf: [
+            { $ref: '../schemas/user/update-user-response.json' },
+            { $ref: '../schemas/registry-user/update-registry-user-response.json' }
+          ]
+        }
       }
     }
   }

--- a/src/controller/schemas.controller/index.js
+++ b/src/controller/schemas.controller/index.js
@@ -50,9 +50,18 @@ router.get('/user/reset-secret-response.json', controller.getResetSecretResponse
 router.get('/user/update-user-response.json', controller.getUpdateUserResponseSchema)
 
 // Schemas relating to Registry-Org
+router.get('/registry-org/create-registry-org-request.json', controller.getCreateRegistryOrgRequestSchema)
+router.get('/registry-org/create-registry-org-response.json', controller.getCreateRegistryOrgResponseSchema)
 router.get('/registry-org/get-registry-org-response.json', controller.getRegistryOrgResponseSchema)
+router.get('/registry-org/get-registry-org-quota-response.json', controller.getRegistryOrgQuotaResponseSchema)
+router.get('/registry-org/list-registry-orgs-response.json', controller.getListRegistryOrgsResponseSchema)
+router.get('/registry-org/update-registry-org-response.json', controller.getUpdateRegistryOrgResponseSchema)
 
 // Schemas relating to Registry-User
-router.get('/registry-user/get-registry-users-response.json', controller.getRegistryUserResponseSchema)
+router.get('/registry-user/create-registry-user-request.json', controller.getCreateRegistryUserRequestSchema)
+router.get('/registry-user/create-registry-user-response.json', controller.getCreateRegistryUserResponseSchema)
+router.get('/registry-user/get-registry-user-response.json', controller.getRegistryUserResponseSchema)
+router.get('/registry-user/list-registry-users-response.json', controller.getListRegistryUsersResponseSchema)
+router.get('/registry-user/update-registry-user-response.json', controller.getUpdateRegistryUserResponseSchema)
 
 module.exports = router

--- a/src/controller/schemas.controller/schemas.controller.js
+++ b/src/controller/schemas.controller/schemas.controller.js
@@ -230,16 +230,16 @@ async function getCveCountResponseSchema (req, res) {
 
 // Schemas relating to Registry Orgs
 
-async function getCreateRegistryOrgRequestSchema(req, res) {
-  const createRegistryOrgRequestSchema = require("../../../schemas/registry-org/create-registry-org-request.json");
-  res.json(createRegistryOrgRequestSchema);
-  res.status(200);
+async function getCreateRegistryOrgRequestSchema (req, res) {
+  const createRegistryOrgRequestSchema = require('../../../schemas/registry-org/create-registry-org-request.json')
+  res.json(createRegistryOrgRequestSchema)
+  res.status(200)
 }
 
-async function getCreateRegistryOrgResponseSchema(req, res) {
-  const createRegistryOrgResponseSchema = require("../../../schemas/registry-org/create-registry-org-response.json");
-  res.json(createRegistryOrgResponseSchema);
-  res.status(200);
+async function getCreateRegistryOrgResponseSchema (req, res) {
+  const createRegistryOrgResponseSchema = require('../../../schemas/registry-org/create-registry-org-response.json')
+  res.json(createRegistryOrgResponseSchema)
+  res.status(200)
 }
 
 async function getRegistryOrgResponseSchema (req, res) {
@@ -248,54 +248,54 @@ async function getRegistryOrgResponseSchema (req, res) {
   res.status(200)
 }
 
-async function getRegistryOrgQuotaResponseSchema(req, res) {
-  const registryOrgQuotaResponseSchema = require("../../../schemas/registry-org/get-registry-org-quota-response.json");
-  res.json(registryOrgQuotaResponseSchema);
-  res.status(200);
+async function getRegistryOrgQuotaResponseSchema (req, res) {
+  const registryOrgQuotaResponseSchema = require('../../../schemas/registry-org/get-registry-org-quota-response.json')
+  res.json(registryOrgQuotaResponseSchema)
+  res.status(200)
 }
 
-async function getListRegistryOrgsResponseSchema(req, res) {
-  const listRegistryOrgsResponseSchema = require("../../../schemas/registry-org/list-registry-orgs-response.json");
-  res.json(listRegistryOrgsResponseSchema);
-  res.status(200);
+async function getListRegistryOrgsResponseSchema (req, res) {
+  const listRegistryOrgsResponseSchema = require('../../../schemas/registry-org/list-registry-orgs-response.json')
+  res.json(listRegistryOrgsResponseSchema)
+  res.status(200)
 }
 
-async function getUpdateRegistryOrgResponseSchema(req, res) {
-  const updateRegistryOrgResponseSchema = require("../../../schemas/registry-org/update-registry-org-response.json");
-  res.json(updateRegistryOrgResponseSchema);
-  res.status(200);
+async function getUpdateRegistryOrgResponseSchema (req, res) {
+  const updateRegistryOrgResponseSchema = require('../../../schemas/registry-org/update-registry-org-response.json')
+  res.json(updateRegistryOrgResponseSchema)
+  res.status(200)
 }
 
 // Schemas relating to Registry Users
 
-async function getCreateRegistryUserRequestSchema(req, res) {
-  const createRegistryUserRequestSchema = require("../../../schemas/registry-user/create-registry-user-request.json");
-  res.json(createRegistryUserRequestSchema);
-  res.status(200);
+async function getCreateRegistryUserRequestSchema (req, res) {
+  const createRegistryUserRequestSchema = require('../../../schemas/registry-user/create-registry-user-request.json')
+  res.json(createRegistryUserRequestSchema)
+  res.status(200)
 }
 
-async function getCreateRegistryUserResponseSchema(req, res) {
-  const createRegistryUserResponseSchema = require("../../../schemas/registry-user/create-registry-user-response.json");
-  res.json(createRegistryUserResponseSchema);
-  res.status(200);
+async function getCreateRegistryUserResponseSchema (req, res) {
+  const createRegistryUserResponseSchema = require('../../../schemas/registry-user/create-registry-user-response.json')
+  res.json(createRegistryUserResponseSchema)
+  res.status(200)
 }
 
-async function getRegistryUserResponseSchema(req, res) {
-  const registryUserResponseSchema = require("../../../schemas/registry-user/get-registry-user-response.json");
-  res.json(registryUserResponseSchema);
-  res.status(200);
+async function getRegistryUserResponseSchema (req, res) {
+  const registryUserResponseSchema = require('../../../schemas/registry-user/get-registry-user-response.json')
+  res.json(registryUserResponseSchema)
+  res.status(200)
 }
 
 async function getListRegistryUsersResponseSchema (req, res) {
   const listRegistryUsersResponseSchema = require('../../../schemas/registry-user/list-registry-users-response.json')
-  res.json(listRegistryUsersResponseSchema);
+  res.json(listRegistryUsersResponseSchema)
   res.status(200)
 }
 
-async function getUpdateRegistryUserResponseSchema(req, res) {
-  const updateRegistryUserResponseSchema = require("../../../schemas/registry-user/update-registry-user-response.json");
-  res.json(updateRegistryUserResponseSchema);
-  res.status(200);
+async function getUpdateRegistryUserResponseSchema (req, res) {
+  const updateRegistryUserResponseSchema = require('../../../schemas/registry-user/update-registry-user-response.json')
+  res.json(updateRegistryUserResponseSchema)
+  res.status(200)
 }
 
 module.exports = {

--- a/src/controller/schemas.controller/schemas.controller.js
+++ b/src/controller/schemas.controller/schemas.controller.js
@@ -228,16 +228,74 @@ async function getCveCountResponseSchema (req, res) {
   res.status(200)
 }
 
+// Schemas relating to Registry Orgs
+
+async function getCreateRegistryOrgRequestSchema(req, res) {
+  const createRegistryOrgRequestSchema = require("../../../schemas/registry-org/create-registry-org-request.json");
+  res.json(createRegistryOrgRequestSchema);
+  res.status(200);
+}
+
+async function getCreateRegistryOrgResponseSchema(req, res) {
+  const createRegistryOrgResponseSchema = require("../../../schemas/registry-org/create-registry-org-response.json");
+  res.json(createRegistryOrgResponseSchema);
+  res.status(200);
+}
+
 async function getRegistryOrgResponseSchema (req, res) {
   const registryOrgResponseSchema = require('../../../schemas/registry-org/get-registry-org-response.json')
   res.json(registryOrgResponseSchema)
   res.status(200)
 }
 
-async function getRegistryUserResponseSchema (req, res) {
-  const registryUserResponseSchema = require('../../../schemas/registry-user/get-registry-users-response.json')
-  res.json(registryUserResponseSchema)
+async function getRegistryOrgQuotaResponseSchema(req, res) {
+  const registryOrgQuotaResponseSchema = require("../../../schemas/registry-org/get-registry-org-quota-response.json");
+  res.json(registryOrgQuotaResponseSchema);
+  res.status(200);
+}
+
+async function getListRegistryOrgsResponseSchema(req, res) {
+  const listRegistryOrgsResponseSchema = require("../../../schemas/registry-org/list-registry-orgs-response.json");
+  res.json(listRegistryOrgsResponseSchema);
+  res.status(200);
+}
+
+async function getUpdateRegistryOrgResponseSchema(req, res) {
+  const updateRegistryOrgResponseSchema = require("../../../schemas/registry-org/update-registry-org-response.json");
+  res.json(updateRegistryOrgResponseSchema);
+  res.status(200);
+}
+
+// Schemas relating to Registry Users
+
+async function getCreateRegistryUserRequestSchema(req, res) {
+  const createRegistryUserRequestSchema = require("../../../schemas/registry-user/create-registry-user-request.json");
+  res.json(createRegistryUserRequestSchema);
+  res.status(200);
+}
+
+async function getCreateRegistryUserResponseSchema(req, res) {
+  const createRegistryUserResponseSchema = require("../../../schemas/registry-user/create-registry-user-response.json");
+  res.json(createRegistryUserResponseSchema);
+  res.status(200);
+}
+
+async function getRegistryUserResponseSchema(req, res) {
+  const registryUserResponseSchema = require("../../../schemas/registry-user/get-registry-user-response.json");
+  res.json(registryUserResponseSchema);
+  res.status(200);
+}
+
+async function getListRegistryUsersResponseSchema (req, res) {
+  const listRegistryUsersResponseSchema = require('../../../schemas/registry-user/list-registry-users-response.json')
+  res.json(listRegistryUsersResponseSchema);
   res.status(200)
+}
+
+async function getUpdateRegistryUserResponseSchema(req, res) {
+  const updateRegistryUserResponseSchema = require("../../../schemas/registry-user/update-registry-user-response.json");
+  res.json(updateRegistryUserResponseSchema);
+  res.status(200);
 }
 
 module.exports = {
@@ -278,6 +336,15 @@ module.exports = {
   getCnaSecretariatFullSchema: getCnaSecretariatFullSchema,
   getCnaMinSchema: getCnaMinSchema,
   getCveCountResponseSchema: getCveCountResponseSchema,
+  getCreateRegistryOrgRequestSchema: getCreateRegistryOrgRequestSchema,
+  getCreateRegistryOrgResponseSchema: getCreateRegistryOrgResponseSchema,
   getRegistryOrgResponseSchema: getRegistryOrgResponseSchema,
-  getRegistryUserResponseSchema: getRegistryUserResponseSchema
+  getRegistryOrgQuotaResponseSchema: getRegistryOrgQuotaResponseSchema,
+  getListRegistryOrgsResponseSchema: getListRegistryOrgsResponseSchema,
+  getUpdateRegistryOrgResponseSchema: getUpdateRegistryOrgResponseSchema,
+  getCreateRegistryUserRequestSchema: getCreateRegistryUserRequestSchema,
+  getCreateRegistryUserResponseSchema: getCreateRegistryUserResponseSchema,
+  getRegistryUserResponseSchema: getRegistryUserResponseSchema,
+  getListRegistryUsersResponseSchema: getListRegistryUsersResponseSchema,
+  getUpdateRegistryUserResponseSchema: getUpdateRegistryUserResponseSchema
 }

--- a/src/controller/user.controller/index.js
+++ b/src/controller/user.controller/index.js
@@ -19,6 +19,7 @@ router.get('/users',
         <p><b>Secretariat:</b> Retrieves information about all users for all organizations</p>"
   #swagger.parameters['$ref'] = [
     '#/components/parameters/pageQuery',
+    '#/components/parameters/registry',
     '#/components/parameters/apiEntityHeader',
     '#/components/parameters/apiUserHeader',
     '#/components/parameters/apiSecretHeader'
@@ -27,7 +28,12 @@ router.get('/users',
     description: 'Returns all users, along with pagination fields if results span multiple pages of data.',
     content:{
       "application/json":{
-        schema: { $ref: '../schemas/user/list-users-response.json' }
+        schema: {
+          oneOf: [
+            { $ref: '../schemas/user/list-users-response.json' },
+            { $ref: '../schemas/registry-user/list-registry-users-response.json' }
+          ]
+        }
       }
     }
   }

--- a/src/swagger.js
+++ b/src/swagger.js
@@ -457,6 +457,15 @@ const doc = {
           minimum: 1
         }
       },
+      registry: {
+        in: 'query',
+        name: 'registry',
+        description: 'When set to true, the endpoint will expect request data to conform to the applicable User Registry schema, and will provide response data conforming to the applicable User Registry schema. Defaults to false.',
+        required: false,
+        schema: {
+          type: 'boolean'
+        }
+      },
       short_name: {
         in: 'query',
         name: 'short_name',


### PR DESCRIPTION
# Summary
Swagger documentation updates for backwards compatibility endpoints

# Important Changes
- Added new schemas for registry user/org request and response objects, and routes to fetch these schemas
- Modified swagger documentation for legacy endpoints to include `registry` parameter and reference both the legacy and registry schema types
- Newly generated `openapi.json` file reflecting the documentation updates
