### PR TITLE
Resolves issue 1413 Create Registry Tests - updateUserTest.js

### DIFF
--- a/test/integration-tests/user/updateUserTest.js
+++ b/test/integration-tests/user/updateUserTest.js
@@ -19,9 +19,28 @@ describe('Testing Edit user endpoint', () => {
           expect(res).to.have.status(200)
         })
     })
+    it('Should return 200 when only name changes are done with registry enabled', async () => {
+      await chai.request(app)
+        .put('/api/org/win_5/user/jasminesmith@win_5.com?registry=true&name.first=NewNameAgain')
+        .set(constants.nonSecretariatUserHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+        })
+    })
     it('Should return an error when admin is required', async () => {
       await chai.request(app)
         .put('/api/org/win_5/user/jasminesmith@win_5.com?new_username=NewUsername')
+        .set(constants.nonSecretariatUserHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
+        })
+    })
+    it('Should return an error when admin is required with registry enabled', async () => {
+      await chai.request(app)
+        .put('/api/org/win_5/user/jasminesmith@win_5.com?registry=true&new_username=NewUsername')
         .set(constants.nonSecretariatUserHeaders)
         .then((res, err) => {
           expect(err).to.be.undefined
@@ -38,9 +57,27 @@ describe('Testing Edit user endpoint', () => {
           expect(res.body.error).to.contain('BAD_INPUT')
         })
     })
+    it('Should not allow a first name of more than 100 characters with registry enabled', async () => {
+      await chai.request(app)
+        .put('/api/org/win_5/user/jasminesmith@win_5.com?registry=true&name.first=1:1234567,2:1234567,3:1234567,4:1234567,5:1234567,6:1234567,7:1234567,8:1234567,9:1234567,10:1234567,11:1234567')
+        .set(constants.nonSecretariatUserHeaders)
+        .then((res, err) => {
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.contain('BAD_INPUT')
+        })
+    })
     it('Should not allow a middle name of more than 100 characters', async () => {
       await chai.request(app)
         .put('/api/org/win_5/user/jasminesmith@win_5.com?name.middle=1:1234567,2:1234567,3:1234567,4:1234567,5:1234567,6:1234567,7:1234567,8:1234567,9:1234567,10:1234567,11:1234567')
+        .set(constants.nonSecretariatUserHeaders)
+        .then((res, err) => {
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.contain('BAD_INPUT')
+        })
+    })
+    it('Should not allow a middle name of more than 100 characters with registry enabled', async () => {
+      await chai.request(app)
+        .put('/api/org/win_5/user/jasminesmith@win_5.com?registry=true&name.middle=1:1234567,2:1234567,3:1234567,4:1234567,5:1234567,6:1234567,7:1234567,8:1234567,9:1234567,10:1234567,11:1234567')
         .set(constants.nonSecretariatUserHeaders)
         .then((res, err) => {
           expect(res).to.have.status(400)
@@ -56,9 +93,27 @@ describe('Testing Edit user endpoint', () => {
           expect(res.body.error).to.contain('BAD_INPUT')
         })
     })
+    it('Should not allow a last name of more than 100 characters with registry enabled', async () => {
+      await chai.request(app)
+        .put('/api/org/win_5/user/jasminesmith@win_5.com?registry=true&name.last=1:1234567,2:1234567,3:1234567,4:1234567,5:1234567,6:1234567,7:1234567,8:1234567,9:1234567,10:1234567,11:1234567')
+        .set(constants.nonSecretariatUserHeaders)
+        .then((res, err) => {
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.contain('BAD_INPUT')
+        })
+    })
     it('Should not allow a suffix of more than 100 characters', async () => {
       await chai.request(app)
         .put('/api/org/win_5/user/jasminesmith@win_5.com?name.suffix=1:1234567,2:1234567,3:1234567,4:1234567,5:1234567,6:1234567,7:1234567,8:1234567,9:1234567,10:1234567,11:1234567')
+        .set(constants.nonSecretariatUserHeaders)
+        .then((res, err) => {
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.contain('BAD_INPUT')
+        })
+    })
+    it('Should not allow a suffix of more than 100 characters with registry enabled', async () => {
+      await chai.request(app)
+        .put('/api/org/win_5/user/jasminesmith@win_5.com?registry=true&name.suffix=1:1234567,2:1234567,3:1234567,4:1234567,5:1234567,6:1234567,7:1234567,8:1234567,9:1234567,10:1234567,11:1234567')
         .set(constants.nonSecretariatUserHeaders)
         .then((res, err) => {
           expect(res).to.have.status(400)


### PR DESCRIPTION
Closes Issue 1413

# Summary
Added tests to validate that Users can be updated when the registry flag is set to true

# Important Changes
`updateUserTest.js`
- Added new tests to check the updating of a user when the registry flag is set to true

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Ensure mongo is up and running, with replication on
- [ ] 2) Run `npm run test:integration`, while targeting localhost mongo
