### PR TITLE
Resolves issue #1499 - fix GET /org unit tests

### DIFF
--- a/test/unit-tests/org/orgGetAllTest.js
+++ b/test/unit-tests/org/orgGetAllTest.js
@@ -1,7 +1,9 @@
 const express = require('express')
 const app = express()
 const chai = require('chai')
+const sinon = require('sinon')
 const expect = chai.expect
+const mongoose = require('mongoose')
 chai.use(require('chai-http'))
 
 // Body Parser Middleware
@@ -14,33 +16,35 @@ const orgFixtures = require('./mockObjects.org')
 const orgController = require('../../../src/controller/org.controller/org.controller')
 const orgParams = require('../../../src/controller/org.controller/org.middleware')
 
-describe.skip('Testing the GET /org endpoint in Org Controller', () => {
+describe('Testing the GET /org endpoint in Org Controller', () => {
+  let mockSession
+  beforeEach(() => {
+    // Stub Mongoose session methods
+    mockSession = {
+      startTransaction: sinon.stub(),
+      commitTransaction: sinon.stub().resolves(),
+      abortTransaction: sinon.stub().resolves(),
+      endSession: sinon.stub().resolves()
+    }
+    sinon.stub(mongoose, 'startSession').resolves(mockSession)
+  })
+  afterEach(() => {
+    sinon.restore()
+  })
   context('Positive Tests', () => {
     it('Page query param not provided: should list non-paginated orgs because orgs fit in one page', async () => {
-      const itemsPerPage = 500
-
       class GetAllOrgs {
-        async aggregatePaginate () {
-          const res = {
-            itemsList: orgFixtures.allOrgs,
-            itemCount: orgFixtures.allOrgs.length,
-            itemsPerPage: itemsPerPage,
-            currentPage: 1,
-            pageCount: 1,
-            pagingCounter: 1,
-            hasPrevPage: false,
-            hasNextPage: false,
-            prevPage: null,
-            nextPage: null
+        async getAllOrgs () {
+          return {
+            organizations: orgFixtures.allOrgs
           }
-          return res
         }
       }
 
       app.route('/org-all-cnas-non-paginated')
         .get((req, res, next) => {
           const factory = {
-            getOrgRepository: () => { return new GetAllOrgs() }
+            getBaseOrgRepository: () => { return new GetAllOrgs() }
           }
           req.ctx.repositories = factory
           next()
@@ -66,10 +70,10 @@ describe.skip('Testing the GET /org endpoint in Org Controller', () => {
       const itemsPerPage = 5
 
       class GetAllOrgs {
-        async aggregatePaginate () {
+        async getAllOrgs () {
           const res = {
-            itemsList: [orgFixtures.allOrgs[0], orgFixtures.allOrgs[1], orgFixtures.allOrgs[3], orgFixtures.allOrgs[3], orgFixtures.allOrgs[4]],
-            itemCount: orgFixtures.allOrgs.length,
+            organizations: [orgFixtures.allOrgs[0], orgFixtures.allOrgs[1], orgFixtures.allOrgs[3], orgFixtures.allOrgs[3], orgFixtures.allOrgs[4]],
+            totalCount: orgFixtures.allOrgs.length,
             itemsPerPage: itemsPerPage,
             currentPage: 1,
             pageCount: 2,
@@ -86,10 +90,10 @@ describe.skip('Testing the GET /org endpoint in Org Controller', () => {
       app.route('/org-all-cnas-paginated')
         .get((req, res, next) => {
           const factory = {
-            getOrgRepository: () => { return new GetAllOrgs() }
+            getBaseOrgRepository: () => { return new GetAllOrgs() }
           }
           req.ctx.repositories = factory
-          // temporary fix for #920: force pagnation
+          // temporary fix for #920: force pagination
           req.TEST_PAGINATOR_LIMIT = itemsPerPage
           next()
         }, orgParams.parseGetParams, orgController.ORG_ALL)
@@ -114,10 +118,10 @@ describe.skip('Testing the GET /org endpoint in Org Controller', () => {
       const itemsPerPage = 5
 
       class GetAllOrgs {
-        async aggregatePaginate () {
+        async getAllOrgs () {
           const res = {
-            itemsList: [orgFixtures.allOrgs[5], orgFixtures.allOrgs[6], orgFixtures.allOrgs[7], orgFixtures.allOrgs[8]],
-            itemCount: orgFixtures.allOrgs.length,
+            organizations: [orgFixtures.allOrgs[5], orgFixtures.allOrgs[6], orgFixtures.allOrgs[7], orgFixtures.allOrgs[8]],
+            totalCount: orgFixtures.allOrgs.length,
             itemsPerPage: itemsPerPage,
             currentPage: 2,
             pageCount: 2,
@@ -134,7 +138,7 @@ describe.skip('Testing the GET /org endpoint in Org Controller', () => {
       app.route('/org-all-cnas-paginated-2')
         .get((req, res, next) => {
           const factory = {
-            getOrgRepository: () => { return new GetAllOrgs() }
+            getBaseOrgRepository: () => { return new GetAllOrgs() }
           }
           req.ctx.repositories = factory
           // temporary fix for #920: force pagnation
@@ -159,21 +163,10 @@ describe.skip('Testing the GET /org endpoint in Org Controller', () => {
     })
 
     it('Page query param provided: should return an empty list because no org exists', async () => {
-      const itemsPerPage = 5
-
       class GetAllOrgs {
-        async aggregatePaginate () {
+        async getAllOrgs () {
           const res = {
-            itemsList: [],
-            itemCount: 0,
-            itemsPerPage: itemsPerPage,
-            currentPage: 1,
-            pageCount: 1,
-            pagingCounter: 1,
-            hasPrevPage: false,
-            hasNextPage: false,
-            prevPage: null,
-            nextPage: null
+            organizations: []
           }
           return res
         }
@@ -182,7 +175,7 @@ describe.skip('Testing the GET /org endpoint in Org Controller', () => {
       app.route('/org-all-cnas-empty')
         .get((req, res, next) => {
           const factory = {
-            getOrgRepository: () => { return new GetAllOrgs() }
+            getBaseOrgRepository: () => { return new GetAllOrgs() }
           }
           req.ctx.repositories = factory
           next()


### PR DESCRIPTION
Closes Issue #1499

# Summary
Fixes unit tests for the GET /org endpoint

# Important Changes
`test/unit-tests/org/orgGetAllTest.js`
- Mock mongoose session methods
- Mock BaseOrgRepository `getAllOrgs()` method
- Adjust mocked return object to properly match fields

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Unit tests for getAllOrgs should pass.
