### PR TITLE
Resolves issue #1411 -  integration tests for creating org users with registry enabled

### DIFF
--- a/test/integration-tests/org/postOrgUsersTest.js
+++ b/test/integration-tests/org/postOrgUsersTest.js
@@ -11,6 +11,7 @@ const User = require('../../../src/model/user')
 // const RegistryUser = require('../../../src/model/registry-user.js')
 
 const shortName = { shortname: 'win_5' }
+const registryFlag = { registry: true }
 
 describe('Testing user post endpoint', () => {
   let orgUuid
@@ -38,8 +39,31 @@ describe('Testing user post endpoint', () => {
           orgUuid = res.body.created.org_UUID
         })
     })
+    it('Allows creation of user with registry enabled', async () => {
+      await chai
+        .request(app)
+        .post('/api/org/win_5/user')
+        .set({ ...constants.headers, ...shortName })
+        .query(registryFlag)
+        .send({
+          user_id: 'fakeregistryuser999',
+          name: {
+            first: 'Dave',
+            last: 'FakeLastName',
+            middle: 'Cool',
+            suffix: 'Mr.'
+          },
+          authority: {
+            active_roles: ['ADMIN']
+          }
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          orgUuid = res.body.created.org_UUID
+        })
+    })
   })
-  context('Negitive Test', () => {
+  context('Negative Tests', () => {
     it('Fails creation of user for bad long first name', async () => {
       await chai.request(app)
         .post('/api/org/win_5/user')
@@ -61,6 +85,35 @@ describe('Testing user post endpoint', () => {
         .then((res, err) => {
           expect(res).to.have.status(400)
           expect(_.some(res.body.details, { msg: 'Invalid name.first. Name must be between 1 and 100 characters in length.' })).to.be.true
+          expect(err).to.be.undefined
+        })
+    })
+    it('Fails creation of user for bad long first name with registry enabled', async () => {
+      await chai
+        .request(app)
+        .post('/api/org/win_5/user')
+        .set({ ...constants.headers, ...shortName })
+        .query(registryFlag)
+        .send({
+          user_id: 'fakeregistryuser9999',
+          name: {
+            first:
+              'VerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnm1',
+            last: 'FakeLastName',
+            middle: 'Cool',
+            suffix: 'Mr.'
+          },
+          authority: {
+            active_roles: ['ADMIN']
+          }
+        })
+        .then((res, err) => {
+          expect(res).to.have.status(400)
+          expect(
+            _.some(res.body.details, {
+              msg: 'Invalid name.first. Name must be between 1 and 100 characters in length.'
+            })
+          ).to.be.true
           expect(err).to.be.undefined
         })
     })
@@ -88,6 +141,34 @@ describe('Testing user post endpoint', () => {
           expect(err).to.be.undefined
         })
     })
+    it('Fails creation of user for bad long last name with registry enabled', async () => {
+      await chai
+        .request(app)
+        .post('/api/org/win_5/user')
+        .set({ ...constants.headers, ...shortName })
+        .query(registryFlag)
+        .send({
+          user_id: 'fakeregistryuser1000',
+          name: {
+            first: 'FirstName',
+            last: 'VerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnm1',
+            middle: 'Cool',
+            suffix: 'Mr.'
+          },
+          authority: {
+            active_roles: ['ADMIN']
+          }
+        })
+        .then((res, err) => {
+          expect(res).to.have.status(400)
+          expect(
+            _.some(res.body.details, {
+              msg: 'Invalid name.last. Name must be between 1 and 100 characters in length.'
+            })
+          ).to.be.true
+          expect(err).to.be.undefined
+        })
+    })
     it('Fails creation of user for bad long middle name', async () => {
       await chai.request(app)
         .post('/api/org/win_5/user')
@@ -112,6 +193,35 @@ describe('Testing user post endpoint', () => {
           expect(err).to.be.undefined
         })
     })
+    it('Fails creation of user for bad long middle name with registry enabled', async () => {
+      await chai
+        .request(app)
+        .post('/api/org/win_5/user')
+        .set({ ...constants.headers, ...shortName })
+        .query(registryFlag)
+        .send({
+          user_id: 'fakeregistryuser1001',
+          name: {
+            first: 'FirstName',
+            last: 'LastName',
+            middle:
+              'VerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnm1',
+            suffix: 'Mr.'
+          },
+          authority: {
+            active_roles: ['ADMIN']
+          }
+        })
+        .then((res, err) => {
+          expect(res).to.have.status(400)
+          expect(
+            _.some(res.body.details, {
+              msg: 'Invalid name.middle. Name must be between 1 and 100 characters in length.'
+            })
+          ).to.be.true
+          expect(err).to.be.undefined
+        })
+    })
     it('Fails creation of user for bad long suffix name', async () => {
       await chai.request(app)
         .post('/api/org/win_5/user')
@@ -133,6 +243,35 @@ describe('Testing user post endpoint', () => {
         .then((res, err) => {
           expect(res).to.have.status(400)
           expect(_.some(res.body.details, { msg: 'Invalid name.suffix. Name must be between 1 and 100 characters in length.' })).to.be.true
+          expect(err).to.be.undefined
+        })
+    })
+    it('Fails creation of user for bad long suffix name with registry enabled', async () => {
+      await chai
+        .request(app)
+        .post('/api/org/win_5/user')
+        .set({ ...constants.headers, ...shortName })
+        .query(registryFlag)
+        .send({
+          user_id: 'fakeregistryuser1002',
+          name: {
+            first: 'FirstName',
+            last: 'LastName',
+            middle: 'MiddleName',
+            suffix:
+              'VerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnmVerylongnm1'
+          },
+          authority: {
+            active_roles: ['ADMIN']
+          }
+        })
+        .then((res, err) => {
+          expect(res).to.have.status(400)
+          expect(
+            _.some(res.body.details, {
+              msg: 'Invalid name.suffix. Name must be between 1 and 100 characters in length.'
+            })
+          ).to.be.true
           expect(err).to.be.undefined
         })
     })
@@ -182,6 +321,32 @@ describe('Testing user post endpoint', () => {
           expect(err).to.be.undefined
           expect(res).to.have.status(400)
           expect(res.body.error).to.contain('NUMBER_OF_USERS_IN_ORG_LIMIT_REACHED')
+        })
+    })
+    it('Fails creation of user for trying to add the 101th user with registry enabled', async function () {
+      await chai
+        .request(app)
+        .post('/api/org/win_5/user')
+        .set({ ...constants.headers, ...shortName })
+        .query(registryFlag)
+        .send({
+          user_id: 'Fake101RegistryUser',
+          name: {
+            first: 'Dave',
+            last: 'FakeLastName',
+            middle: 'Cool',
+            suffix: 'Mr.'
+          },
+          authority: {
+            active_roles: ['ADMIN']
+          }
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.contain(
+            'NUMBER_OF_USERS_IN_ORG_LIMIT_REACHED'
+          )
         })
     })
   })


### PR DESCRIPTION
Closes Issue #1411 

# Summary
Adds integration tests for creating org users with registry flag set to true.

# Important Changes
`test/integration-tests/org/postOrgUsersTest.js`
- New tests added for all cases with registry flag set to true

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run integration tests. All tests should pass
