### PR TITLE
Resolves issue 1401, Validates the request body for registryOrg POST request

### DIFF
--- a/src/controller/registry-org.controller/index.js
+++ b/src/controller/registry-org.controller/index.js
@@ -71,7 +71,7 @@ router.get('/registryOrg',
   query().custom((query) => { return mw.validateQueryParameterNames(query, ['page']) }),
   query(['page']).custom((val) => { return mw.containsNoInvalidCharacters(val) }),
   query(['page']).optional().isInt({ min: CONSTANTS.PAGINATOR_PAGE }),
-  // parseError,
+  parseError,
   parseGetParams,
   controller.ALL_ORGS
 )
@@ -141,7 +141,7 @@ router.get('/registryOrg/:identifier',
   mw.validateUser,
   mw.onlySecretariat,
   param(['identifier']).isString().trim(),
-  // parseError,
+  parseError,
   parseGetParams,
   controller.SINGLE_ORG
 )
@@ -331,8 +331,40 @@ router.put('/registryOrg/:shortname',
   mw.validateUser,
   mw.onlySecretariat,
   param(['shortname']).isString().trim(),
-  // TODO: do more validation here
-  // parseError,
+  body(['short_name']).isString().trim().notEmpty().isLength({ min: CONSTANTS.MIN_SHORTNAME_LENGTH, max: CONSTANTS.MAX_SHORTNAME_LENGTH }),
+  body(['long_name']).isString().trim().notEmpty(),
+  body(['cve_program_org_function']).isString().trim().default('CNA'),
+  body(['root_or_tlr']).default(false).isBoolean(),
+  body(['oversees']).default([]).isArray(),
+  body(
+    [
+      'charter_or_scope',
+      'disclosure_policy',
+      'product_list',
+      'reports_to',
+      'contact_info.poc',
+      'contact_info.poc_email',
+      'contact_info.poc_phone',
+      'contact_info.org_email',
+      'contact_info.website'
+    ])
+    .default('')
+    .isString(),
+  body(['authority.active_roles']).optional()
+    .custom(isFlatStringArray)
+    .customSanitizer(toUpperCaseArray)
+    .custom(isOrgRole),
+  body(['soft_quota']).optional().not().isArray().isInt({ min: CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_min, max: CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_max }).withMessage(errorMsgs.ID_QUOTA),
+  body(['hard_quota']).optional().not().isArray().isInt({ min: CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_min, max: CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_max }).withMessage(errorMsgs.ID_QUOTA),
+  body(['contact_info.additional_contact_users']).optional()
+    .custom(isFlatStringArray),
+  body(['contact_info.admins']).optional()
+    .custom(isFlatStringArray),
+  body(['aliases']).optional()
+    .custom(isFlatStringArray)
+    .customSanitizer(toLowerCaseArray),
+  // TO-DO: validate users here once implemented
+  parseError,
   parsePostParams,
   parseGetParams,
   controller.UPDATE_ORG
@@ -404,7 +436,7 @@ router.delete('/registryOrg/:identifier',
   // TODO: permissions
   mw.onlySecretariat,
   param(['identifier']).isString().trim(),
-  // parseError,
+  parseError,
   parseDeleteParams,
   controller.DELETE_ORG
 )

--- a/src/controller/registry-org.controller/index.js
+++ b/src/controller/registry-org.controller/index.js
@@ -5,7 +5,7 @@ const errorMsgs = require('../../middleware/errorMessages')
 const { body, param, query } = require('express-validator')
 const controller = require('./registry-org.controller')
 const { parseGetParams, parsePostParams, parseDeleteParams, parseError, isOrgRole } = require('./registry-org.middleware')
-const { toUpperCaseArray, isFlatStringArray } = require('../../middleware/middleware')
+const { toUpperCaseArray, toLowerCaseArray, isFlatStringArray } = require('../../middleware/middleware')
 const getConstants = require('../../constants').getConstants
 const CONSTANTS = getConstants()
 
@@ -214,14 +214,38 @@ router.post('/registryOrg',
   mw.onlySecretariat,
   body(['short_name']).isString().trim().notEmpty().isLength({ min: CONSTANTS.MIN_SHORTNAME_LENGTH, max: CONSTANTS.MAX_SHORTNAME_LENGTH }),
   body(['long_name']).isString().trim().notEmpty(),
+  body(['cve_program_org_function']).isString().trim().default('CNA'),
+  body(['root_or_tlr']).default(false).isBoolean(),
+  body(['oversees']).default([]).isArray(),
+  body(
+    [
+      'charter_or_scope',
+      'disclosure_policy',
+      'product_list',
+      'reports_to',
+      'contact_info.poc',
+      'contact_info.poc_email',
+      'contact_info.poc_phone',
+      'contact_info.org_email',
+      'contact_info.website'
+    ])
+    .default('')
+    .isString(),
   body(['authority.active_roles']).optional()
     .custom(isFlatStringArray)
     .customSanitizer(toUpperCaseArray)
     .custom(isOrgRole),
   body(['soft_quota']).optional().not().isArray().isInt({ min: CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_min, max: CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_max }).withMessage(errorMsgs.ID_QUOTA),
   body(['hard_quota']).optional().not().isArray().isInt({ min: CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_min, max: CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_max }).withMessage(errorMsgs.ID_QUOTA),
-  // TODO: more validation needed?
-  // parseError,
+  body(['contact_info.additional_contact_users']).optional()
+    .custom(isFlatStringArray),
+  body(['contact_info.admins']).optional()
+    .custom(isFlatStringArray),
+  body(['aliases']).optional()
+    .custom(isFlatStringArray)
+    .customSanitizer(toLowerCaseArray),
+  // TO-DO: validate users here once implemented
+  parseError,
   parsePostParams,
   controller.CREATE_ORG
 )

--- a/src/controller/registry-org.controller/registry-org.controller.js
+++ b/src/controller/registry-org.controller/registry-org.controller.js
@@ -98,7 +98,7 @@ async function createOrg (req, res, next) {
       } else if (k === 'short_name') {
         newOrg.short_name = body[k]
       } else if (k === 'aliases') {
-        newOrg.aliases = [...new Set(body[k].active_roles)]
+        newOrg.aliases = [...new Set(body[k])]
       } else if (k === 'cve_program_org_function') {
         newOrg.cve_program_org_function = body[k]
       } else if (k === 'authority') {

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -533,6 +533,27 @@ function toUpperCaseArray (val) {
   return newArr
 }
 
+/**
+ * Recursively casts to strings and lower-cases all items in array
+ *
+ * @param {Array} val
+ */
+function toLowerCaseArray (val) {
+  if (!Array.isArray(val)) {
+    return val.toString().toLowerCase()
+  }
+
+  const newArr = val.map(k => {
+    if (Array.isArray(k)) {
+      return toLowerCaseArray(k)
+    } else {
+      return k.toString().toLowerCase()
+    }
+  })
+
+  return newArr
+}
+
 // Check for the invalid characters <, >, and "
 function containsNoInvalidCharacters (val) {
   const invalidCharacterList = ['<', '>', '"']
@@ -568,6 +589,7 @@ module.exports = {
   isFlatStringArray,
   isCveProgramOrgMembershipObject,
   toUpperCaseArray,
+  toLowerCaseArray,
   containsNoInvalidCharacters,
   trimJSONWhitespace
 }


### PR DESCRIPTION
Closes Issue 1401
Also closes [1403](https://github.com/orgs/CVEProject/projects/67/views/1?pane=issue&itemId=115515331&issue=CVEProject%7Ccve-services%7C1403) 

# Summary
[Issue 1401](https://github.com/orgs/CVEProject/projects/67/views/1?pane=issue&itemId=115515326&issue=CVEProject%7Ccve-services%7C1401) occurs because there is currently not type validation for the request body inputs. 

# Important Changes
`cve-services/src/controller/registry-org.controller/index.js`
- Add validation checks for the request body input values

`cve-services/src/controller/registry-org.controller/registry-org.controller.js`
- fixed bug: `aliases` value was not being updated properly


# Notes
I will be creating additional tickets to 
- implement validation for the other endpoints and uncomment parseError
- create registryOrg tests for these endpoints
- Implement the [users](https://github.com/CVEProject/cve-services/compare/emathew/1401-registryOrg-admin-error?expand=1#diff-566587cf7c509d7af6267ab95af481ce3a0e992c1ce126838632a5c978c49d84L114) request body field as well
