### PR TITLE
Resolves issue #1406 - fixed error handling when UUID provided for registry org/user creation

### DIFF
--- a/src/controller/registry-org.controller/registry-org.controller.js
+++ b/src/controller/registry-org.controller/registry-org.controller.js
@@ -92,8 +92,14 @@ async function createOrg (req, res, next) {
     const registryOrgRepo = req.ctx.repositories.getRegistryOrgRepository()
     const body = req.ctx.body
 
+    // Short circuit if UUID provided
+    const bodyKeys = Object.keys(body).map(k => k.toLowerCase())
+    if (bodyKeys.includes('uuid')) {
+      return res.status(400).json(error.uuidProvided('org'))
+    }
+
     const newOrg = new RegistryOrg()
-    Object.keys(body).map(k => k.toLowerCase()).forEach(k => {
+    bodyKeys.forEach(k => {
       if (k === 'long_name') {
         newOrg.long_name = body[k]
       } else if (k === 'short_name') {
@@ -136,8 +142,6 @@ async function createOrg (req, res, next) {
           website: '',
           ...contactInfo
         }
-      } else if (k === 'uuid') {
-        return res.status(400).json(error.uuidProvided('org'))
       }
     })
 

--- a/src/controller/registry-user.controller/registry-user.controller.js
+++ b/src/controller/registry-user.controller/registry-user.controller.js
@@ -71,6 +71,12 @@ async function createUser (req, res, next) {
     const registryUserRepo = req.ctx.repositories.getRegistryUserRepository()
     const body = req.ctx.body
 
+    // Short circuit if UUID provided
+    const bodyKeys = Object.keys(body).map((k) => k.toLowerCase())
+    if (bodyKeys.includes('uuid')) {
+      return res.status(400).json(error.uuidProvided('user'))
+    }
+
     // TODO: check if affiliated orgs and program orgs exist, and if their membership limit is reached
 
     const newUser = new RegistryUser()
@@ -89,8 +95,6 @@ async function createUser (req, res, next) {
         // TODO: dedupe
       } else if (k === 'cve_program_org_membership') {
         // TODO: dedupe
-      } else if (k === 'uuid') {
-        return res.status(400).json(error.uuidProvided('user'))
       }
     })
 


### PR DESCRIPTION
Closes Issue #1406

# Summary
Errors returned when a UUID is provided as part of the post body for creating a registry org or user were allowing the function to continue executing since they were within a `forEach` block. Fixed this to check for UUID before the `forEach` and short circuit if found.

# Important Changes
`src/controller/registry-org.controller/registry-org.controller.js`, `src/controller/registry-user.controller/registry-user.controller.js`
- Moved check for UUID key outside of and before `forEach` block in order to short circuit.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Calling the create registry org or registry user endpoints should return the appropriate error and not allow the rest of the function to execute.
