### PR TITLE
Add integration test for regularUser trying to make Org and User requests with registry=true

### DIFF
--- a/test/integration-tests/org/regularUsersTestRegistryFlag.js
+++ b/test/integration-tests/org/regularUsersTestRegistryFlag.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-expressions */
 const chai = require('chai')
 chai.use(require('chai-http'))
 const expect = chai.expect
@@ -13,6 +12,7 @@ const Org = require('../../../src/model/org.js')
 const shortName = { shortname: 'win_5' }
 const ORG_URL = '/api/org'
 const MAX_SHORTNAME_LENGTH = 32
+const helpers = require('../helpers.js')
 /**
  * Unit Tests for testing regular user permissions for Org and User /api/org endpoints with the `registry=true` flag
  */
@@ -41,8 +41,6 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
       it('regular users can update their secret ', async () => { // --> line 312
         const org = constants.nonSecretariatUserHeaders3['CVE-API-ORG']
         const user = constants.nonSecretariatUserHeaders3['CVE-API-USER']
-        // Create a new user so other tests are not affected
-        // await helpers.createNewUserHelper('testRegularUser', constants.nonSecretariatUserHeaders['CVE-API-ORG'])
         await chai.request(app)
           .put(`${ORG_URL}/${org}/user/${user}/reset_secret?registry=true`)
           .set(constants.nonSecretariatUserHeaders3)
@@ -50,9 +48,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
           })
           .then((res) => {
             expect(res).to.have.status(200)
-            console.log(res.body)
           })
-          // TO-DO: why is this giving me a service not found 500 error?
       })
     })
     /* Negative Tests */
@@ -192,7 +188,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
           })
       })
       it("regular user cannot reset the secret of a user from an org that doesn't exist", async () => { // --> line 338
-        const org =  faker.datatype.uuid().slice(0, MAX_SHORTNAME_LENGTH)
+        const org = faker.datatype.uuid().slice(0, MAX_SHORTNAME_LENGTH)
         const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
         await chai.request(app)
           .put(`${ORG_URL}/${org}/user/${user}/reset_secret?registry=true`)
@@ -205,7 +201,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
           })
       })
       it("regular user cannot reset the secret of a user that doesn't exist", async () => { // --> line 349
-        const org =  constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         const user = faker.datatype.uuid()
         await chai.request(app)
           .put(`${ORG_URL}/${org}/user/${user}/reset_secret?registry=true`)
@@ -218,7 +214,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
           })
       })
       it("regular user tries resetting admin user's secret, fails and admin user's role remains preserved", async () => { // --> line 361
-        const org =  constants.nonSecretariatUserHeaders2['CVE-API-ORG']
+        const org = constants.nonSecretariatUserHeaders2['CVE-API-ORG']
         const user = constants.nonSecretariatUserHeaders2['CVE-API-USER']
         await chai.request(app)
           .put(`${ORG_URL}/${org}/user/${user}/reset_secret?registry=true`)
@@ -396,20 +392,20 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.short_name === org).to.be.true
           })
       })
-      it("regular users can see their organization's cve id quota", async () => { // --> line 286
-        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
-        await chai.request(app)
-          .get(`${ORG_URL}/${org}/id_quota?registry=true`)
-          .set(constants.nonSecretariatUserHeaders)
-          .send({
-          })
-          .then((res) => {
-            expect(res).to.have.status(200)
-            expect(res.body.hard_quota > 0).to.be.true
-            expect(res.body.total_reserved > 0).to.be.true
-            expect(res.body.available > 0).to.be.true
-          })
-      })
+        it("regular users can see their organization's cve id quota", async () => { // --> line 286
+          const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+          await chai.request(app)
+            .get(`${ORG_URL}/${org}/id_quota?registry=true`)
+            .set(constants.nonSecretariatUserHeaders)
+            .send({
+            })
+            .then((res) => {
+              expect(res).to.have.status(200)
+              expect(res.body.hard_quota > 0).to.be.true
+              expect(res.body.total_reserved > 0).to.be.true
+              expect(res.body.available > 0).to.be.true
+            })
+        })
     })
     /* Negative Tests */
     context('Negative Test', () => {

--- a/test/integration-tests/org/regularUsersTestRegistryFlag.js
+++ b/test/integration-tests/org/regularUsersTestRegistryFlag.js
@@ -5,14 +5,8 @@ const { faker } = require('@faker-js/faker')
 
 const constants = require('../constants.js')
 const app = require('../../../src/index.js')
-const _ = require('lodash')
-const Org = require('../../../src/model/org.js')
-// const RegistryUser = require('../../../src/model/registry-user.js')
-
-const shortName = { shortname: 'win_5' }
 const ORG_URL = '/api/org'
 const MAX_SHORTNAME_LENGTH = 32
-const helpers = require('../helpers.js')
 /**
  * Unit Tests for testing regular user permissions for Org and User /api/org endpoints with the `registry=true` flag
  */
@@ -32,10 +26,10 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
           })
           .then((res) => {
             expect(res).to.have.status(200)
-            expect(res.body.updated.name.first === 'aaa').to.be.true
-            expect(res.body.updated.name.last === 'bbb').to.be.true
-            expect(res.body.updated.name.middle === 'ccc').to.be.true
-            expect(res.body.updated.name.suffix === 'ddd').to.be.true
+            expect(res.body.updated.name.first).contain('aaa')
+            expect(res.body.updated.name.last).contain('bbb')
+            expect(res.body.updated.name.middle).contain('ccc')
+            expect(res.body.updated.name.suffix).contain('ddd')
           })
       })
       it('regular users can update their secret ', async () => { // --> line 312
@@ -48,6 +42,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
           })
           .then((res) => {
             expect(res).to.have.status(200)
+            expect(res.body).to.have.property('API-secret')
           })
       })
     })
@@ -225,7 +220,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res).to.have.status(403)
             expect(res.body.error).to.contain('NOT_SAME_USER_OR_SECRETARIAT')
           })
-        /* Commenting out since authority.active_roles are not returned in the GET request response for registry=true*/
+        /* Commenting out since authority.active_roles are not returned in the GET request response for registry=true */
         // await chai.request(app)
         //   .get(`${ORG_URL}/${org}/user/${user}?registry=true`)
         //   .set(constants.nonSecretariatUserHeaders2)
@@ -271,7 +266,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
           })
           .then((res) => {
             expect(res).to.have.status(200)
-            expect(res.body.users.length > 0).to.be.true
+            expect(res.body.users).to.have.lengthOf.above(0)
           })
       })
       it('regular users can view users of the same organization ', async () => { // --> line 249
@@ -284,7 +279,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
           })
           .then((res) => {
             expect(res).to.have.status(200)
-            expect(res.body.user_id.length > 0).to.be.true
+            expect(res.body.user_id).to.have.lengthOf.above(0)
           })
       })
     })
@@ -389,23 +384,23 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
           })
           .then((res) => {
             expect(res).to.have.status(200)
-            expect(res.body.short_name === org).to.be.true
+            expect(res.body.short_name).to.equal(org)
           })
       })
-        it("regular users can see their organization's cve id quota", async () => { // --> line 286
-          const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
-          await chai.request(app)
-            .get(`${ORG_URL}/${org}/id_quota?registry=true`)
-            .set(constants.nonSecretariatUserHeaders)
-            .send({
-            })
-            .then((res) => {
-              expect(res).to.have.status(200)
-              expect(res.body.hard_quota > 0).to.be.true
-              expect(res.body.total_reserved > 0).to.be.true
-              expect(res.body.available > 0).to.be.true
-            })
-        })
+      it("regular users can see their organization's cve id quota", async () => { // --> line 286
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        await chai.request(app)
+          .get(`${ORG_URL}/${org}/id_quota?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(200)
+            expect(res.body.hard_quota).to.be.greaterThan(0)
+            expect(res.body.total_reserved).to.be.greaterThan(0)
+            expect(res.body.available).to.be.greaterThan(0)
+          })
+      })
     })
     /* Negative Tests */
     context('Negative Test', () => {

--- a/test/integration-tests/org/regularUsersTestRegistryFlag.js
+++ b/test/integration-tests/org/regularUsersTestRegistryFlag.js
@@ -1,0 +1,347 @@
+/* eslint-disable no-unused-expressions */
+const chai = require('chai')
+chai.use(require('chai-http'))
+const expect = chai.expect
+const { faker } = require('@faker-js/faker')
+
+const constants = require('../constants.js')
+const app = require('../../../src/index.js')
+const _ = require('lodash')
+const Org = require('../../../src/model/org.js')
+// const RegistryUser = require('../../../src/model/registry-user.js')
+
+const shortName = { shortname: 'win_5' }
+const ORG_URL = '/api/org'
+const MAX_SHORTNAME_LENGTH = 32
+/**
+ * Unit Tests for testing regular user permissions for Org and User /api/org endpoints with the `registry=true` flag
+ */
+
+describe('Testing regular user permissions for /api/org/ endpoints with `registry=true`', () => {
+  // Testing USER PUT Endpoints for regular users with `registry=true` flag
+  describe('Testing USER PUT endpoint with `registry=true`', () => {
+    /* Positive Tests */
+    context('Positive Test', () => {
+      it('regular user can update their name', async () => { // --> line 20
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}/user/${user}?registry=true&name.first=aaa&name.last=bbb&name.middle=ccc&name.suffix=ddd`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(200)
+            expect(res.body.updated.name.first === 'aaa').to.be.true
+            expect(res.body.updated.name.last === 'bbb').to.be.true
+            expect(res.body.updated.name.middle === 'ccc').to.be.true
+            expect(res.body.updated.name.suffix === 'ddd').to.be.true
+          })
+      })
+    })
+    /* Negative Tests */
+    context('Negative Test', () => {
+      it('regular user cannot update their username', async () => { // --> line 37
+        const newUsername = faker.datatype.uuid()
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}/user/${user}?registry=true&new_username=${newUsername}`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
+          })
+      })
+      it('regular user cannot update information of another user of the same organization', async () => { // --> line 45
+        const newUsername = faker.datatype.uuid()
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        const user2 = constants.nonSecretariatUserHeaders2['CVE-API-USER']
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}/user/${user2}?registry=true&new_username=${newUsername}`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('NOT_SAME_USER_OR_SECRETARIAT')
+          })
+      })
+      it("regular users cannot update a user's username if that user already exist", async () => { // --> line 62
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        const user1 = constants.nonSecretariatUserHeaders['CVE-API-USER']
+        const user2 = constants.nonSecretariatUserHeaders2['CVE-API-USER']
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}/user/${user1}?registry=true&new_username=${user2}`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
+          })
+      })
+      it('regular users cannot update organization', async () => { // --> line 78
+        const org1 = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
+        const org2 = faker.datatype.uuid().slice(0, MAX_SHORTNAME_LENGTH)
+        await chai.request(app)
+          .put(`${ORG_URL}/${org1}/user/${user}?registry=true&org_short_name=${org2}`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('NOT_ALLOWED_TO_CHANGE_ORGANIZATION')
+          })
+      })
+      it('regular user cannot change its own active state', async () => { // --> line 91
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}/user/${user}?registry=true&active=false`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
+          })
+      })
+      it('rregular users cannot add role', async () => { // --> line 103
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}/user/${user}?registry=true&active_roles.add=admin`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
+          })
+      })
+      it('regular users cannot remove role', async () => { // --> line 116
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}/user/${user}?registry=true&active_roles.remove=admin`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
+          })
+      })
+      it("regular user cannot update a user from an org that doesn't exist", async () => { // --> line 129
+        const org = faker.datatype.uuid().slice(0, MAX_SHORTNAME_LENGTH)
+        const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}/user/${user}?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(404)
+            expect(res.body.error).to.contain('ORG_DNE_PARAM')
+          })
+      })
+      it("regular user cannot update a user that doesn't exist ", async () => { // --> line 141
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        const user = faker.datatype.uuid()
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}/user/${user}?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(404)
+            expect(res.body.error).to.contain('USER_DNE')
+          })
+      })
+    })
+  })
+  // Testing USER POST Endpoints for regular users with `registry=true` flag
+  describe('Testing USER POST endpoint with `registry=true`', () => {
+    /* Negative Tests */
+    context('Negative Test', () => {
+      it('regular user cannot create another user', async () => { // --> line 155
+        const newUsername = faker.datatype.uuid()
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        await chai.request(app)
+          .post(`${ORG_URL}/${org}/user?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+            username: newUsername
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT')
+          })
+      })
+    })
+  })
+  // Testing USER GET Endpoints for regular users with `registry=true` flag
+  describe('Testing USER GET endpoint with `registry=true`', () => {
+    /* Positive Tests */
+    context('Positive Test', () => {
+      it('regular users can view users of the same organization', async () => { // --> line 213
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        await chai.request(app)
+          .get(`${ORG_URL}/${org}/users?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(200)
+            expect(res.body.users.length > 0).to.be.true
+          })
+      })
+      it('regular users can view users of the same organization ', async () => { // --> line 249
+        const org = constants.nonSecretariatUserHeaders2['CVE-API-ORG']
+        const user2 = constants.nonSecretariatUserHeaders2['CVE-API-USER']
+        await chai.request(app)
+          .get(`${ORG_URL}/${org}/user/${user2}?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(200)
+            expect(res.body.user_id.length > 0).to.be.true
+          })
+      })
+    })
+    /* Negative Tests */
+    context('Negative Test', () => {
+      it("regular users cannot view users of an organization that doesn't exist", async () => { // --> line 225
+        const org = faker.datatype.uuid().slice(0, MAX_SHORTNAME_LENGTH)
+        await chai.request(app)
+          .get(`${ORG_URL}/${org}/users?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(404)
+            expect(res.body.error).to.contain('ORG_DNE_PARAM')
+          })
+      })
+      it('regular users cannot view users of another organization', async () => { // --> line 235
+        const org = constants.nonSecretariatUserHeaders3['CVE-API-ORG']
+        await chai.request(app)
+          .get(`${ORG_URL}/${org}/users?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('NOT_SAME_ORG_OR_SECRETARIAT')
+          })
+      })
+      it('regular users cannot view users from another organization', async () => { // --> line 262
+        const org = constants.nonSecretariatUserHeaders3['CVE-API-ORG']
+        const user = constants.nonSecretariatUserHeaders3['CVE-API-USER']
+        await chai.request(app)
+          .get(`${ORG_URL}/${org}/user/${user}?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('NOT_SAME_ORG_OR_SECRETARIAT')
+          })
+      })
+      it("regular user cannot view user that doesn't exist", async () => { // --> line 273
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        const user = faker.datatype.uuid()
+        await chai.request(app)
+          .get(`${ORG_URL}/${org}/user/${user}?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(404)
+            expect(res.body.error).to.contain('USER_DNE')
+          })
+      })
+    })
+  })
+  // Testing ORG PUT Endpoints for regular users with `registry=true` flag
+  describe('Testing ORG PUT endpoint with `registry=true`', () => {
+    /* Negative Tests */
+    context('Negative Test', () => {
+      it('regular user cannot update an organization', async () => { // --> line 167
+        const org = faker.datatype.uuid().slice(0, MAX_SHORTNAME_LENGTH)
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('SECRETARIAT_ONLY')
+          })
+      })
+    })
+  })
+  // Testing ORG GET Endpoints for regular users with `registry=true` flag
+  describe('Testing ORG GET endpoint with `registry=true`', () => {
+    /* Positive Tests */
+    context('Positive Test', () => {
+      it('regular users can view the organization they belong to', async () => { // --> line 180
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        await chai.request(app)
+          .get(`${ORG_URL}/${org}?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(200)
+            expect(res.body.short_name === org).to.be.true
+          })
+      })
+      it("regular users can see their organization's cve id quota", async () => { // --> line 286
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        await chai.request(app)
+          .get(`${ORG_URL}/${org}/id_quota?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(200)
+            expect(res.body.hard_quota > 0).to.be.true
+            expect(res.body.total_reserved > 0).to.be.true
+            expect(res.body.available > 0).to.be.true
+          })
+      })
+    })
+    /* Negative Tests */
+    context('Negative Test', () => {
+      it("regular users cannot view an organization they don't belong to", async () => { // --> line 191
+        const org = faker.datatype.uuid().slice(0, MAX_SHORTNAME_LENGTH)
+        await chai.request(app)
+          .get(`${ORG_URL}/${org}?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('NOT_SAME_ORG_OR_SECRETARIAT')
+          })
+      })
+      it('regular users cannot view all organizations', async () => { // --> line 202
+        await chai.request(app)
+          .get(`${ORG_URL}?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('SECRETARIAT_ONLY')
+          })
+      })
+    })
+  })
+})

--- a/test/integration-tests/org/regularUsersTestRegistryFlag.js
+++ b/test/integration-tests/org/regularUsersTestRegistryFlag.js
@@ -38,6 +38,22 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.updated.name.suffix === 'ddd').to.be.true
           })
       })
+      it('regular users can update their secret ', async () => { // --> line 312
+        const org = constants.nonSecretariatUserHeaders3['CVE-API-ORG']
+        const user = constants.nonSecretariatUserHeaders3['CVE-API-USER']
+        // Create a new user so other tests are not affected
+        // await helpers.createNewUserHelper('testRegularUser', constants.nonSecretariatUserHeaders['CVE-API-ORG'])
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}/user/${user}/reset_secret?registry=true`)
+          .set(constants.nonSecretariatUserHeaders3)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(200)
+            console.log(res.body)
+          })
+          // TO-DO: why is this giving me a service not found 500 error?
+      })
     })
     /* Negative Tests */
     context('Negative Test', () => {
@@ -110,7 +126,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
           })
       })
-      it('rregular users cannot add role', async () => { // --> line 103
+      it('regular users cannot add role', async () => { // --> line 103
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
         await chai.request(app)
@@ -161,6 +177,68 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res).to.have.status(404)
             expect(res.body.error).to.contain('USER_DNE')
           })
+      })
+      it('regular user cannot update the secret of another user', async () => { // --> line 323
+        const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        const user = constants.nonSecretariatUserHeaders2['CVE-API-USER']
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}/user/${user}/reset_secret?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('NOT_SAME_USER_OR_SECRETARIAT')
+          })
+      })
+      it("regular user cannot reset the secret of a user from an org that doesn't exist", async () => { // --> line 338
+        const org =  faker.datatype.uuid().slice(0, MAX_SHORTNAME_LENGTH)
+        const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}/user/${user}/reset_secret?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(404)
+            expect(res.body.error).to.contain('ORG_DNE_PARAM')
+          })
+      })
+      it("regular user cannot reset the secret of a user that doesn't exist", async () => { // --> line 349
+        const org =  constants.nonSecretariatUserHeaders['CVE-API-ORG']
+        const user = faker.datatype.uuid()
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}/user/${user}/reset_secret?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(404)
+            expect(res.body.error).to.contain('USER_DNE')
+          })
+      })
+      it("regular user tries resetting admin user's secret, fails and admin user's role remains preserved", async () => { // --> line 361
+        const org =  constants.nonSecretariatUserHeaders2['CVE-API-ORG']
+        const user = constants.nonSecretariatUserHeaders2['CVE-API-USER']
+        await chai.request(app)
+          .put(`${ORG_URL}/${org}/user/${user}/reset_secret?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('NOT_SAME_USER_OR_SECRETARIAT')
+          })
+        /* Commenting out since authority.active_roles are not returned in the GET request response for registry=true*/
+        // await chai.request(app)
+        //   .get(`${ORG_URL}/${org}/user/${user}?registry=true`)
+        //   .set(constants.nonSecretariatUserHeaders2)
+        //   .send({
+        //   })
+        //   .then((res) => {
+        //     expect(res).to.have.status(200)
+        //     console.log(res.body)
+        //   })
       })
     })
   })
@@ -286,6 +364,22 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
       })
     })
   })
+  // Testing ORG POST Endpoints for regular users with `registry=true` flag
+  describe('Testing ORG POST endpoint with `registry=true`', () => {
+    context('Negative Test', () => {
+      it('regular users cannot create new org', async () => { // --> line 386
+        await chai.request(app)
+          .post(`${ORG_URL}?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('SECRETARIAT_ONLY')
+          })
+      })
+    })
+  })
   // Testing ORG GET Endpoints for regular users with `registry=true` flag
   describe('Testing ORG GET endpoint with `registry=true`', () => {
     /* Positive Tests */
@@ -340,6 +434,18 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
           .then((res) => {
             expect(res).to.have.status(403)
             expect(res.body.error).to.contain('SECRETARIAT_ONLY')
+          })
+      })
+      it("regular users cannot see an organization's cve id quota they don't belong to", async () => { // --> line 298
+        const org = constants.nonSecretariatUserHeaders3['CVE-API-ORG']
+        await chai.request(app)
+          .get(`${ORG_URL}/${org}/id_quota?registry=true`)
+          .set(constants.nonSecretariatUserHeaders)
+          .send({
+          })
+          .then((res) => {
+            expect(res).to.have.status(403)
+            expect(res.body.error).to.contain('NOT_SAME_ORG_OR_SECRETARIAT')
           })
       })
     })

--- a/test/integration-tests/org/regularUsersTestRegistryFlag.js
+++ b/test/integration-tests/org/regularUsersTestRegistryFlag.js
@@ -16,7 +16,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
   describe('Testing USER PUT endpoint with `registry=true`', () => {
     /* Positive Tests */
     context('Positive Test', () => {
-      it('regular user can update their name', async () => { // --> line 20
+      it('regular user can update their name', async () => {
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
         await chai.request(app)
@@ -32,7 +32,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.updated.name.suffix).contain('ddd')
           })
       })
-      it('regular users can update their secret ', async () => { // --> line 312
+      it('regular users can update their secret ', async () => {
         const org = constants.nonSecretariatUserHeaders3['CVE-API-ORG']
         const user = constants.nonSecretariatUserHeaders3['CVE-API-USER']
         await chai.request(app)
@@ -48,7 +48,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
     })
     /* Negative Tests */
     context('Negative Test', () => {
-      it('regular user cannot update their username', async () => { // --> line 37
+      it('regular user cannot update their username', async () => {
         const newUsername = faker.datatype.uuid()
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
@@ -62,7 +62,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
           })
       })
-      it('regular user cannot update information of another user of the same organization', async () => { // --> line 45
+      it('regular user cannot update information of another user of the same organization', async () => {
         const newUsername = faker.datatype.uuid()
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         const user2 = constants.nonSecretariatUserHeaders2['CVE-API-USER']
@@ -76,7 +76,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('NOT_SAME_USER_OR_SECRETARIAT')
           })
       })
-      it("regular users cannot update a user's username if that user already exist", async () => { // --> line 62
+      it("regular users cannot update a user's username if that user already exist", async () => {
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         const user1 = constants.nonSecretariatUserHeaders['CVE-API-USER']
         const user2 = constants.nonSecretariatUserHeaders2['CVE-API-USER']
@@ -90,7 +90,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
           })
       })
-      it('regular users cannot update organization', async () => { // --> line 78
+      it('regular users cannot update organization', async () => {
         const org1 = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
         const org2 = faker.datatype.uuid().slice(0, MAX_SHORTNAME_LENGTH)
@@ -104,7 +104,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('NOT_ALLOWED_TO_CHANGE_ORGANIZATION')
           })
       })
-      it('regular user cannot change its own active state', async () => { // --> line 91
+      it('regular user cannot change its own active state', async () => {
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
         await chai.request(app)
@@ -117,7 +117,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
           })
       })
-      it('regular users cannot add role', async () => { // --> line 103
+      it('regular users cannot add role', async () => {
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
         await chai.request(app)
@@ -130,7 +130,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
           })
       })
-      it('regular users cannot remove role', async () => { // --> line 116
+      it('regular users cannot remove role', async () => {
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
         await chai.request(app)
@@ -143,7 +143,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('NOT_ORG_ADMIN_OR_SECRETARIAT_UPDATE')
           })
       })
-      it("regular user cannot update a user from an org that doesn't exist", async () => { // --> line 129
+      it("regular user cannot update a user from an org that doesn't exist", async () => {
         const org = faker.datatype.uuid().slice(0, MAX_SHORTNAME_LENGTH)
         const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
         await chai.request(app)
@@ -156,7 +156,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('ORG_DNE_PARAM')
           })
       })
-      it("regular user cannot update a user that doesn't exist ", async () => { // --> line 141
+      it("regular user cannot update a user that doesn't exist ", async () => {
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         const user = faker.datatype.uuid()
         await chai.request(app)
@@ -169,7 +169,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('USER_DNE')
           })
       })
-      it('regular user cannot update the secret of another user', async () => { // --> line 323
+      it('regular user cannot update the secret of another user', async () => {
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         const user = constants.nonSecretariatUserHeaders2['CVE-API-USER']
         await chai.request(app)
@@ -182,7 +182,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('NOT_SAME_USER_OR_SECRETARIAT')
           })
       })
-      it("regular user cannot reset the secret of a user from an org that doesn't exist", async () => { // --> line 338
+      it("regular user cannot reset the secret of a user from an org that doesn't exist", async () => {
         const org = faker.datatype.uuid().slice(0, MAX_SHORTNAME_LENGTH)
         const user = constants.nonSecretariatUserHeaders['CVE-API-USER']
         await chai.request(app)
@@ -195,7 +195,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('ORG_DNE_PARAM')
           })
       })
-      it("regular user cannot reset the secret of a user that doesn't exist", async () => { // --> line 349
+      it("regular user cannot reset the secret of a user that doesn't exist", async () => {
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         const user = faker.datatype.uuid()
         await chai.request(app)
@@ -208,7 +208,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('USER_DNE')
           })
       })
-      it("regular user tries resetting admin user's secret, fails and admin user's role remains preserved", async () => { // --> line 361
+      it("regular user tries resetting admin user's secret, fails and admin user's role remains preserved", async () => {
         const org = constants.nonSecretariatUserHeaders2['CVE-API-ORG']
         const user = constants.nonSecretariatUserHeaders2['CVE-API-USER']
         await chai.request(app)
@@ -237,7 +237,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
   describe('Testing USER POST endpoint with `registry=true`', () => {
     /* Negative Tests */
     context('Negative Test', () => {
-      it('regular user cannot create another user', async () => { // --> line 155
+      it('regular user cannot create another user', async () => {
         const newUsername = faker.datatype.uuid()
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         await chai.request(app)
@@ -257,7 +257,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
   describe('Testing USER GET endpoint with `registry=true`', () => {
     /* Positive Tests */
     context('Positive Test', () => {
-      it('regular users can view users of the same organization', async () => { // --> line 213
+      it('regular users can view users of the same organization', async () => {
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         await chai.request(app)
           .get(`${ORG_URL}/${org}/users?registry=true`)
@@ -269,7 +269,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.users).to.have.lengthOf.above(0)
           })
       })
-      it('regular users can view users of the same organization ', async () => { // --> line 249
+      it('regular users can view users of the same organization ', async () => {
         const org = constants.nonSecretariatUserHeaders2['CVE-API-ORG']
         const user2 = constants.nonSecretariatUserHeaders2['CVE-API-USER']
         await chai.request(app)
@@ -285,7 +285,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
     })
     /* Negative Tests */
     context('Negative Test', () => {
-      it("regular users cannot view users of an organization that doesn't exist", async () => { // --> line 225
+      it("regular users cannot view users of an organization that doesn't exist", async () => {
         const org = faker.datatype.uuid().slice(0, MAX_SHORTNAME_LENGTH)
         await chai.request(app)
           .get(`${ORG_URL}/${org}/users?registry=true`)
@@ -297,7 +297,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('ORG_DNE_PARAM')
           })
       })
-      it('regular users cannot view users of another organization', async () => { // --> line 235
+      it('regular users cannot view users of another organization', async () => {
         const org = constants.nonSecretariatUserHeaders3['CVE-API-ORG']
         await chai.request(app)
           .get(`${ORG_URL}/${org}/users?registry=true`)
@@ -309,7 +309,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('NOT_SAME_ORG_OR_SECRETARIAT')
           })
       })
-      it('regular users cannot view users from another organization', async () => { // --> line 262
+      it('regular users cannot view users from another organization', async () => {
         const org = constants.nonSecretariatUserHeaders3['CVE-API-ORG']
         const user = constants.nonSecretariatUserHeaders3['CVE-API-USER']
         await chai.request(app)
@@ -322,7 +322,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('NOT_SAME_ORG_OR_SECRETARIAT')
           })
       })
-      it("regular user cannot view user that doesn't exist", async () => { // --> line 273
+      it("regular user cannot view user that doesn't exist", async () => {
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         const user = faker.datatype.uuid()
         await chai.request(app)
@@ -341,7 +341,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
   describe('Testing ORG PUT endpoint with `registry=true`', () => {
     /* Negative Tests */
     context('Negative Test', () => {
-      it('regular user cannot update an organization', async () => { // --> line 167
+      it('regular user cannot update an organization', async () => {
         const org = faker.datatype.uuid().slice(0, MAX_SHORTNAME_LENGTH)
         await chai.request(app)
           .put(`${ORG_URL}/${org}?registry=true`)
@@ -358,7 +358,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
   // Testing ORG POST Endpoints for regular users with `registry=true` flag
   describe('Testing ORG POST endpoint with `registry=true`', () => {
     context('Negative Test', () => {
-      it('regular users cannot create new org', async () => { // --> line 386
+      it('regular users cannot create new org', async () => {
         await chai.request(app)
           .post(`${ORG_URL}?registry=true`)
           .set(constants.nonSecretariatUserHeaders)
@@ -375,7 +375,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
   describe('Testing ORG GET endpoint with `registry=true`', () => {
     /* Positive Tests */
     context('Positive Test', () => {
-      it('regular users can view the organization they belong to', async () => { // --> line 180
+      it('regular users can view the organization they belong to', async () => {
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         await chai.request(app)
           .get(`${ORG_URL}/${org}?registry=true`)
@@ -387,7 +387,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.short_name).to.equal(org)
           })
       })
-      it("regular users can see their organization's cve id quota", async () => { // --> line 286
+      it("regular users can see their organization's cve id quota", async () => {
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         await chai.request(app)
           .get(`${ORG_URL}/${org}/id_quota?registry=true`)
@@ -404,7 +404,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
     })
     /* Negative Tests */
     context('Negative Test', () => {
-      it("regular users cannot view an organization they don't belong to", async () => { // --> line 191
+      it("regular users cannot view an organization they don't belong to", async () => {
         const org = faker.datatype.uuid().slice(0, MAX_SHORTNAME_LENGTH)
         await chai.request(app)
           .get(`${ORG_URL}/${org}?registry=true`)
@@ -416,7 +416,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('NOT_SAME_ORG_OR_SECRETARIAT')
           })
       })
-      it('regular users cannot view all organizations', async () => { // --> line 202
+      it('regular users cannot view all organizations', async () => {
         await chai.request(app)
           .get(`${ORG_URL}?registry=true`)
           .set(constants.nonSecretariatUserHeaders)
@@ -427,7 +427,7 @@ describe('Testing regular user permissions for /api/org/ endpoints with `registr
             expect(res.body.error).to.contain('SECRETARIAT_ONLY')
           })
       })
-      it("regular users cannot see an organization's cve id quota they don't belong to", async () => { // --> line 298
+      it("regular users cannot see an organization's cve id quota they don't belong to", async () => {
         const org = constants.nonSecretariatUserHeaders3['CVE-API-ORG']
         await chai.request(app)
           .get(`${ORG_URL}/${org}/id_quota?registry=true`)


### PR DESCRIPTION
Closes Issue 1416

# Summary
Added tests to check that regular users have some limited permissions when the registry flag is set to true

# Important Changes
`cve-services/test/integration-tests/org/regularUsersTestRegistryFlag.js`
- Created file from `regular_users.py`

# Testing

Steps to manually test updated functionality, if possible
 1) Ensure mongo is up and running, with replication on
 2) Run npm run test:integration, while targeting localhost mongo

