### PR TITLE
Resolves issue 1417, Testing User Get Request for /api/org with the `registry=true` flag

### DIFF
--- a/test/integration-tests/user/getUserTestRegistryFlag.js
+++ b/test/integration-tests/user/getUserTestRegistryFlag.js
@@ -114,18 +114,5 @@ describe('Testing /api/org/ user endpoints with `registry=true`', () => {
           expect(res.body.error).to.contain('BAD_INPUT')
         })
     })
-    // can move this to another file for testing the PUT request
-    it('expect error when trying to add existing user to the same org', async () => {
-      const user = constants.nonSecretariatUserHeaders3['CVE-API-USER']
-      const org = constants.nonSecretariatUserHeaders3['CVE-API-ORG']
-      await chai.request(app)
-        .put(`${BASE_URL}/org/${org}/user/${user}?registry=true&org_short_name=${org}`)
-        .set(constants.headers)
-        .send()
-        .then((res) => {
-          expect(res).to.have.status(403)
-          expect(res.body.error).to.contain('USER_ALREADY_IN_ORG')
-        })
-    })
   })
 })

--- a/test/integration-tests/user/getUserTestRegistryFlag.js
+++ b/test/integration-tests/user/getUserTestRegistryFlag.js
@@ -1,0 +1,131 @@
+const chai = require('chai')
+chai.use(require('chai-http'))
+const expect = chai.expect
+
+const constants = require('../constants.js')
+const app = require('../../../src/index.js')
+const BASE_URL = '/api'
+/**
+ * Unit Tests for testing User Get Request for /api/org with the `registry=true` flag
+ */
+
+describe('Testing /api/org/ user endpoints with `registry=true`', () => {
+  // Testing USER GET Endpoints with `registry=true` flag
+  describe('Testing USER GET endpoint with `registry=true`', () => {
+    /* Positive Tests */
+    it('secretariat users can request a list of all users', async () => {
+      await chai.request(app)
+        .get(`${BASE_URL}/users?registry=true`)
+        .set(constants.headers)
+        .send({
+        })
+        .then((res) => {
+          expect(res).to.have.status(200)
+          // check the fields returned
+        })
+    })
+    it('page must be a positive int', async () => {
+      await chai.request(app)
+        .get(`${BASE_URL}/users?registry=true&page=1`)
+        .set(constants.headers)
+        .send()
+        .then((res) => {
+          expect(res).to.have.status(200)
+        })
+    })
+    it('can retrieve user after an update', async () => {
+      const user = constants.nonSecretariatUserHeaders3['CVE-API-USER']
+      const org = constants.nonSecretariatUserHeaders3['CVE-API-ORG']
+      const newFirstName = 'testFirstName'
+      var oldFirstName = ''
+      await chai.request(app)
+        .get(`${BASE_URL}/org/${org}/user/${user}?registry=true`)
+        .set(constants.headers)
+        .send()
+        .then((res) => {
+          expect(res).to.have.status(200)
+          oldFirstName = res.body.name.first
+        })
+      await chai.request(app)
+        .put(`${BASE_URL}/org/${org}/user/${user}?registry=true&name.first=${newFirstName}`)
+        .set(constants.headers)
+        .send()
+        .then((res) => {
+          expect(res).to.have.status(200)
+        })
+      await chai.request(app)
+        .get(`${BASE_URL}/org/${org}/user/${user}?registry=true`)
+        .set(constants.headers)
+        .send()
+        .then((res) => {
+          expect(res).to.have.status(200)
+          expect(res.body.name.first).to.contain(newFirstName)
+        })
+      await chai.request(app)
+        .put(`${BASE_URL}/org/${org}/user/${user}?registry=true&name.first=${oldFirstName}`)
+        .set(constants.headers)
+        .send()
+        .then((res) => {
+          expect(res).to.have.status(200)
+        })
+    })
+  })
+  /* Negative Tests */
+  context('Negative Test', () => {
+    it('regular users cannot request a list of all users', async () => {
+      await chai.request(app)
+        .get(`${BASE_URL}/users?registry=true`)
+        .set(constants.nonSecretariatUserHeaders)
+        .send({
+        })
+        .then((res) => {
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.contain('SECRETARIAT_ONLY')
+        })
+    })
+    it('org admins cannot request a list of all users', async () => {
+      await chai.request(app)
+        .get(`${BASE_URL}/users?registry=true`)
+        .set(constants.nonSecretariatUserHeaders2)
+        .send({
+        })
+        .then((res) => {
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.contain('SECRETARIAT_ONLY')
+        })
+    })
+    it('page must be a positive int', async () => {
+      // test negative int
+      await chai.request(app)
+        .get(`${BASE_URL}/users?registry=true&page=-1`)
+        .set(constants.headers)
+        .send({})
+        .then((res) => {
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.contain('BAD_INPUT')
+        })
+      // test string
+      await chai.request(app)
+        .get(`${BASE_URL}/users?registry=true&page=abc`)
+        .set(constants.headers)
+        .send({})
+        .then((res) => {
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.contain('BAD_INPUT')
+        })
+    })
+    // can move this to another file for testing the PUT request
+    it('expect error when trying to add existing user to the same org', async () => {
+      const user = constants.nonSecretariatUserHeaders3['CVE-API-USER']
+      const org = constants.nonSecretariatUserHeaders3['CVE-API-ORG']
+      await chai.request(app)
+        .put(`${BASE_URL}/org/${org}/user/${user}?registry=true&org_short_name=${org}`)
+        .set(constants.headers)
+        .send()
+        .then((res) => {
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.contain('USER_ALREADY_IN_ORG')
+        })
+    })
+  })
+})

--- a/test/integration-tests/user/updateUserTest.js
+++ b/test/integration-tests/user/updateUserTest.js
@@ -120,5 +120,17 @@ describe('Testing Edit user endpoint', () => {
           expect(res.body.error).to.contain('BAD_INPUT')
         })
     })
+    it('expect error when trying to add existing user to the same org', async () => {
+      const user = constants.nonSecretariatUserHeaders3['CVE-API-USER']
+      const org = constants.nonSecretariatUserHeaders3['CVE-API-ORG']
+      await chai.request(app)
+        .put(`/api/org/${org}/user/${user}?registry=true&org_short_name=${org}`)
+        .set(constants.headers)
+        .send()
+        .then((res) => {
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.contain('USER_ALREADY_IN_ORG')
+        })
+    })
   })
 })


### PR DESCRIPTION
Closes Issue 1417

# Summary
Added tests to check that users can be retrieved when the registry flag is set to true.
These tests are based off the `user.py` file

# Important Changes
- updateUserTest.js
I added one test here since it is more relevant for the updateUser usecase
- getUserTestRegistryFlag.js
Handles all other tests

# Testing

Steps to manually test updated functionality, if possible

 1) Ensure mongo is up and running, with replication on
 2) Run npm run test:integration, while targeting localhost mongo


