### PR TITLE
Resolves issue #1410 - registry tests for postOrgTest, and issue #1426 - improper handling of contact_info for registry org

### DIFF
--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -321,20 +321,11 @@ async function createOrg (req, res, next) {
       handlers.reports_to = () => {
         regOrg.reports_to = body.reports_to
       }
-
-      handlers['contact_info.poc'] = () => {
+      handlers.contact_info = () => {
         regOrg.contact_info.poc = body.contact_info.poc
-      }
-      handlers['contact_info.poc_email'] = () => {
         regOrg.contact_info.poc_email = body.contact_info.poc_email
-      }
-      handlers['contact_info.poc_phone'] = () => {
         regOrg.contact_info.poc_phone = body.contact_info.poc_phone
-      }
-      handlers['contact_info.org_email'] = () => {
         regOrg.contact_info.org_email = body.contact_info.org_email
-      }
-      handlers['contact_info.website'] = () => {
         regOrg.contact_info.website = body.contact_info.website
       }
     } else {

--- a/test/integration-tests/constants.js
+++ b/test/integration-tests/constants.js
@@ -363,6 +363,23 @@ const testOrg = {
   }
 }
 
+const testRegistryOrg = {
+  short_name: 'test_registry_org',
+  long_name: 'Test Registry Organization',
+  cve_program_org_function: 'CNA',
+  contact_info: {
+    poc: 'Dave',
+    poc_email: 'dave@test.org',
+    poc_phone: '555-1234',
+    org_email: 'contact@test.org',
+    website: 'test.org'
+  },
+  authority: {
+    active_roles: ['CNA']
+  },
+  hard_quota: 100000
+}
+
 const existingOrg = {
 
   short_name: 'win_5',
@@ -375,6 +392,23 @@ const existingOrg = {
   policies: {
     id_quota: 100000
   }
+}
+
+const existingRegistryOrg = {
+  short_name: 'win_5',
+  long_name: 'Test Registry Organization',
+  cve_program_org_function: 'CNA',
+  contact_info: {
+    poc: 'Dave',
+    poc_email: 'dave@test.org',
+    poc_phone: '555-1234',
+    org_email: 'contact@test.org',
+    website: 'test.org'
+  },
+  authority: {
+    active_roles: ['CNA']
+  },
+  hard_quota: 100000
 }
 
 module.exports = {
@@ -390,5 +424,7 @@ module.exports = {
   testAdp,
   testAdp2,
   testOrg,
-  existingOrg
+  testRegistryOrg,
+  existingOrg,
+  existingRegistryOrg
 }

--- a/test/integration-tests/org/postOrgTest.js
+++ b/test/integration-tests/org/postOrgTest.js
@@ -68,7 +68,7 @@ describe('Testing Org post endpoint', () => {
           expect(res.body.created.cve_program_org_function).to.equal(constants.testRegistryOrg.cve_program_org_function)
 
           expect(res.body.created).to.haveOwnProperty('contact_info')
-          expect(res.body.created.contact_info).to.deep.equal(constants.testRegistryOrg.contact_info)
+          expect(res.body.created.contact_info).to.include(constants.testRegistryOrg.contact_info)
 
           expect(res.body.created).to.haveOwnProperty('authority')
           expect(res.body.created.authority).to.deep.equal(constants.testRegistryOrg.authority)

--- a/test/integration-tests/org/postOrgTest.js
+++ b/test/integration-tests/org/postOrgTest.js
@@ -6,6 +6,10 @@ const expect = chai.expect
 const constants = require('../constants.js')
 const app = require('../../../src/index.js')
 
+const registryFlag = {
+  registry: true
+}
+
 describe('Testing Org post endpoint', () => {
   context('Positive Tests', () => {
     it('Allows creation of org', async () => {
@@ -37,13 +41,63 @@ describe('Testing Org post endpoint', () => {
           expect(res.body.created.authority).to.deep.equal(constants.testOrg.authority)
         })
     })
+    it('Allows creation of an org with registry enabled', async () => {
+      await chai.request(app)
+        .post('/api/org')
+        .set(constants.headers)
+        .query(registryFlag)
+        .send(constants.testRegistryOrg)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+
+          expect(res.body).to.haveOwnProperty('message')
+          expect(res.body.message).to.equal(constants.testRegistryOrg.short_name + ' organization was successfully created.')
+
+          expect(res.body).to.haveOwnProperty('created')
+
+          expect(res.body.created).to.haveOwnProperty('UUID')
+
+          expect(res.body.created).to.haveOwnProperty('short_name')
+          expect(res.body.created.short_name).to.equal(constants.testRegistryOrg.short_name)
+
+          expect(res.body.created).to.haveOwnProperty('long_name')
+          expect(res.body.created.long_name).to.equal(constants.testRegistryOrg.long_name)
+
+          expect(res.body.created).to.haveOwnProperty('cve_program_org_function')
+          expect(res.body.created.cve_program_org_function).to.equal(constants.testRegistryOrg.cve_program_org_function)
+
+          expect(res.body.created).to.haveOwnProperty('contact_info')
+          expect(res.body.created.contact_info).to.deep.equal(constants.testRegistryOrg.contact_info)
+
+          expect(res.body.created).to.haveOwnProperty('authority')
+          expect(res.body.created.authority).to.deep.equal(constants.testRegistryOrg.authority)
+
+          expect(res.body.created).to.haveOwnProperty('hard_quota')
+          expect(res.body.created.hard_quota).to.equal(constants.testRegistryOrg.hard_quota)
+        })
+    })
   })
-  context('Negitive Test', () => {
-    it('Should fail to create an org that already exists ', async () => {
+  context('Negative Tests', () => {
+    it('Should fail to create an org that already exists', async () => {
       await chai.request(app)
         .post('/api/org')
         .set({ ...constants.headers })
         .send(constants.existingOrg)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+
+          expect(res.body).to.haveOwnProperty('error')
+          expect(res.body.error).to.equal('ORG_EXISTS')
+        })
+    })
+    it('Should fail to create an org that already exists with registry enabled', async () => {
+      await chai.request(app)
+        .post('/api/org')
+        .set({ ...constants.headers })
+        .query(registryFlag)
+        .send(constants.existingRegistryOrg)
         .then((res, err) => {
           expect(err).to.be.undefined
           expect(res).to.have.status(400)


### PR DESCRIPTION
Closes Issue #1410, #1426

# Summary
Adds integration tests for creating an org with registry enabled. Fixes a bug with the way the `contact_info` field was being handled while creating a registry org.

# Important Changes
`test/integration-tests/org/postOrgTest.js`
- Adds integration tests for all cases with registry enabled.

`test/integration-tests/constants.js`
- Adds post body constants for registry org

`src/controller/org.controller/org.controller.js`
- Fixes handler functions to properly handle `contact_info` field when creating registry org

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) When posting to create org endpoint with registry enabled, `contact_info` field should be properly created.
- [ ] 2) Run integration tests. All tests should pass.
