### PR TITLE
Resolves issue #1414, Creating node registry tests replacing the ones in org_as_org_admin.py

### DIFF
--- a/test/integration-tests/org/registryOrgAsOrgAdmin.js
+++ b/test/integration-tests/org/registryOrgAsOrgAdmin.js
@@ -1,0 +1,457 @@
+/* eslint-disable no-unused-expressions */
+const chai = require('chai')
+chai.use(require('chai-http'))
+
+const expect = chai.expect
+const constants = require('../constants.js')
+const app = require('../../../src/index.js')
+const _ = require('lodash')
+
+const shortName = 'beat_10'
+const userId = 'drocca@test.mitre.org'
+
+const adminHeaders = {
+  'CVE-API-ORG': shortName,
+  'content-type': 'application/json',
+  'CVE-API-USER': userId
+}
+
+describe('Testing Registry Org as org admin', () => {
+  let secret
+  before(async () => {
+    await chai.request(app)
+      .post('/api/org/beat_10/user?registry=true')
+      .set(constants.headers)
+      .send(
+        {
+          user_id: userId,
+          authority: {
+            active_roles: ['ADMIN']
+          }
+        }
+      ).then((res, err) => {
+        expect(err).to.be.undefined
+        secret = res.body.created.secret
+        adminHeaders['CVE-API-KEY'] = secret
+      })
+
+    await chai.request(app)
+      .post('/api/org/beat_10/user?registry=true')
+      .set(constants.headers)
+      .send(
+        {
+          user_id: 'second_user@beat_10.mitre.org'
+        }
+      ).then((res, err) => {
+        expect(err).to.be.undefined
+      })
+
+    await chai.request(app)
+      .post('/api/org/beat_10/user?registry=true')
+      .set(constants.headers)
+      .send(
+        {
+          user_id: 'third_user@beat_10.mitre.org'
+        }
+      ).then((res, err) => {
+        expect(err).to.be.undefined
+      })
+  })
+  context('Positive Tests', () => {
+    it('Registry: reset secret for user in org', async () => {
+      await chai.request(app)
+        .put('/api/org/beat_10/user/second_user@beat_10.mitre.org/reset_secret?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+        })
+    })
+    it('Registry: reset secret for self admin', async () => {
+      await chai.request(app)
+        .put('/api/org/beat_10/user/drocca@test.mitre.org/reset_secret?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          secret = res.body['API-secret']
+          adminHeaders['CVE-API-KEY'] = secret
+        })
+
+      await chai.request(app)
+        .get('/api/org/beat_10/user/drocca@test.mitre.org?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(_.some(res.body.cve_program_org_membership, (obj) => _.includes(obj.roles, 'ADMIN'))).to.be.true
+        })
+    })
+    it('Registry: allows admin users to update a user username', async () => {
+      await chai.request(app)
+        .put('/api/org/beat_10/user/second_user@beat_10.mitre.org?registry=true&new_username=second_user_update@beat_10.mitre.org')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.updated.user_id).to.equal('second_user_update@beat_10.mitre.org')
+        })
+    })
+    it('Registry: allows admin users to update a users name', async () => {
+      await chai.request(app)
+        .put('/api/org/beat_10/user/third_user@beat_10.mitre.org?registry=true&name.first=t&name.last=e&name.middle=s&name.suffix=t')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.updated.name.first).to.equal('t')
+          expect(res.body.updated.name.last).to.equal('e')
+          expect(res.body.updated.name.middle).to.equal('s')
+          expect(res.body.updated.name.suffix).to.equal('t')
+        })
+    })
+    it('Registry: allows admin users to update their own name', async () => {
+      await chai.request(app)
+        .put('/api/org/beat_10/user/drocca@test.mitre.org?registry=true&name.first=t&name.last=e&name.middle=s&name.suffix=t')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.updated.name.first).to.equal('t')
+          expect(res.body.updated.name.last).to.equal('e')
+          expect(res.body.updated.name.middle).to.equal('s')
+          expect(res.body.updated.name.suffix).to.equal('t')
+        })
+    })
+    it('Registry: allows admin users to add a users role', async () => {
+      await chai.request(app)
+        .put('/api/org/beat_10/user/third_user@beat_10.mitre.org?registry=true&active_roles.add=admin')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(_.some(res.body.updated.cve_program_org_membership, (obj) => _.includes(obj.roles, 'ADMIN'))).to.be.true
+        })
+    })
+    it('Registry: allows admin users to remove a users role', async () => {
+      await chai.request(app)
+        .put('/api/org/beat_10/user/third_user@beat_10.mitre.org?registry=true&active_roles.remove=admin')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(_.some(res.body.updated.cve_program_org_membership, (obj) => _.includes(obj.roles, 'ADMIN'))).to.be.false
+        })
+    })
+    it('Registry: page must be a positive int', async () => {
+      await chai.request(app)
+        .get(`/api/org/${shortName}/users?registry=true&page=1`)
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+        })
+    })
+    it('Registry: services api allows org admins to get their own org document', async () => {
+      await chai.request(app)
+        .get(`/api/org/${shortName}?registry=true`)
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.short_name).to.equal(shortName)
+        })
+    })
+    it('Registry: services api allows org admins to get their own user list', async () => {
+      await chai.request(app)
+        .get(`/api/org/${shortName}/users?registry=true`)
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.users).length.greaterThan(0)
+        })
+    })
+    it('Registry: services api allows org admins to get their own user info', async () => {
+      await chai.request(app)
+        .get(`/api/org/${shortName}/user/${userId}?registry=true`)
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.user_id).to.equal(userId)
+        })
+    })
+    it('Registry: services api allows org admins to get their own org quota', async () => {
+      await chai.request(app)
+        .get(`/api/org/${shortName}/id_quota?registry=true`)
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.hard_quota).to.be.lessThan(100000)
+          expect(res.body.hard_quota).to.be.greaterThan(0)
+        })
+    })
+  })
+  context('Negative Tests', () => {
+    it('Registry: reset secret for fails user in other org', async () => {
+      await chai.request(app)
+        .put('/api/org/range_4/user/scottmitchell@range_4.com/reset_secret?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('NOT_SAME_ORG_OR_SECRETARIAT')
+        })
+    })
+    it('Registry: reset secret for fails user dne', async () => {
+      await chai.request(app)
+        .put('/api/org/beat_10/user/asdf/reset_secret?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(404)
+          expect(res.body.error).to.equal('USER_DNE')
+        })
+    })
+    it('Registry: rest secret fails for org dne', async () => {
+      await chai.request(app)
+        .put('/api/org/fake_org/user/second_user@beat_10.mitre.org/reset_secret?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(404)
+          expect(res.body.error).to.equal('ORG_DNE_PARAM')
+        })
+    })
+    it('Registry: does not allow an admin to self demote', async () => {
+      await chai.request(app)
+        .put('/api/org/beat_10/user/drocca@test.mitre.org?registry=true&active_roles.remove=admin')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('NOT_ALLOWED_TO_SELF_DEMOTE')
+        })
+    })
+    it('Registry: Services api prevents org admins from updating a users user_id if that user already exists', async () => {
+      await chai.request(app)
+        .put('/api/org/beat_10/user/patriciawilliams@beat_10.com?registry=true&new_username=drocca@test.mitre.org')
+        .set(adminHeaders)
+        .send({
+          user_id: userId
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('DUPLICATE_USERNAME')
+        })
+    })
+    it('Registry: services api prevents org admins from updating a user from an org that doesnt exist', async () => {
+      await chai.request(app)
+        .put('/api/org/fake_org_5000/user/fake_user_1000?registry=true')
+        .set(adminHeaders)
+        .send({
+          user_id: userId
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(404)
+          expect(res.body.error).to.equal('ORG_DNE_PARAM')
+        })
+    })
+    it('Registry: services api prevents org admins from updating a user that doesnt exist', async () => {
+      await chai.request(app)
+        .put('/api/org/beat_10/user/fake_user_1000?registry=true')
+        .set(adminHeaders)
+        .send({
+          user_id: userId
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(404)
+          expect(res.body.error).to.equal('USER_DNE')
+        })
+    })
+    it('Registry: services api prevents org admins from updating a user for a different org', async () => {
+      await chai.request(app)
+        .put('/api/org/range_4/user/scottmitchell@range_4.com?registry=true')
+        .set(adminHeaders)
+        .send({
+          user_id: userId
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('NOT_SAME_ORG_OR_SECRETARIAT')
+        })
+    })
+    it('Registry: services api prevents org admins from creating existing users', async () => {
+      await chai.request(app)
+        .post('/api/org/beat_10/user?registry=true')
+        .set(adminHeaders)
+        .send({
+          user_id: userId
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.equal('USER_EXISTS')
+        })
+    })
+    it('Registry: Services api prevents org admins from creating users for other orgs', async () => {
+      await chai.request(app)
+        .post('/api/org/range_4/user?registry=true')
+        .set(adminHeaders)
+        .send({
+          user_id: 'BLARG'
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('NOT_ORG_ADMIN_OR_SECRETARIAT')
+        })
+    })
+    it('Registry: Services prevents org admins from creating a user with conflicts in the organization the user belongs to (org in the path is diff from the org in the json body)', async () => {
+      await chai.request(app)
+        .post(`/api/org/${shortName}/user?registry=true`)
+        .set(adminHeaders)
+        .send({
+          user_id: 'BLARG',
+          org_UUID: 'test'
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+        })
+    })
+    it('Registry: Services api does not allow org admins to update their own orgs', async () => {
+      await chai.request(app)
+        .post('/api/org?registry=true')
+        .set(adminHeaders)
+        .send({
+          long_name: 'Super cool long name'
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.be.equal('SECRETARIAT_ONLY')
+        })
+    })
+    it('Registry: Services api does not allow org admins to create other orgs', async () => {
+      await chai.request(app)
+        .post('/api/org?registry=true')
+        .set(adminHeaders)
+        .send({
+          short_name: 'fake_org_1'
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.be.equal('SECRETARIAT_ONLY')
+        })
+    })
+    it('Registry: page must be a positive int', async () => {
+      await chai.request(app)
+        .get(`/api/org/${shortName}/users?registry=true&page=-1`)
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.equal('BAD_INPUT')
+          expect(_.some(res.body.details, { msg: 'Invalid value', param: 'page', location: 'query' })).to.be.true
+        })
+    })
+    it('Registry: services api rejects requests for secretariat by admin of another org', async () => {
+      await chai.request(app)
+        .get('/api/org/mitre/user/test_secretariat_0@mitre.org?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('NOT_SAME_ORG_OR_SECRETARIAT')
+        })
+    })
+    it('Registry: services api rejects requests for secretariat user list by admin of another org', async () => {
+      await chai.request(app)
+        .get('/api/org/mitre/users?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('NOT_SAME_ORG_OR_SECRETARIAT')
+        })
+    })
+    it('Registry: services api rejects requests for org user list by admin of another org', async () => {
+      await chai.request(app)
+        .get('/api/org/range_4/users?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('NOT_SAME_ORG_OR_SECRETARIAT')
+        })
+    })
+    it('Registry: services api rejects requests for users info by admin of another org', async () => {
+      await chai.request(app)
+        .get('/api/org/range_4/user/scottmitchell@range_4.com?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('NOT_SAME_ORG_OR_SECRETARIAT')
+        })
+    })
+    it('Registry: services api rejects requests for org quota by admin of another org', async () => {
+      await chai.request(app)
+        .get('/api/org/range_4/id_quota?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('NOT_SAME_ORG_OR_SECRETARIAT')
+        })
+    })
+    it('Registry: services api rejects requests for secretariat quota by non-secretariat users', async () => {
+      await chai.request(app)
+        .get('/api/org/mitre/id_quota?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('NOT_SAME_ORG_OR_SECRETARIAT')
+        })
+    })
+    it('Registry: Services api rejects requests for all orgs by non-secretariat users', async () => {
+      await chai.request(app)
+        .get('/api/org?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('SECRETARIAT_ONLY')
+        })
+    })
+    it('Registry: Services api rejects requests for secretariat by non-secretariat users', async () => {
+      await chai.request(app)
+        .get('/api/org/mitre?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('NOT_SAME_ORG_OR_SECRETARIAT')
+        })
+    })
+    it('Registry: Services api rejects requests for any org by another org user', async () => {
+      await chai.request(app)
+        .get('/api/org/range_4?registry=true')
+        .set(adminHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('NOT_SAME_ORG_OR_SECRETARIAT')
+        })
+    })
+  })
+})


### PR DESCRIPTION
Closes Issue #1414 

# Summary
Creates tests for registry actions that were covered in org_as_org_admin.py

# Testing

Steps to manually test updated functionality, if possible
- [ ] ) Run npm run test:integration

