### PR TITLE
Resolves issue 1400, Add createUserByOrg registryOrg/ endpoint

### DIFF
--- a/src/controller/registry-org.controller/index.js
+++ b/src/controller/registry-org.controller/index.js
@@ -541,9 +541,32 @@ router.post('/registryOrg/:shortname/user',
   // // mw.onlyOrgWithPartnerRole,
   mw.onlySecretariat,
   param(['shortname']).isString().trim().notEmpty().isLength({ min: CONSTANTS.MIN_SHORTNAME_LENGTH, max: CONSTANTS.MAX_SHORTNAME_LENGTH }),
-  body(['cve_program_org_membership'])
+  body(['cve_program_org_membership']).optional().custom(isFlatStringArray), // TO-DO: implement custom(mw.isCveProgramOrgMembershipObject),
+  body(
+    [
+      'user_id',
+      'name.first',
+      'name.last'
+    ])
+    .isString(),
+  body(
+    [
+      'name.middle',
+      'name.suffix',
+      'contact_info.phone',
+      'contact_info.email' // // TO-DO: this needs to be required only when contact-info is present?
+    ])
+    .default('')
+    .isString(),
+  body(['org_affiliations'])
     .optional()
-    .custom(mw.isCveProgramOrgMembershipObject),
+    .custom(isFlatStringArray)
+    .customSanitizer(toUpperCaseArray),
+  body(['authority.active_roles'])
+    .optional()
+    .custom(isFlatStringArray)
+    .customSanitizer(toUpperCaseArray)
+    .custom(isOrgRole), // TO-DO: this needs to be required only when authority is present?
   parseError,
   parsePostParams,
   controller.USER_CREATE_SINGLE)

--- a/src/controller/registry-org.controller/index.js
+++ b/src/controller/registry-org.controller/index.js
@@ -541,7 +541,7 @@ router.post('/registryOrg/:shortname/user',
   // // mw.onlyOrgWithPartnerRole,
   mw.onlySecretariat,
   param(['shortname']).isString().trim().notEmpty().isLength({ min: CONSTANTS.MIN_SHORTNAME_LENGTH, max: CONSTANTS.MAX_SHORTNAME_LENGTH }),
-  body(['cve_program_org_membership']).optional().custom(isFlatStringArray), // TO-DO: implement custom(mw.isCveProgramOrgMembershipObject),
+  // body(['cve_program_org_membership']).optional().custom(isFlatStringArray), // TO-DO: implement custom(mw.isCveProgramOrgMembershipObject),
   body(
     [
       'user_id',
@@ -558,10 +558,8 @@ router.post('/registryOrg/:shortname/user',
     ])
     .default('')
     .isString(),
-  body(['org_affiliations'])
-    .optional()
-    .custom(isFlatStringArray)
-    .customSanitizer(toUpperCaseArray),
+  body(['org_affiliations']) // TO-DO
+    .optional(),
   body(['authority.active_roles'])
     .optional()
     .custom(isFlatStringArray)

--- a/src/controller/registry-org.controller/registry-org.controller.js
+++ b/src/controller/registry-org.controller/registry-org.controller.js
@@ -417,9 +417,14 @@ async function createUserByOrg (req, res, next) {
       return res.status(400).json(error.userExists(username))
     }
 
+    const bodyKeys = Object.keys(body).map(k => k.toLowerCase())
+    if (bodyKeys.includes('uuid')) {
+      return res.status(400).json(error.uuidProvided('user'))
+    }
+
     // Creating a new user under specific org
     const newUser = new RegistryUser()
-    Object.keys(body).map(k => k.toLowerCase()).forEach(k => {
+    bodyKeys.forEach(k => {
       if (k === 'user_id' || k === 'username') {
         newUser.user_id = body[k]
       } else if (k === 'name') {
@@ -463,8 +468,6 @@ async function createUserByOrg (req, res, next) {
             ...rest
           }
         })
-      } else if (k === 'uuid') {
-        return res.status(400).json(error.uuidProvided('user'))
       }
     })
 

--- a/src/controller/registry-org.controller/registry-org.controller.js
+++ b/src/controller/registry-org.controller/registry-org.controller.js
@@ -388,7 +388,7 @@ async function createUserByOrg (req, res, next) {
     const requesterOrgUUID = await registryOrgRepo.getOrgUUID(requesterShortName)
     const body = req.ctx.body
 
-    const isSecretariat = await registryOrgRepo.isSecretariat(shortName)
+    const isSecretariat = await registryOrgRepo.isSecretariat(requesterShortName)
     const isAdmin = await registryUserRepo.isAdmin(requesterUsername, requesterShortName)
 
     if (!isSecretariat && !isAdmin) { // may be redundant after validation check is implemented
@@ -401,6 +401,15 @@ async function createUserByOrg (req, res, next) {
       if (orgUUID !== requesterOrgUUID) {
         return res.status(403).json(error.notOrgAdminOrSecretariat()) // The Admin user must belong to the new user's organization
       }
+    }
+
+    const username = body.user_id || body.username
+    if (!username) {
+      return res.status(400).json({ message: 'user_id is required' })
+    }
+    const existingUser = await registryUserRepo.findOneByUserNameAndOrgUUID(username, orgUUID)
+    if (existingUser) {
+      return res.status(400).json(error.userExists(username))
     }
 
     // Creating a new user under specific org
@@ -417,21 +426,54 @@ async function createUserByOrg (req, res, next) {
           ...body.name
         }
       } else if (k === 'org_affiliations') {
-        // TODO: dedupe
+        newUser.org_affiliations = body[k].map(item => {
+          const {
+            orgId = '',
+            email = '',
+            phone = '',
+            ...rest
+          } = item
+
+          return {
+            org_id: orgId,
+            email,
+            phone,
+            ...rest
+          }
+        })
       } else if (k === 'cve_program_org_membership') {
-        // TODO: dedupe
+        newUser.cve_program_org_membership = body[k].map(item => {
+          const {
+            programOrg = '',
+            roles = [],
+
+            status = false,
+            ...rest
+          } = item
+
+          return {
+            program_org: programOrg,
+            roles,
+            status,
+            ...rest
+          }
+        })
       } else if (k === 'uuid') {
         return res.status(400).json(error.uuidProvided('user'))
       }
     })
 
     newUser.UUID = uuid.v4()
+
     const randomKey = cryptoRandomString({ length: getConstants().CRYPTO_RANDOM_STRING_LENGTH })
     newUser.secret = await argon2.hash(randomKey)
     newUser.last_active = null
     newUser.deactivation_date = null
 
-    await registryUserRepo.updateByUUID(newUser.UUID, newUser, { upsert: true })
+    await registryUserRepo.updateByUserNameAndOrgUUID(newUser.user_id, orgUUID, newUser, { upsert: true })
+    await registryUserRepo.addOrgToUserAffiliation(newUser.UUID, orgUUID)
+    await registryOrgRepo.addUserToOrgList(orgUUID, newUser.UUID, body.authority?.active_roles ? [...new Set(body.authority.active_roles)].includes('ADMIN') : false, { upsert: true })
+
     const agt = setAggregateUserObj({ UUID: newUser.UUID })
     let result = await registryUserRepo.aggregate(agt)
     result = result.length > 0 ? result[0] : null
@@ -440,10 +482,10 @@ async function createUserByOrg (req, res, next) {
       action: 'create_registry_user',
       change: result.user_id + ' was successfully created.',
       req_UUID: req.ctx.uuid,
-      org_UUID: await registryOrgRepo.getOrgUUID(req.ctx.org),
+      org_UUID: orgUUID,
       user: result
     }
-    payload.user_UUID = await registryUserRepo.getUserUUID(req.ctx.user, payload.org_UUID)
+    payload.user_UUID = await registryUserRepo.getUserUUID(req.ctx.user, orgUUID)
     logger.info(JSON.stringify(payload))
 
     result.secret = randomKey

--- a/src/controller/registry-org.controller/registry-org.controller.js
+++ b/src/controller/registry-org.controller/registry-org.controller.js
@@ -1,9 +1,11 @@
+const argon2 = require('argon2')
 const uuid = require('uuid')
 const logger = require('../../middleware/logger')
 const { getConstants } = require('../../constants')
 const RegistryOrg = require('../../model/registry-org')
 const RegistryUser = require('../../model/registry-user')
 const errors = require('./error')
+const cryptoRandomString = require('crypto-random-string')
 const error = new errors.RegistryOrgControllerError()
 const validateUUID = require('uuid').validate
 
@@ -98,7 +100,7 @@ async function createOrg (req, res, next) {
       } else if (k === 'short_name') {
         newOrg.short_name = body[k]
       } else if (k === 'aliases') {
-        newOrg.aliases = [...new Set(body[k].active_roles)]
+        newOrg.aliases = [...new Set(body[k])]
       } else if (k === 'cve_program_org_function') {
         newOrg.cve_program_org_function = body[k]
       } else if (k === 'authority') {
@@ -197,7 +199,6 @@ async function updateOrg (req, res, next) {
     const shortName = req.ctx.params.shortname
     const userRepo = req.ctx.repositories.getRegistryUserRepository()
     const registryOrgRepo = req.ctx.repositories.getRegistryOrgRepository()
-    // const shortName = req.ctx.params.shortname
 
     const org = await registryOrgRepo.findOneByShortName(shortName)
     if (!org) {
@@ -375,8 +376,86 @@ async function getUsers (req, res, next) {
   }
 }
 
-function createUserByOrg (req, res, next) {
-  console.log('HERE')
+async function createUserByOrg (req, res, next) {
+  try {
+    const requesterUsername = req.ctx.user
+    const requesterShortName = req.ctx.org
+    const shortName = req.ctx.params.shortname
+
+    const registryUserRepo = req.ctx.repositories.getRegistryUserRepository()
+    const registryOrgRepo = req.ctx.repositories.getRegistryOrgRepository()
+    const orgUUID = await registryOrgRepo.getOrgUUID(shortName)
+    const requesterOrgUUID = await registryOrgRepo.getOrgUUID(requesterShortName)
+    const body = req.ctx.body
+
+    const isSecretariat = await registryOrgRepo.isSecretariat(shortName)
+    const isAdmin = await registryUserRepo.isAdmin(requesterUsername, requesterShortName)
+
+    if (!isSecretariat && !isAdmin) { // may be redundant after validation check is implemented
+      return res.status(403).json(error.notOrgAdminOrSecretariat()) // User must be secretariat or an admin
+    }
+    if (!orgUUID) {
+      return res.status(404).json(error.orgDnePathParam(shortName)) // Org must exist
+    }
+    if (!isSecretariat) { // Admins can only create user within the same org
+      if (orgUUID !== requesterOrgUUID) {
+        return res.status(403).json(error.notOrgAdminOrSecretariat()) // The Admin user must belong to the new user's organization
+      }
+    }
+
+    // Creating a new user under specific org
+    const newUser = new RegistryUser()
+    Object.keys(body).map(k => k.toLowerCase()).forEach(k => {
+      if (k === 'user_id' || k === 'username') {
+        newUser.user_id = body[k]
+      } else if (k === 'name') {
+        newUser.name = {
+          first: '',
+          last: '',
+          middle: '',
+          suffix: '',
+          ...body.name
+        }
+      } else if (k === 'org_affiliations') {
+        // TODO: dedupe
+      } else if (k === 'cve_program_org_membership') {
+        // TODO: dedupe
+      } else if (k === 'uuid') {
+        return res.status(400).json(error.uuidProvided('user'))
+      }
+    })
+
+    newUser.UUID = uuid.v4()
+    const randomKey = cryptoRandomString({ length: getConstants().CRYPTO_RANDOM_STRING_LENGTH })
+    newUser.secret = await argon2.hash(randomKey)
+    newUser.last_active = null
+    newUser.deactivation_date = null
+
+    await registryUserRepo.updateByUUID(newUser.UUID, newUser, { upsert: true })
+    const agt = setAggregateUserObj({ UUID: newUser.UUID })
+    let result = await registryUserRepo.aggregate(agt)
+    result = result.length > 0 ? result[0] : null
+
+    const payload = {
+      action: 'create_registry_user',
+      change: result.user_id + ' was successfully created.',
+      req_UUID: req.ctx.uuid,
+      org_UUID: await registryOrgRepo.getOrgUUID(req.ctx.org),
+      user: result
+    }
+    payload.user_UUID = await registryUserRepo.getUserUUID(req.ctx.user, payload.org_UUID)
+    logger.info(JSON.stringify(payload))
+
+    result.secret = randomKey
+    const responseMessage = {
+      message: result.user_id + ' was successfully created.',
+      created: result
+    }
+
+    return res.status(200).json(responseMessage)
+  } catch (err) {
+    next(err)
+  }
 }
 
 function setAggregateUserObj (query) {

--- a/src/controller/registry-org.controller/registry-org.middleware.js
+++ b/src/controller/registry-org.controller/registry-org.middleware.js
@@ -6,7 +6,7 @@ const error = new errors.RegistryOrgControllerError()
 
 function parsePostParams (req, res, next) {
   utils.reqCtxMapping(req, 'body', [])
-  utils.reqCtxMapping(req, 'params', ['identifier, shortname'])
+  utils.reqCtxMapping(req, 'params', ['identifier', 'shortname'])
   utils.reqCtxMapping(req, 'query', [
     'long_name', 'short_name', 'aliases',
     'cve_program_org_function', 'authority.active_roles',

--- a/test/integration-tests/org/postRegistryOrgUsers.js
+++ b/test/integration-tests/org/postRegistryOrgUsers.js
@@ -9,16 +9,10 @@ const app = require('../../../src/index.js')
 describe('Testing user can be created by org with /registryOrg endpoint', () => {
   context('Positive Tests', () => {
     it('Allows creation of user by org', async () => {
-    // Create a new org
-      await chai.request(app)
-        .post('/api/registryOrg')
-        .set(constants.headers)
-        .send({ long_name: 'Test Registry Create Org', short_name: 'testOrg' })
-
       const payload = {
-        user_id: 'fakeregistryuser999',
+        user_id: 'testUser',
         name: {
-          first: 'TestFirstName',
+          first: 'TestFirst',
           last: 'FakeLastName',
           middle: 'Cool',
           suffix: 'Mr.'
@@ -31,7 +25,7 @@ describe('Testing user can be created by org with /registryOrg endpoint', () => 
       // Create a new user by org
       const res = await chai
         .request(app)
-        .post('/api/registryOrg/testOrg/user')
+        .post('/api/registryOrg/win_5/user')
         .set(constants.headers)
         .send(payload)
 
@@ -73,7 +67,7 @@ describe('Testing user can be created by org with /registryOrg endpoint', () => 
       }
       await chai
         .request(app)
-        .post('/api/registryOrg/testOrg/user')
+        .post('/api/registryOrg/win_5/user')
         .set(constants.nonSecretariatUserHeaders)
         .send(payload)
         .then((res, err) => {
@@ -97,7 +91,7 @@ describe('Testing user can be created by org with /registryOrg endpoint', () => 
       }
       await chai
         .request(app)
-        .post('/api/registryOrg/testOrg/user')
+        .post('/api/registryOrg/win_5/user')
         .set(constants.headers)
         .send(payload)
         .then((res, err) => {

--- a/test/integration-tests/org/postRegistryOrgUsers.js
+++ b/test/integration-tests/org/postRegistryOrgUsers.js
@@ -2,7 +2,6 @@
 const chai = require('chai')
 chai.use(require('chai-http'))
 const expect = chai.expect
-const _ = require('lodash')
 
 const constants = require('../constants.js')
 const app = require('../../../src/index.js')

--- a/test/integration-tests/org/postRegistryOrgUsers.js
+++ b/test/integration-tests/org/postRegistryOrgUsers.js
@@ -1,0 +1,110 @@
+/* eslint-disable no-unused-expressions */
+const chai = require('chai')
+chai.use(require('chai-http'))
+const expect = chai.expect
+const _ = require('lodash')
+
+const constants = require('../constants.js')
+const app = require('../../../src/index.js')
+
+describe('Testing user can be created by org with /registryOrg endpoint', () => {
+  context('Positive Tests', () => {
+    it('Allows creation of user by org', async () => {
+    // Create a new org
+      await chai.request(app)
+        .post('/api/registryOrg')
+        .set(constants.headers)
+        .send({ long_name: 'Test Registry Create Org', short_name: 'testOrg' })
+
+      const payload = {
+        user_id: 'fakeregistryuser999',
+        name: {
+          first: 'TestFirstName',
+          last: 'FakeLastName',
+          middle: 'Cool',
+          suffix: 'Mr.'
+        },
+        authority: {
+          active_roles: ['CNA']
+        }
+      }
+
+      // Create a new user by org
+      const res = await chai
+        .request(app)
+        .post('/api/registryOrg/testOrg/user')
+        .set(constants.headers)
+        .send(payload)
+
+      expect(res).to.have.status(200)
+      expect(res.body).to.have.property('message', `${payload.user_id} was successfully created.`)
+      expect(res.body).to.have.property('created').that.is.an('object')
+
+      const created = res.body.created
+      expect(created).to.include({
+        user_id: payload.user_id
+      })
+      expect(created.name).to.deep.include({
+        first: payload.name.first,
+        last: payload.name.last,
+        middle: payload.name.middle,
+        suffix: payload.name.suffix
+      })
+
+      expect(created).to.have.property('UUID').that.is.a('string')
+      expect(created).to.have.property('last_active', null)
+      expect(created).to.have.property('deactivation_date', null)
+      expect(created).to.have.property('org_affiliations')
+      expect(created.org_affiliations[0]).to.have.nested.property('org_id')
+    })
+  })
+  context('Negative Tests', () => {
+    it('Fails creation of user for nonSecretariat role', async () => {
+      const payload = {
+        user_id: 'fakeregistryuser999',
+        name: {
+          first: 'TestFirstName',
+          last: 'FakeLastName',
+          middle: 'Cool',
+          suffix: 'Mr.'
+        },
+        authority: {
+          active_roles: ['CNA']
+        }
+      }
+      await chai
+        .request(app)
+        .post('/api/registryOrg/testOrg/user')
+        .set(constants.nonSecretariatUserHeaders)
+        .send(payload)
+        .then((res, err) => {
+          expect(res).to.have.status(403)
+          expect(res.body.error).to.equal('SECRETARIAT_ONLY')
+        // expect(res.body.error).to.equal('NOT_ORG_ADMIN_OR_SECRETARIAT') // Will be this error when validation is fixed
+        })
+    })
+    it('Fails creation of user if they exist', async () => {
+      const payload = {
+        user_id: 'fakeregistryuser999',
+        name: {
+          first: 'TestFirstName',
+          last: 'FakeLastName',
+          middle: 'Cool',
+          suffix: 'Mr.'
+        },
+        authority: {
+          active_roles: ['CNA']
+        }
+      }
+      await chai
+        .request(app)
+        .post('/api/registryOrg/testOrg/user')
+        .set(constants.headers)
+        .send(payload)
+        .then((res, err) => {
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.equal('USER_EXISTS')
+        })
+    })
+  })
+})


### PR DESCRIPTION
Closes Issue 1400

# Summary
- implements the createUserByOrg endpoint for the /api/registryOrg api 
- includes an integration test
# Testing

- run 'npm run test:integration'

# Notes
- Needs more validation but seems better to wait for schema validation to be implemented than to repeat efforts
- need to debug why `cve-services/src/controller/registry-org.controller/index.js` Line 540 mw.onlySecretariatOrAdmin(true) is causing an error. Right now this endpoint is secretariatOnly but should allow for admins too
- Endpoint does not create an org if it does not exist 
