### PR TITLE
Resolves issue #1402 - updated swagger docs for registry endpoints

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -21,7 +21,7 @@
           "CVE ID"
         ],
         "summary": "Retrieves information about CVE IDs after applying the query parameters as filters (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves filtered CVE IDs owned by the user's organization</p>  <p><b>Secretariat:</b> Retrieves filtered CVE IDs owned by any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular, CNA & Admin Users:</b> Retrieves filtered CVE IDs owned by the user's organization</p>\r  <p><b>Secretariat:</b> Retrieves filtered CVE IDs owned by any organization</p>",
         "operationId": "cveIdGetFiltered",
         "parameters": [
           {
@@ -123,7 +123,7 @@
           "CVE ID"
         ],
         "summary": "Reserves CVE IDs for the organization provided in the short_name query parameter (accessible to CNAs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Reserves CVE IDs for the CNA</p>  <p><b>Secretariat:</b> Reserves CVE IDs for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>CNA:</b> Reserves CVE IDs for the CNA</p>\r  <p><b>Secretariat:</b> Reserves CVE IDs for any organization</p>",
         "operationId": "cveIdReserve",
         "parameters": [
           {
@@ -228,7 +228,7 @@
           "CVE ID"
         ],
         "summary": "Retrieves information about the specified CVE ID (accessible to all users)",
-        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users: </b>Retrieves full information about a CVE ID owned by their organization; partial information about a CVE ID owned by other organizations</p>  <p><b>Unauthenticated Users: </b>Retrieves partial information about a CVE ID  <p><b>Secretariat: </b>Retrieves full information about a CVE ID owned by any organization</p>  <p><i><b>Note - </b>The owning organization of RESERVED CVE IDs is redacted for all users other than those in the owning organization or Secretariat</i></p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Endpoint is accessible to all</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular, CNA & Admin Users: </b>Retrieves full information about a CVE ID owned by their organization; partial information about a CVE ID owned by other organizations</p>\r  <p><b>Unauthenticated Users: </b>Retrieves partial information about a CVE ID\r  <p><b>Secretariat: </b>Retrieves full information about a CVE ID owned by any organization</p>\r  <p><i><b>Note - </b>The owning organization of RESERVED CVE IDs is redacted for all users other than those in the owning organization or Secretariat</i></p>",
         "operationId": "cveIdGetSingle",
         "parameters": [
           {
@@ -510,7 +510,7 @@
           "CVE ID"
         ],
         "summary": "Updates information related to the specified CVE ID (accessible to CNAs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Updates information related to a CVE ID owned by the CNA</p>  <p><b>Secretariat:</b> Updates a CVE ID owned by any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>CNA:</b> Updates information related to a CVE ID owned by the CNA</p>\r  <p><b>Secretariat:</b> Updates a CVE ID owned by any organization</p>",
         "operationId": "cveIdUpdateSingle",
         "parameters": [
           {
@@ -608,7 +608,7 @@
           "CVE ID"
         ],
         "summary": "Creates a CVE-ID-Range for the specified year (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates a CVE-ID-Range for the specified year</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Creates a CVE-ID-Range for the specified year</p>",
         "operationId": "cveIdRangeCreate",
         "parameters": [
           {
@@ -693,7 +693,7 @@
           "CVE Record"
         ],
         "summary": "Returns a CVE Record by CVE ID (accessible to all users)",
-        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p><b>All users:</b> Retrieves the CVE Record specified</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Endpoint is accessible to all</p>\r  <h2>Expected Behavior</h2>\r  <p><b>All users:</b> Retrieves the CVE Record specified</p>",
         "operationId": "cveGetSingle",
         "parameters": [
           {
@@ -893,7 +893,7 @@
           "CVE Record"
         ],
         "summary": "Creates a CVE Record from full CVE Record JSON for the specified ID (accessible to Secretariat.)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates a CVE Record for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Creates a CVE Record for any organization</p>",
         "operationId": "cveSubmit",
         "parameters": [
           {
@@ -993,7 +993,7 @@
           "CVE Record"
         ],
         "summary": "Updates a CVE Record from full CVE Record JSON for the specified ID (accessible to Secretariat.)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Updates a CVE Record for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Updates a CVE Record for any organization</p>",
         "operationId": "cveUpdateSingle",
         "parameters": [
           {
@@ -1095,7 +1095,7 @@
           "CVE Record"
         ],
         "summary": "Retrieves all CVE Records after applying the query parameters as filters (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves all CVE records for all organizations</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Retrieves all CVE records for all organizations</p>",
         "operationId": "cveGetFiltered",
         "parameters": [
           {
@@ -1196,7 +1196,7 @@
           "CVE Record"
         ],
         "summary": "Retrieves the count of all the CVE Records after applying the query parameters as filters (accessible to all users)",
-        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p>Retrieves the count of all CVE records for all organizations</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Endpoint is accessible to all</p>\r  <h2>Expected Behavior</h2>\r  <p>Retrieves the count of all CVE records for all organizations</p>",
         "operationId": "cveGetFilteredCount",
         "parameters": [
           {
@@ -1253,7 +1253,7 @@
           "CVE Record"
         ],
         "summary": "Retrieves all CVE Records after applying the query parameters as filters. Uses cursor pagination to paginate results (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves all CVE records for all organizations</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Retrieves all CVE records for all organizations</p>",
         "operationId": "cveGetFilteredCursor",
         "parameters": [
           {
@@ -1360,7 +1360,7 @@
           "CVE Record"
         ],
         "summary": "Creates a CVE Record from CNA Container JSON for the specified ID (accessible to CNAs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Creates CVE Record for a CVE ID owned by their organization</p>  <p><b>Secretariat:</b> Creates CVE Record for CVE IDs owned by any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>CNA:</b> Creates CVE Record for a CVE ID owned by their organization</p>\r  <p><b>Secretariat:</b> Creates CVE Record for CVE IDs owned by any organization</p>",
         "operationId": "cveCnaCreateSingle",
         "parameters": [
           {
@@ -1448,7 +1448,7 @@
           }
         },
         "requestBody": {
-          "description": "<h3>Notes:</h3>  <ul>  <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>  <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>  </ul>",
+          "description": "<h3>Notes:</h3>   <ul>   <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>   <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>   </ul>",
           "required": true,
           "content": {
             "application/json": {
@@ -1472,7 +1472,7 @@
           "CVE Record"
         ],
         "summary": "Updates the CVE Record from CNA Container JSON for the specified ID (accessible to CNAs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Updates a CVE Record for records that are owned by their organization</p>  <p><b>Secretariat:</b> Updates a CVE Record for records that are owned by any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>CNA:</b> Updates a CVE Record for records that are owned by their organization</p>\r  <p><b>Secretariat:</b> Updates a CVE Record for records that are owned by any organization</p>",
         "operationId": "cveCnaUpdateSingle",
         "parameters": [
           {
@@ -1560,7 +1560,7 @@
           }
         },
         "requestBody": {
-          "description": "<h3>Notes:</h3>  <ul>  <li>When updating a rejected record to published, it is recommended to confirm that both the Cve-Id and CVE record are in the correct state after calling this endpoint. Though very unlikely, a race condition can occur causing the two states to be out of sync. </li>  <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>  <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>  </ul>",
+          "description": "<h3>Notes:</h3>   <ul>   <li>When updating a rejected record to published, it is recommended to confirm that both the Cve-Id and CVE record are in the correct state after calling this endpoint. Though very unlikely, a race condition can occur causing the two states to be out of sync. </li>   <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>   <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>   </ul>",
           "required": true,
           "content": {
             "application/json": {
@@ -1586,7 +1586,7 @@
           "CVE Record"
         ],
         "summary": "Creates a rejected CVE Record for the specified ID if no record yet exists (accessible to CNAs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Creates a rejected CVE Record for a record owned by their organization</p>  <p><b>Secretariat:</b> Creates a rejected CVE Record for a record owned by any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>CNA:</b> Creates a rejected CVE Record for a record owned by their organization</p>\r  <p><b>Secretariat:</b> Creates a rejected CVE Record for a record owned by any organization</p>",
         "operationId": "cveCnaCreateReject",
         "parameters": [
           {
@@ -1671,7 +1671,7 @@
           }
         },
         "requestBody": {
-          "description": "<h3>Notes:</h3>  <ul>  <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>  <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>  </ul>",
+          "description": "<h3>Notes:</h3>   <ul>   <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>   <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>   </ul>",
           "required": true,
           "content": {
             "application/json": {
@@ -1687,7 +1687,7 @@
           "CVE Record"
         ],
         "summary": "Updates an existing CVE Record with a rejected record for the specified ID (accessible to CNAs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>CNA:</b> Updates a rejected CVE Record for a record owned by their organization</p>  <p><b>Secretariat:</b> Updates a rejected CVE Record for a record owned by any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>CNA</b> or <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>CNA:</b> Updates a rejected CVE Record for a record owned by their organization</p>\r  <p><b>Secretariat:</b> Updates a rejected CVE Record for a record owned by any organization</p>",
         "operationId": "cveCnaUpdateReject",
         "parameters": [
           {
@@ -1772,7 +1772,7 @@
           }
         },
         "requestBody": {
-          "description": "<h3>Notes:</h3>  <ul>  <li>It is recommended to confirm that both the Cve-Id and CVE record are in the REJECTED state after calling this endpoint. Though very unlikely, a race condition can occur causing the two states to be out of sync. </li>  <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>  <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>  </ul>",
+          "description": "<h3>Notes:</h3>   <ul>   <li>It is recommended to confirm that both the Cve-Id and CVE record are in the REJECTED state after calling this endpoint. Though very unlikely, a race condition can occur causing the two states to be out of sync. </li>   <li>**providerMetadata** is set by the server. If provided, it will be overwritten.</li>   <li>**datePublished** and **assignerShortname** are optional fields in the schema, but are set by the server. </li>   </ul>",
           "required": true,
           "content": {
             "application/json": {
@@ -1790,7 +1790,7 @@
           "CVE Record"
         ],
         "summary": "Updates the CVE Record from ADP Container JSON for the specified ID (accessible to ADPs and Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>ADP</b> or <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>ADP:</b> Updates a CVE Record for records that are owned by any organization</p>  <p><b>Secretariat:</b> Updates a CVE Record for records that are owned by any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>ADP</b> or <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>ADP:</b> Updates a CVE Record for records that are owned by any organization</p>\r  <p><b>Secretariat:</b> Updates a CVE Record for records that are owned by any organization</p>",
         "operationId": "cveAdpUpdateSingle",
         "parameters": [
           {
@@ -1893,7 +1893,7 @@
           "Organization"
         ],
         "summary": "Retrieves all organizations (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves information about all organizations</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Retrieves information about all organizations</p>",
         "operationId": "orgAll",
         "parameters": [
           {
@@ -1987,7 +1987,7 @@
           "Organization"
         ],
         "summary": "Creates an organization as specified in the request body (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates an organization</p>  ",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Creates an organization</p>\r  ",
         "operationId": "orgCreateSingle",
         "parameters": [
           {
@@ -2097,7 +2097,7 @@
           "Organization"
         ],
         "summary": "Retrieves information about the organization specified by short name or UUID (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves organization record for the specified shortname or UUID if it is the user's organization</p>  <p><b>Secretariat:</b> Retrieves information about any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular, CNA & Admin Users:</b> Retrieves organization record for the specified shortname or UUID if it is the user's organization</p>\r  <p><b>Secretariat:</b> Retrieves information about any organization</p>",
         "operationId": "orgSingle",
         "parameters": [
           {
@@ -2199,7 +2199,7 @@
           "Organization"
         ],
         "summary": "Updates information about the organization specified by short name (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Updates any organization's information</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Updates any organization's information</p>",
         "operationId": "orgUpdateSingle",
         "parameters": [
           {
@@ -2316,7 +2316,7 @@
           "Organization"
         ],
         "summary": "Retrieves an organization's CVE ID quota (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves the CVE ID quota for the user's organization</p>  <p><b>Secretariat:</b> Retrieves the CVE ID quota for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular, CNA & Admin Users:</b> Retrieves the CVE ID quota for the user's organization</p>\r  <p><b>Secretariat:</b> Retrieves the CVE ID quota for any organization</p>",
         "operationId": "orgIdQuota",
         "parameters": [
           {
@@ -2418,7 +2418,7 @@
           "Users"
         ],
         "summary": "Retrieves all users for the organization with the specified short name (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about users in the same organization</p>  <p><b>Secretariat:</b> Retrieves all user information for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about users in the same organization</p>\r  <p><b>Secretariat:</b> Retrieves all user information for any organization</p>",
         "operationId": "userOrgAll",
         "parameters": [
           {
@@ -2523,7 +2523,7 @@
           "Users"
         ],
         "summary": "Create a user with the provided short name as the owning organization (accessible to Admins and Secretariats)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>  <h2>Expected Behavior</h2>  <p><b>Admin User:</b> Creates a user for the Admin's organization</p>  <p><b>Secretariat:</b> Creates a user for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Admin User:</b> Creates a user for the Admin's organization</p>\r  <p><b>Secretariat:</b> Creates a user for any organization</p>",
         "operationId": "userCreateSingle",
         "parameters": [
           {
@@ -2642,7 +2642,7 @@
           "Users"
         ],
         "summary": "Retrieves information about a user for the specified username and organization short name (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about a user in the same organization</p>  <p><b>Secretariat:</b> Retrieves any user's information</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about a user in the same organization</p>\r  <p><b>Secretariat:</b> Retrieves any user's information</p>",
         "operationId": "userSingle",
         "parameters": [
           {
@@ -2751,7 +2751,7 @@
           "Users"
         ],
         "summary": "Updates information about a user for the specified username and organization shortname (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular User:</b> Updates the user's own information. Only name fields may be changed.</p>  <p><b>Admin User:</b> Updates information about a user in the Admin's organization. Allowed to change all fields except org_short_name. </p>  <p><b>Secretariat:</b> Updates information about a user in any organization. Allowed to change all fields.</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular User:</b> Updates the user's own information. Only name fields may be changed.</p>\r  <p><b>Admin User:</b> Updates information about a user in the Admin's organization. Allowed to change all fields except org_short_name. </p>\r  <p><b>Secretariat:</b> Updates information about a user in any organization. Allowed to change all fields.</p>",
         "operationId": "userUpdateSingle",
         "parameters": [
           {
@@ -2889,7 +2889,7 @@
           "Users"
         ],
         "summary": "Reset the API key for a user (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular User:</b> Resets user's own API secret</p>  <p><b>Admin User:</b> Resets any user's API secret in the Admin's organization</p>  <p><b>Secretariat:</b> Resets any user's API secret</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular User:</b> Resets user's own API secret</p>\r  <p><b>Admin User:</b> Resets any user's API secret in the Admin's organization</p>\r  <p><b>Secretariat:</b> Resets any user's API secret</p>",
         "operationId": "userResetSecret",
         "parameters": [
           {
@@ -2997,7 +2997,7 @@
           "Users"
         ],
         "summary": "Retrieves information about all registered users (accessible to Secretariat)",
-        "description": "  <h2>Access Control</h2>  <p> User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves information about all users for all organizations</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p> User must belong to an organization with the <b>Secretariat</b> role</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Retrieves information about all users for all organizations</p>",
         "operationId": "userAll",
         "parameters": [
           {
@@ -3093,7 +3093,7 @@
           "Utilities"
         ],
         "summary": "Checks that the system is running (accessible to all users)",
-        "description": "  <h2>Access Control</h2>  <p>Endpoint is accessible to all</p>  <h2>Expected Behavior</h2>  <p>Returns a 200 response code when CVE Services are running</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Endpoint is accessible to all</p>\r  <h2>Expected Behavior</h2>\r  <p>Returns a 200 response code when CVE Services are running</p>",
         "operationId": "healthCheck",
         "responses": {
           "200": {
@@ -3108,7 +3108,7 @@
           "Registry Organization"
         ],
         "summary": "Retrieves information about all registry organizations (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves a list of all registry organizations</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Retrieves a list of all registry organizations</p>",
         "operationId": "getAllRegistryOrgs",
         "parameters": [
           {
@@ -3130,7 +3130,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/registry-org/get-registry-org-response.json"
+                  "$ref": "../schemas/registry-org/list-registry-orgs-response.json"
                 }
               }
             }
@@ -3182,7 +3182,7 @@
           "Registry Organization"
         ],
         "summary": "Creates a new registry organization (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates a new registry organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Creates a new registry organization</p>",
         "operationId": "createRegistryOrg",
         "parameters": [
           {
@@ -3201,7 +3201,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/org/create-org-response.json"
+                  "$ref": "../schemas/registry-org/create-registry-org-response.json"
                 }
               }
             }
@@ -3252,7 +3252,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateOrgPayload"
+                "$ref": "../schemas/registry-org/create-registry-org-request.json"
               }
             }
           }
@@ -3265,7 +3265,7 @@
           "Registry Organization"
         ],
         "summary": "Retrieves information about a specific registry organization",
-        "description": "  <h2>Access Control</h2>  <p>All authenticated users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>All Users:</b> Retrieves information about the specified registry organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All authenticated users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>All Users:</b> Retrieves information about the specified registry organization</p>",
         "operationId": "getSingleRegistryOrg",
         "parameters": [
           {
@@ -3293,7 +3293,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/org/get-org-response.json"
+                  "$ref": "../schemas/registry-org/get-registry-org-response.json"
                 }
               }
             }
@@ -3348,7 +3348,7 @@
           "Registry Organization"
         ],
         "summary": "Deletes an existing registry organization (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Deletes an existing registry organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Deletes an existing registry organization</p>",
         "operationId": "deleteRegistryOrg",
         "parameters": [
           {
@@ -3376,7 +3376,13 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/org/delete-org-response.json"
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Message describing successful deletion operation"
+                    }
+                  }
                 }
               }
             }
@@ -3430,7 +3436,7 @@
           "Registry Organization"
         ],
         "summary": "Updates an existing registry organization (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Updates an existing registry organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Updates an existing registry organization</p>",
         "operationId": "updateRegistryOrg",
         "parameters": [
           {
@@ -3458,7 +3464,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/org/update-org-response.json"
+                  "$ref": "../schemas/registry-org/update-registry-org-response.json"
                 }
               }
             }
@@ -3519,7 +3525,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateOrgPayload"
+                "$ref": "../schemas/registry-org/update-registry-org-request.json"
               }
             }
           }
@@ -3532,7 +3538,7 @@
           "Registry User"
         ],
         "summary": "Retrieves all users for the organization with the specified short name (accessible to all registered users)",
-        "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about users in the same organization</p>  <p><b>Secretariat:</b> Retrieves all user information for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All registered users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Regular, CNA & Admin Users:</b> Retrieves information about users in the same organization</p>\r  <p><b>Secretariat:</b> Retrieves all user information for any organization</p>",
         "operationId": "registryUserOrgAll",
         "parameters": [
           {
@@ -3563,7 +3569,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/user/list-users-response.json"
+                  "$ref": "../schemas/registry-user/list-registry-users-response.json"
                 }
               }
             }
@@ -3627,7 +3633,7 @@
           "Registry User"
         ],
         "summary": "Create a user with the provided short name as the owning organization (accessible to Admins and Secretariats)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>  <h2>Expected Behavior</h2>  <p><b>Admin User:</b> Creates a user for the Admin's organization</p>  <p><b>Secretariat:</b> Creates a user for any organization</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>User must belong to an organization with the <b>Secretariat</b> role or be an <b>Admin</b> of the organization</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Admin User:</b> Creates a user for the Admin's organization</p>\r  <p><b>Secretariat:</b> Creates a user for any organization</p>",
         "operationId": "RegistryUserCreateSingle",
         "parameters": [
           {
@@ -3655,7 +3661,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/user/create-user-response.json"
+                  "$ref": "../schemas/registry-user/create-registry-user-response.json"
                 }
               }
             }
@@ -3716,7 +3722,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "../schemas/user/create-user-request.json"
+                "$ref": "../schemas/registry-user/create-registry-user-request.json"
               }
             }
           }
@@ -3729,7 +3735,7 @@
           "Registry User"
         ],
         "summary": "Retrieves information about all registry users (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Retrieves a list of all registry users</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Retrieves a list of all registry users</p>",
         "operationId": "getAllRegistryUsers",
         "parameters": [
           {
@@ -3747,11 +3753,11 @@
         ],
         "responses": {
           "200": {
-            "description": "A list of all registry organizations, along with pagination fields if results span multiple pages of data",
+            "description": "A list of all registry users, along with pagination fields if results span multiple pages of data",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/registry-user/get-registry-users-response.json"
+                  "$ref": "../schemas/registry-user/list-registry-users-response.json"
                 }
               }
             }
@@ -3803,7 +3809,7 @@
           "Registry User"
         ],
         "summary": "Creates a new registry user (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Creates a new registry user</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Creates a new registry user</p>",
         "operationId": "createRegistryUser",
         "parameters": [
           {
@@ -3822,7 +3828,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/user/create-user-response.json"
+                  "$ref": "../schemas/registry-user/create-registry-user-response.json"
                 }
               }
             }
@@ -3873,7 +3879,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateUserPayload"
+                "$ref": "../schemas/registry-user/create-registry-user-request.json"
               }
             }
           }
@@ -3886,7 +3892,7 @@
           "Registry User"
         ],
         "summary": "Retrieves information about a specific registry user",
-        "description": "  <h2>Access Control</h2>  <p>All authenticated users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>All Users:</b> Retrieves information about the specified registry user</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>All authenticated users can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>All Users:</b> Retrieves information about the specified registry user</p>",
         "operationId": "getSingleRegistryUser",
         "parameters": [
           {
@@ -3914,7 +3920,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/user/get-user-response.json"
+                  "$ref": "../schemas/registry-user/get-registry-user-response.json"
                 }
               }
             }
@@ -3969,7 +3975,7 @@
           "Registry User"
         ],
         "summary": "Updates an existing registry user (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Updates an existing registry user</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Updates an existing registry user</p>",
         "operationId": "updateRegistryUser",
         "parameters": [
           {
@@ -3997,7 +4003,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/user/update-user-response.json"
+                  "$ref": "../schemas/registry-user/update-registry-user-response.json"
                 }
               }
             }
@@ -4058,7 +4064,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/UpdateUserPayload"
+                "$ref": "../schemas/registry-user/update-registry-user-request.json"
               }
             }
           }
@@ -4069,7 +4075,7 @@
           "Registry User"
         ],
         "summary": "Deletes an existing registry user (accessible to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>Only users with Secretariat role can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Deletes an existing registry user</p>",
+        "description": "\r  <h2>Access Control</h2>\r  <p>Only users with Secretariat role can access this endpoint</p>\r  <h2>Expected Behavior</h2>\r  <p><b>Secretariat:</b> Deletes an existing registry user</p>",
         "operationId": "deleteRegistryUser",
         "parameters": [
           {
@@ -4097,7 +4103,13 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "../schemas/user/delete-user-response.json"
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "description": "Message describing successful deletion operation"
+                    }
+                  }
                 }
               }
             }

--- a/schemas/registry-org/update-registry-org-request.json
+++ b/schemas/registry-org/update-registry-org-request.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://cve.mitre.org/schema/org/organization.json",
+  "type": "object",
+  "title": "CVE Update Registry Org Request",
+  "description": "JSON Schema for updating a CVE Registry organization",
+  "properties": {
+    "long_name": {
+      "type": "string",
+      "description": "Full name of the organization"
+    },
+    "short_name": {
+      "type": "string",
+      "description": "Short name or acronym of the organization"
+    },
+    "aliases": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Alternative names or aliases for the organization"
+    },
+    "cve_program_org_function": {
+      "type": "string",
+      "enum": ["CNA", "ADP", "Root", "Secretariat"],
+      "description": "The organization's function within the CVE program"
+    },
+    "authority": {
+      "type": "object",
+      "properties": {
+        "active_roles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["CNA", "ADP", "Root", "Secretariat"]
+          }
+        }
+      },
+      "required": ["active_roles"]
+    },
+    "reports_to": {
+      "type": ["string", "null"],
+      "description": "UUID of the parent organization, if any"
+    },
+    "oversees": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "UUIDs of organizations overseen by this organization"
+    },
+    "root_or_tlr": {
+      "type": "boolean",
+      "description": "Indicates if the organization is a root or top-level root"
+    },
+    "users": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "UUIDs of users associated with this organization"
+    },
+    "charter_or_scope": {
+      "type": "string",
+      "description": "Description of the organization's charter or scope"
+    },
+    "disclosure_policy": {
+      "type": "string",
+      "description": "The organization's disclosure policy"
+    },
+    "product_list": {
+      "type": "string",
+      "description": "List of products associated with the organization"
+    },
+    "contact_info": {
+      "type": "object",
+      "properties": {
+        "additional_contact_users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "poc": {
+          "type": "string",
+          "description": "Point of contact name"
+        },
+        "poc_email": {
+          "type": "string",
+          "format": "email",
+          "description": "Point of contact email"
+        },
+        "poc_phone": {
+          "type": "string",
+          "description": "Point of contact phone number"
+        },
+        "admins": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "UUIDs of admin users"
+        },
+        "org_email": {
+          "type": "string",
+          "format": "email",
+          "description": "Organization's email address"
+        },
+        "website": {
+          "type": "string",
+          "format": "uri",
+          "description": "Organization's website URL"
+        }
+      }
+    }
+  }
+}

--- a/schemas/registry-user/update-registry-user-request.json
+++ b/schemas/registry-user/update-registry-user-request.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://cve.mitre.org/schema/user/registry-user.json",
+  "type": "object",
+  "title": "CVE Update Registry User Request",
+  "description": "JSON Schema for updating a CVE Registry User",
+  "properties": {
+    "user_id": {
+      "type": "string",
+      "description": "User's identifier or username"
+    },
+    "name": {
+      "type": "object",
+      "properties": {
+        "first": {
+          "type": "string",
+          "description": "User's first name"
+        },
+        "last": {
+          "type": "string",
+          "description": "User's last name"
+        },
+        "middle": {
+          "type": "string",
+          "description": "User's middle name"
+        },
+        "suffix": {
+          "type": "string",
+          "description": "User's name suffix"
+        }
+      }
+    },
+    "org_affiliations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "UUIDs of organizations the user is affiliated with"
+    },
+    "cve_program_org_membership": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "UUIDs of CVE program organizations the user is a member of"
+    },
+    "authority": {
+      "type": "object",
+      "properties": {
+        "active_roles": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["ADMIN", "PUBLISHER"]
+          }
+        }
+      },
+      "required": ["active_roles"]
+    },
+    "contact_info": {
+      "type": "object",
+      "properties": {
+        "email": {
+          "type": "string",
+          "format": "email",
+          "description": "User's email address"
+        },
+        "phone": {
+          "type": "string",
+          "description": "User's phone number"
+        }
+      }
+    }
+  }
+}

--- a/src/controller/registry-org.controller/index.js
+++ b/src/controller/registry-org.controller/index.js
@@ -29,7 +29,7 @@ router.get('/registryOrg',
     description: 'A list of all registry organizations, along with pagination fields if results span multiple pages of data',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/registry-org/get-registry-org-response.json' }
+        schema: { $ref: '../schemas/registry-org/list-registry-orgs-response.json' }
       }
     }
   }
@@ -101,7 +101,7 @@ router.get('/registryOrg/:identifier',
     description: 'The requested registry organization information is returned',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/org/get-org-response.json' }
+        schema: { $ref: '../schemas/registry-org/get-registry-org-response.json' }
       }
     }
   }
@@ -165,7 +165,7 @@ router.post('/registryOrg',
     required: true,
     content: {
       'application/json': {
-        schema: { $ref: '#/components/schemas/CreateOrgPayload' }
+        schema: { $ref: '../schemas/registry-org/create-registry-org-request.json' }
       }
     }
   }
@@ -173,7 +173,7 @@ router.post('/registryOrg',
     description: 'The registry organization was successfully created',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/org/create-org-response.json' }
+        schema: { $ref: '../schemas/registry-org/create-registry-org-response.json' }
       }
     }
   }
@@ -275,7 +275,7 @@ router.put('/registryOrg/:shortname',
     required: true,
     content: {
       'application/json': {
-        schema: { $ref: '#/components/schemas/UpdateOrgPayload' }
+        schema: { $ref: '../schemas/registry-org/update-registry-org-request.json' }
       }
     }
   }
@@ -283,7 +283,7 @@ router.put('/registryOrg/:shortname',
     description: 'The registry organization was successfully updated',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/org/update-org-response.json' }
+        schema: { $ref: '../schemas/registry-org/update-registry-org-response.json' }
       }
     }
   }
@@ -395,7 +395,15 @@ router.delete('/registryOrg/:identifier',
     description: 'The registry organization was successfully deleted',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/org/delete-org-response.json' }
+        schema: {
+          type: 'object',
+          properties: {
+            message: {
+              type: 'string',
+              description: 'Message describing successful deletion operation'
+            }
+          }
+        }
       }
     }
   }
@@ -465,7 +473,7 @@ router.get('/registryOrg/:shortname/users',
     description: 'Returns all users for the organization, along with pagination fields if results span multiple pages of data',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/user/list-users-response.json' }
+        schema: { $ref: '../schemas/registry-user/list-registry-users-response.json' }
       }
     }
   }
@@ -539,7 +547,7 @@ router.post('/registryOrg/:shortname/user',
     required: true,
     content: {
       'application/json': {
-        schema: { $ref: '../schemas/user/create-user-request.json' },
+        schema: { $ref: '../schemas/registry-user/create-registry-user-request.json' },
       }
     }
   }
@@ -547,7 +555,7 @@ router.post('/registryOrg/:shortname/user',
     description: 'Returns the new user information (with the secret)',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/user/create-user-response.json' },
+        schema: { $ref: '../schemas/registry-user/create-registry-user-response.json' },
       }
     }
   }

--- a/src/controller/registry-user.controller/index.js
+++ b/src/controller/registry-user.controller/index.js
@@ -24,10 +24,10 @@ router.get('/registryUser',
     '#/components/parameters/apiSecretHeader'
   ]
   #swagger.responses[200] = {
-    description: 'A list of all registry organizations, along with pagination fields if results span multiple pages of data',
+    description: 'A list of all registry users, along with pagination fields if results span multiple pages of data',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/registry-user/get-registry-users-response.json' }
+        schema: { $ref: '../schemas/registry-user/list-registry-users-response.json' }
       }
     }
   }
@@ -98,7 +98,7 @@ router.get('/registryUser/:identifier',
     description: 'The requested registry user information is returned',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/user/get-user-response.json' }
+        schema: { $ref: '../schemas/registry-user/get-registry-user-response.json' }
       }
     }
   }
@@ -162,7 +162,7 @@ router.post('/registryUser',
     required: true,
     content: {
       'application/json': {
-        schema: { $ref: '#/components/schemas/CreateUserPayload' }
+        schema: { $ref: '../schemas/registry-user/create-registry-user-request.json' }
       }
     }
   }
@@ -170,7 +170,7 @@ router.post('/registryUser',
     description: 'The registry user was successfully created',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/user/create-user-response.json' }
+        schema: { $ref: '../schemas/registry-user/create-registry-user-response.json' }
       }
     }
   }
@@ -241,7 +241,7 @@ router.put('/registryUser/:identifier',
     required: true,
     content: {
       'application/json': {
-        schema: { $ref: '#/components/schemas/UpdateUserPayload' }
+        schema: { $ref: '../schemas/registry-user/update-registry-user-request.json' }
       }
     }
   }
@@ -249,7 +249,7 @@ router.put('/registryUser/:identifier',
     description: 'The registry user was successfully updated',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/user/update-user-response.json' }
+        schema: { $ref: '../schemas/registry-user/update-registry-user-response.json' }
       }
     }
   }
@@ -303,7 +303,8 @@ router.put('/registryUser/:identifier',
   controller.UPDATE_USER
 )
 
-router.delete('/registryUser/:identifier',
+router.delete(
+  '/registryUser/:identifier',
   /*
   #swagger.tags = ['Registry User']
   #swagger.operationId = 'deleteRegistryUser'
@@ -328,7 +329,15 @@ router.delete('/registryUser/:identifier',
     description: 'The registry user was successfully deleted',
     content: {
       "application/json": {
-        schema: { $ref: '../schemas/user/delete-user-response.json' }
+        schema: {
+          type: 'object',
+          properties: {
+            message: {
+              type: 'string',
+              description: 'Message describing successful deletion operation'
+            }
+          }
+        }
       }
     }
   }

--- a/src/controller/schemas.controller/index.js
+++ b/src/controller/schemas.controller/index.js
@@ -55,6 +55,7 @@ router.get('/registry-org/create-registry-org-response.json', controller.getCrea
 router.get('/registry-org/get-registry-org-response.json', controller.getRegistryOrgResponseSchema)
 router.get('/registry-org/get-registry-org-quota-response.json', controller.getRegistryOrgQuotaResponseSchema)
 router.get('/registry-org/list-registry-orgs-response.json', controller.getListRegistryOrgsResponseSchema)
+router.get('/registry-org/update-registry-org-request.json', controller.getUpdateRegistryOrgRequestSchema)
 router.get('/registry-org/update-registry-org-response.json', controller.getUpdateRegistryOrgResponseSchema)
 
 // Schemas relating to Registry-User
@@ -62,6 +63,7 @@ router.get('/registry-user/create-registry-user-request.json', controller.getCre
 router.get('/registry-user/create-registry-user-response.json', controller.getCreateRegistryUserResponseSchema)
 router.get('/registry-user/get-registry-user-response.json', controller.getRegistryUserResponseSchema)
 router.get('/registry-user/list-registry-users-response.json', controller.getListRegistryUsersResponseSchema)
+router.get('/registry-user/update-registry-user-request.json', controller.getUpdateRegistryUserRequestSchema)
 router.get('/registry-user/update-registry-user-response.json', controller.getUpdateRegistryUserResponseSchema)
 
 module.exports = router

--- a/src/controller/schemas.controller/schemas.controller.js
+++ b/src/controller/schemas.controller/schemas.controller.js
@@ -260,6 +260,12 @@ async function getListRegistryOrgsResponseSchema (req, res) {
   res.status(200)
 }
 
+async function getUpdateRegistryOrgRequestSchema (req, res) {
+  const updateRegistryOrgRequestSchema = require('../../../schemas/registry-org/update-registry-org-request.json')
+  res.json(updateRegistryOrgRequestSchema)
+  res.status(200)
+}
+
 async function getUpdateRegistryOrgResponseSchema (req, res) {
   const updateRegistryOrgResponseSchema = require('../../../schemas/registry-org/update-registry-org-response.json')
   res.json(updateRegistryOrgResponseSchema)
@@ -289,6 +295,12 @@ async function getRegistryUserResponseSchema (req, res) {
 async function getListRegistryUsersResponseSchema (req, res) {
   const listRegistryUsersResponseSchema = require('../../../schemas/registry-user/list-registry-users-response.json')
   res.json(listRegistryUsersResponseSchema)
+  res.status(200)
+}
+
+async function getUpdateRegistryUserRequestSchema (req, res) {
+  const updateRegistryUserRequestSchema = require('../../../schemas/registry-user/update-registry-user-request.json')
+  res.json(updateRegistryUserRequestSchema)
   res.status(200)
 }
 
@@ -341,10 +353,12 @@ module.exports = {
   getRegistryOrgResponseSchema: getRegistryOrgResponseSchema,
   getRegistryOrgQuotaResponseSchema: getRegistryOrgQuotaResponseSchema,
   getListRegistryOrgsResponseSchema: getListRegistryOrgsResponseSchema,
+  getUpdateRegistryOrgRequestSchema: getUpdateRegistryOrgRequestSchema,
   getUpdateRegistryOrgResponseSchema: getUpdateRegistryOrgResponseSchema,
   getCreateRegistryUserRequestSchema: getCreateRegistryUserRequestSchema,
   getCreateRegistryUserResponseSchema: getCreateRegistryUserResponseSchema,
   getRegistryUserResponseSchema: getRegistryUserResponseSchema,
   getListRegistryUsersResponseSchema: getListRegistryUsersResponseSchema,
+  getUpdateRegistryUserRequestSchema: getUpdateRegistryUserRequestSchema,
   getUpdateRegistryUserResponseSchema: getUpdateRegistryUserResponseSchema
 }


### PR DESCRIPTION
Closes Issue #1402

# Summary
Swagger docs for registry endpoints have been updated to reference the correct schemas. Created new request schemas for updating registry orgs and users.

# Important Changes
`schemas/registry-org/update-registry-org-request.json`, `schemas/registry-user/update-registry-user-request.json`:
- New schemas for update requests

`src/controller/schemas.controller/index.js`, `src/controller/schemas.controller/schemas.controller.js`:
- Created endpoints for fetching new schemas

`src/controller/registry-org.controller/index.js`, `src/controller/registry-user.controller/index.js`:
- Updated swagger parameters to reference correct schemas

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Swagger docs should now reference correct schemas for registry endpoints and not throw any errors.
