### PR TITLE
Resolves issue 1412 Create Registry Tests - createUserTest.js

### DIFF
--- a/test/integration-tests/user/createUserTest.js
+++ b/test/integration-tests/user/createUserTest.js
@@ -22,6 +22,20 @@ const body = {
   }
 }
 
+const registryBody = {
+  user_id: 'adpUser2',
+  active: 'true',
+  name: {
+    first: 'SecondTestCnaAdmin',
+    last: 'test',
+    middle: 'N',
+    suffix: 'I'
+  },
+  authority: {
+    active_roles: ['Admin']
+  }
+}
+
 const nonAdminBody = {
   username: 'nonAdminUser',
   active: 'true',
@@ -33,6 +47,23 @@ const nonAdminBody = {
   },
   authority: {
   }
+}
+
+const registryNonAdminBody = {
+  user_id: 'nonAdminUser2',
+  active: 'true',
+  name: {
+    first: 'SecondTestCnaAdmin',
+    last: 'test',
+    middle: 'N',
+    suffix: 'I'
+  },
+  authority: {
+  }
+}
+
+const registryFlag = {
+  registry: true
 }
 
 describe('Testing create user endpoint', () => {
@@ -49,6 +80,20 @@ describe('Testing create user endpoint', () => {
         done()
       })
   })
+  it('Should return 200 and new user with registry enabled', (done) => {
+    chai.request(app)
+      .post('/api/org/range_4/user')
+      .set(constants.headers)
+      .query(registryFlag)
+      .send(registryBody)
+      .end((err, res) => {
+        expect(err).to.be.null
+        expect(res.body).to.have.property('created')
+        expect(res.body.created.user_id).to.equal(registryBody.user_id)
+        expect(res).to.have.status(200)
+        done()
+      })
+  })
   it('Should return 200 and create a non admin user', (done) => {
     chai.request(app)
       .post('/api/org/range_4/user')
@@ -58,6 +103,20 @@ describe('Testing create user endpoint', () => {
         expect(err).to.be.null
         expect(res.body).to.have.property('created')
         expect(res.body.created.username).to.equal(nonAdminBody.username)
+        expect(res).to.have.status(200)
+        done()
+      })
+  })
+  it('Should return 200 and create a non admin user with registry enabled', (done) => {
+    chai.request(app)
+      .post('/api/org/range_4/user')
+      .set(constants.headers)
+      .query(registryFlag)
+      .send(registryNonAdminBody)
+      .end((err, res) => {
+        expect(err).to.be.null
+        expect(res.body).to.have.property('created')
+        expect(res.body.created.user_id).to.equal(registryNonAdminBody.user_id)
         expect(res).to.have.status(200)
         done()
       })


### PR DESCRIPTION
Closes Issue 1412

# Summary
Added tests to validate that Users can be created when the registry flag is set to true

# Important Changes
`createUserTest.js`
- Added new request body constants
- Added new tests to check the creation of a user when the registry flag is set to true

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Ensure mongo is up and running, with replication on
- [ ] 2) Run `npm run test:integration`, while targeting localhost mongo
