### PR TITLE
Resolves issue 1531, 1532, 1533, creating Audit Collection

### DIFF
--- a/src/controller/audit.controller/audit.controller.js
+++ b/src/controller/audit.controller/audit.controller.js
@@ -1,0 +1,402 @@
+const mongoose = require('mongoose')
+const logger = require('../../middleware/logger')
+const errors = require('./error')
+const error = new errors.AuditControllerError()
+const validateUUID = require('uuid').validate
+
+/**
+ * Create a new audit document
+ * Called by POST /api/audit/org/
+ */
+async function createAuditDocument (req, res, next) {
+  try {
+    const session = await mongoose.startSession()
+    const repo = req.ctx.repositories.getAuditRepository()
+    const orgRepo = req.ctx.repositories.getBaseOrgRepository()
+    const body = req.ctx.body
+    let returnValue
+
+    if (body?.uuid ?? null) {
+      return res.status(400).json(error.uuidProvided('audit'))
+    }
+
+    if (!body.target_uuid) {
+      logger.info({ uuid: req.ctx.uuid, message: 'Missing required field: target_uuid' })
+      return res.status(400).json(error.missingRequiredField('target_uuid'))
+    }
+
+    if (!validateUUID(body.target_uuid)) {
+      logger.info({ uuid: req.ctx.uuid, message: 'Invalid target_uuid format' })
+      return res.status(400).json(error.invalidUUID('target_uuid'))
+    }
+
+    try {
+      session.startTransaction()
+
+      // Validate the audit document against the schema
+      const auditValidation = await repo.validateAudit(body, { session })
+      if (!auditValidation.isValid) {
+        logger.error({ uuid: req.ctx.uuid, message: 'Audit document validation FAILED' })
+        await session.abortTransaction()
+        return res.status(400).json(
+          error.invalidAuditObject()
+        )
+      }
+
+      // Check if audit document already exists
+      const exists = await repo.findOneByTargetUUID(body.target_uuid, { session })
+      if (exists) {
+        logger.info({ uuid: req.ctx.uuid, message: `Audit document was not created because one already exists for target_uuid: ${body.target_uuid}` })
+        await session.abortTransaction()
+        return res.status(400).json(error.auditExists(body.target_uuid))
+      }
+
+      // Validate initial history entries if provided
+      if (body.history && body.history.length > 0) {
+        for (const entry of body.history) {
+          if (!entry.audit_object) {
+            logger.info({ uuid: req.ctx.uuid, message: 'Missing audit_object in history entry' })
+            await session.abortTransaction()
+            return res.status(400).json(error.missingRequiredField('audit_object'))
+          }
+          if (!entry.change_author) {
+            logger.info({ uuid: req.ctx.uuid, message: 'Missing change_author in history entry' })
+            await session.abortTransaction()
+            return res.status(400).json(error.missingRequiredField('change_author'))
+          }
+
+          // Specific for org audits: if the target_uuid matches an exisiting org, validate the audit object against the org schema
+          const targetOrg = await orgRepo.getOrg(body.target_uuid, true, { session })
+          if (targetOrg) {
+            // TODO: differentiate between legacy and registry orgs in order to perform correct validations
+            // const result = await orgRepo.validateOrg(entry.audit_object, { session })
+            // if (!result.isValid) {
+            //   logger.error({ uuid: req.ctx.uuid, message: 'Audit object validation failed', errors: result.errors })
+            //   await session.abortTransaction()
+            //   return res.status(400).json({
+            //     message: 'Invalid audit_object in history entry',
+            //     errors: result.errors
+            //   })
+            // }
+          // If other types of audits are added in the future, their validation would go here
+          } else {
+            logger.info({ uuid: req.ctx.uuid, message: `No organization found with UUID ${body.target_uuid} to validate audit_object against` })
+            await session.abortTransaction()
+            return res.status(404).json(error.orgDne(body.target_uuid))
+          }
+        }
+      }
+      returnValue = await repo.createAuditDocument(body, { session })
+      await session.commitTransaction()
+
+      logger.info({
+        uuid: req.ctx.uuid,
+        message: `Audit document created for target_uuid ${body.target_uuid}`,
+        audit_uuid: returnValue.uuid
+      })
+    } catch (err) {
+      await session.abortTransaction()
+      throw err
+    } finally {
+      await session.endSession()
+    }
+
+    return res.status(200).json({ message: 'Audit ' + returnValue.uuid + ' was successfully created.', created: returnValue })
+  } catch (err) {
+    next(err)
+  }
+}
+
+/**
+ * Append a new entry to the audit history (Secretariat only)
+ * Called by PUT /api/audit/org/
+ * Allows for multiple appends in a single request
+ */
+async function appendToAuditHistory (req, res, next) {
+  try {
+    const session = await mongoose.startSession()
+    const repo = req.ctx.repositories.getAuditRepository()
+    const orgRepo = req.ctx.repositories.getBaseOrgRepository()
+    const body = req.ctx.body
+    let returnValue
+
+    // Requiring target_uuid to validate audit_object easily.
+    // TODO: will need to query by uuid instead if target_uuid should be optional in the future
+    if (!body.target_uuid) {
+      logger.info({ uuid: req.ctx.uuid, message: 'Missing required field: target_uuid' })
+      return res.status(400).json(error.missingRequiredField('target_uuid'))
+    }
+
+    if (!validateUUID(body.target_uuid)) {
+      logger.info({ uuid: req.ctx.uuid, message: 'Invalid target_uuid format' })
+      return res.status(400).json(error.invalidUUID('target_uuid'))
+    }
+
+    try {
+      session.startTransaction()
+
+      // Validate the audit document against the schema
+      const auditValidation = await repo.validateAudit(body, { session })
+      if (!auditValidation.isValid) {
+        logger.error({ uuid: req.ctx.uuid, message: 'Audit document validation FAILED' })
+        await session.abortTransaction()
+        return res.status(400).json(
+          error.invalidAuditObject()
+        )
+      }
+
+      // Check if target org exists first
+      const targetOrg = await orgRepo.getOrg(body.target_uuid, true, { session })
+
+      // Process each history entry
+      for (const entry of body.history) {
+        if (!entry.audit_object) {
+          logger.info({ uuid: req.ctx.uuid, message: 'Missing audit_object in history entry' })
+          await session.abortTransaction()
+          return res.status(400).json(error.missingRequiredField('audit_object'))
+        }
+
+        // Specific for org audits: if the target_uuid matches an existing org, validate the audit object against the org schema
+        if (targetOrg) {
+        // TODO: differentiate between legacy and registry orgs in order to perform correct validations
+        //   const result = orgRepo.validateOrg(entry.audit_object, { session })
+        //   if (!result.isValid) {
+        //     logger.error({ uuid: req.ctx.uuid, message: 'Audit object validation failed', errors: result.errors })
+        //     await session.abortTransaction()
+        //     return res.status(400).json({
+        //       message: 'Invalid audit_object: does not match organization schema',
+        //       errors: result.errors
+        //     })
+        //   }
+        }
+
+        // Append this history entry
+        returnValue = await repo.appendToAuditHistory(
+          body.target_uuid,
+          entry.audit_object,
+          entry.change_author,
+          { session }
+        )
+
+        if (!returnValue) {
+          logger.info({ uuid: req.ctx.uuid, message: `No audit document found for target_uuid ${body.target_uuid}` })
+          await session.abortTransaction()
+          return res.status(404).json(error.auditDneByTarget(body.target_uuid))
+        }
+      }
+
+      await session.commitTransaction()
+
+      logger.info({
+        uuid: req.ctx.uuid,
+        message: `${body.history.length} audit entry(ies) appended for target_uuid ${body.target_uuid}`,
+        change_author: body.change_author
+      })
+    } catch (err) {
+      await session.abortTransaction()
+      throw err
+    } finally {
+      await session.endSession()
+    }
+
+    return res.status(200).json({
+      message: `${body.history.length} audit entry(ies) for ${body.target_uuid} was successfully appended.`,
+      updated: returnValue
+    })
+  } catch (err) {
+    next(err)
+  }
+}
+
+/**
+ * Get all audit documents
+ * Called by GET /api/audit/org/
+ */
+async function getAllAuditDocuments (req, res, next) {
+  try {
+    const session = await mongoose.startSession()
+    const repo = req.ctx.repositories.getAuditRepository()
+    let returnValue
+
+    try {
+      returnValue = await repo.findAllAuditDocuments({ session })
+    } finally {
+      await session.endSession()
+    }
+
+    logger.info({ uuid: req.ctx.uuid, message: 'All audit documents sent to user' })
+    return res.status(200).json(returnValue)
+  } catch (err) {
+    next(err)
+  }
+}
+
+/**
+ * Get audit document by its document UUID
+ * Called by GET /api/audit/org/document/:document_uuid
+ */
+async function getAuditByDocumentUUID (req, res, next) {
+  try {
+    const session = await mongoose.startSession()
+    const repo = req.ctx.repositories.getAuditRepository()
+    const documentUUID = req.ctx.params.document_uuid
+    let returnValue
+
+    if (!documentUUID) {
+      logger.info({ uuid: req.ctx.uuid, message: 'Missing audit uuid parameter' })
+      return res.status(400).json(error.missingRequiredField('document_uuid'))
+    }
+
+    if (!validateUUID(documentUUID)) {
+      logger.info({ uuid: req.ctx.uuid, message: 'Invalid document_uuid format' })
+      return res.status(400).json(error.invalidUUID('document_uuid'))
+    }
+
+    try {
+      returnValue = await repo.findOneByUUID(documentUUID, { session })
+
+      if (!returnValue) {
+        logger.info({ uuid: req.ctx.uuid, message: `No audit document found with UUID ${documentUUID}` })
+        return res.status(404).json(error.auditDneByDocument(documentUUID))
+      }
+    } finally {
+      await session.endSession()
+    }
+
+    logger.info({ uuid: req.ctx.uuid, message: `Audit document ${documentUUID} sent to user` })
+    return res.status(200).json(returnValue)
+  } catch (err) {
+    next(err)
+  }
+}
+/**
+ * Get audit history by target UUID
+ * Called by GET /api/audit/org/:target_uuid
+ * TODO: remove comment-> I changed parameter name from org_identifier to target_uuid to be more generic.
+ */
+async function getAuditByTargetUUID (req, res, next) {
+  try {
+    const session = await mongoose.startSession()
+    const repo = req.ctx.repositories.getAuditRepository()
+    const orgRepo = req.ctx.repositories.getBaseOrgRepository()
+    const targetUUID = req.ctx.params.target_uuid
+    let returnValue
+
+    if (!targetUUID) {
+      logger.info({ uuid: req.ctx.uuid, message: 'Missing target_uuid parameter' })
+      return res.status(400).json(error.missingRequiredField('target_uuid'))
+    }
+
+    if (!validateUUID(targetUUID)) {
+      logger.info({ uuid: req.ctx.uuid, message: 'Invalid target_uuid format' })
+      return res.status(400).json(error.invalidUUID('target_uuid'))
+    }
+
+    try {
+      session.startTransaction()
+
+      // Find the target organization
+      const targetOrg = await orgRepo.findOneByUUID(targetUUID, { session })
+      if (!targetOrg) {
+        logger.info({ uuid: req.ctx.uuid, message: `No organization found with UUID ${targetUUID}` })
+        await session.abortTransaction()
+        return res.status(404).json(error.orgDne(targetUUID))
+      }
+
+      // TODO: confirm middleware is checking admin and secretariat permissions properly
+
+      returnValue = await repo.findOneByTargetUUID(targetUUID, { session })
+
+      if (!returnValue) {
+        logger.info({ uuid: req.ctx.uuid, message: `No audit history found for target UUID ${targetUUID}` })
+        await session.abortTransaction()
+        return res.status(404).json(error.auditDneByTarget(targetUUID))
+      }
+
+      await session.commitTransaction()
+    } catch (err) {
+      await session.abortTransaction()
+      throw err
+    } finally {
+      await session.endSession()
+    }
+
+    logger.info({
+      uuid: req.ctx.uuid,
+      message: `Audit history for target UUID ${targetUUID} sent to user ${req.ctx.user}`
+    })
+    return res.status(200).json(returnValue)
+  } catch (err) {
+    next(err)
+  }
+}
+
+/**
+ * Get last X changes for an organization
+ * Called by GET /api/audit/org/:target_uuid/:number_of_changes
+ */
+async function getLastXChanges (req, res, next) {
+  try {
+    const session = await mongoose.startSession()
+    const repo = req.ctx.repositories.getAuditRepository()
+    const targetUUID = req.ctx.params.target_uuid
+    const numberOfChanges = parseInt(req.ctx.params.number_of_changes)
+    let returnValue
+
+    if (!targetUUID) {
+      logger.info({ uuid: req.ctx.uuid, message: 'Missing org_identifier parameter' })
+      return res.status(400).json(error.missingRequiredField('org_identifier'))
+    }
+
+    if (!validateUUID(targetUUID)) {
+      logger.info({ uuid: req.ctx.uuid, message: 'Invalid target_uuid format' })
+      return res.status(400).json(error.invalidUUID('target_uuid'))
+    }
+
+    if (isNaN(numberOfChanges) || numberOfChanges < 1) {
+      logger.info({ uuid: req.ctx.uuid, message: 'Invalid number_of_changes parameter' })
+      return res.status(400).json(error.invalidNumberOfChanges())
+    }
+
+    try {
+      session.startTransaction()
+
+      const lastChanges = await repo.getLastXChanges(targetUUID, numberOfChanges, { session })
+
+      if (!lastChanges || lastChanges.length === 0) {
+        logger.info({ uuid: req.ctx.uuid, message: `No audit history found for organization ${targetUUID}` })
+        await session.abortTransaction()
+        return res.status(404).json(error.auditDneByTarget(targetUUID))
+      }
+
+      returnValue = {
+        target_uuid: targetUUID,
+        changes: lastChanges
+      }
+
+      await session.commitTransaction()
+    } catch (err) {
+      await session.abortTransaction()
+      throw err
+    } finally {
+      await session.endSession()
+    }
+
+    logger.info({
+      uuid: req.ctx.uuid,
+      message: `Last ${numberOfChanges} changes for ${targetUUID} sent to user ${req.ctx.user}`
+    })
+    return res.status(200).json(returnValue)
+  } catch (err) {
+    next(err)
+  }
+}
+
+module.exports = {
+  AUDIT_CREATE_SINGLE: createAuditDocument,
+  AUDIT_UPDATE: appendToAuditHistory,
+  AUDIT_GET_ALL: getAllAuditDocuments,
+  AUDIT_GET_BY_UUID: getAuditByDocumentUUID,
+  AUDIT_GET_BY_TARGET_UUID: getAuditByTargetUUID,
+  AUDIT_GET_LAST: getLastXChanges
+}

--- a/src/controller/audit.controller/audit.controller.js
+++ b/src/controller/audit.controller/audit.controller.js
@@ -51,6 +51,14 @@ async function createAuditDocument (req, res, next) {
         return res.status(400).json(error.auditExists(body.target_uuid))
       }
 
+      // Check if target org exists first
+      const targetOrg = await orgRepo.getOrg(body.target_uuid, true, { session })
+      if (!targetOrg) {
+        logger.info({ uuid: req.ctx.uuid, message: `No organization found with UUID ${body.target_uuid}` })
+        await session.abortTransaction()
+        return res.status(404).json(error.orgDne(body.target_uuid))
+      }
+
       // Validate initial history entries if provided
       if (body.history && body.history.length > 0) {
         for (const entry of body.history) {
@@ -63,26 +71,6 @@ async function createAuditDocument (req, res, next) {
             logger.info({ uuid: req.ctx.uuid, message: 'Missing change_author in history entry' })
             await session.abortTransaction()
             return res.status(400).json(error.missingRequiredField('change_author'))
-          }
-
-          // Specific for org audits: if the target_uuid matches an exisiting org, validate the audit object against the org schema
-          const targetOrg = await orgRepo.getOrg(body.target_uuid, true, { session })
-          if (targetOrg) {
-            // TODO: differentiate between legacy and registry orgs in order to perform correct validations
-            // const result = await orgRepo.validateOrg(entry.audit_object, { session })
-            // if (!result.isValid) {
-            //   logger.error({ uuid: req.ctx.uuid, message: 'Audit object validation failed', errors: result.errors })
-            //   await session.abortTransaction()
-            //   return res.status(400).json({
-            //     message: 'Invalid audit_object in history entry',
-            //     errors: result.errors
-            //   })
-            // }
-          // If other types of audits are added in the future, their validation would go here
-          } else {
-            logger.info({ uuid: req.ctx.uuid, message: `No organization found with UUID ${body.target_uuid} to validate audit_object against` })
-            await session.abortTransaction()
-            return res.status(404).json(error.orgDne(body.target_uuid))
           }
         }
       }
@@ -147,27 +135,17 @@ async function appendToAuditHistory (req, res, next) {
 
       // Check if target org exists first
       const targetOrg = await orgRepo.getOrg(body.target_uuid, true, { session })
-
+      if (!targetOrg) {
+        logger.info({ uuid: req.ctx.uuid, message: `No organization found with UUID ${body.target_uuid}` })
+        await session.abortTransaction()
+        return res.status(404).json(error.orgDne(body.target_uuid))
+      }
       // Process each history entry
       for (const entry of body.history) {
         if (!entry.audit_object) {
           logger.info({ uuid: req.ctx.uuid, message: 'Missing audit_object in history entry' })
           await session.abortTransaction()
           return res.status(400).json(error.missingRequiredField('audit_object'))
-        }
-
-        // Specific for org audits: if the target_uuid matches an existing org, validate the audit object against the org schema
-        if (targetOrg) {
-        // TODO: differentiate between legacy and registry orgs in order to perform correct validations
-        //   const result = orgRepo.validateOrg(entry.audit_object, { session })
-        //   if (!result.isValid) {
-        //     logger.error({ uuid: req.ctx.uuid, message: 'Audit object validation failed', errors: result.errors })
-        //     await session.abortTransaction()
-        //     return res.status(400).json({
-        //       message: 'Invalid audit_object: does not match organization schema',
-        //       errors: result.errors
-        //     })
-        //   }
         }
 
         // Append this history entry

--- a/src/controller/audit.controller/audit.middleware.js
+++ b/src/controller/audit.controller/audit.middleware.js
@@ -1,0 +1,24 @@
+const utils = require('../../utils/utils')
+
+/**
+ * Parse POST/PUT parameters and map to req.ctx
+ */
+function parsePostParams (req, res, next) {
+  utils.reqCtxMapping(req, 'body', [])
+  utils.reqCtxMapping(req, 'params', ['document_uuid', 'target_uuid', 'org_identifier', 'number_of_changes'])
+  next()
+}
+
+/**
+ * Parse GET parameters and map to req.ctx
+ */
+function parseGetParams (req, res, next) {
+  utils.reqCtxMapping(req, 'params', ['document_uuid', 'target_uuid', 'org_identifier', 'number_of_changes'])
+  utils.reqCtxMapping(req, 'query', ['page'])
+  next()
+}
+
+module.exports = {
+  parsePostParams,
+  parseGetParams
+}

--- a/src/controller/audit.controller/error.js
+++ b/src/controller/audit.controller/error.js
@@ -1,0 +1,77 @@
+const idrErr = require('../../utils/error')
+
+class AuditControllerError extends idrErr.IDRError {
+  auditDneByTarget (targetUUID) {
+    const err = {}
+    err.error = 'AUDIT_DNE_TARGET'
+    err.message = `No audit history found for target UUID '${targetUUID}'.`
+    return err
+  }
+
+  auditDneByDocument (documentUUID) {
+    const err = {}
+    err.error = 'AUDIT_DNE_DOCUMENT'
+    err.message = `No audit document found with UUID '${documentUUID}'.`
+    return err
+  }
+
+  orgDne (identifier) {
+    const err = {}
+    err.error = 'ORG_DNE'
+    err.message = `No organization found with identifier '${identifier}'.`
+    return err
+  }
+
+  auditExists (targetUUID) {
+    const err = {}
+    err.error = 'AUDIT_EXISTS'
+    err.message = `Audit document already exists for target UUID '${targetUUID}'.`
+    return err
+  }
+
+  invalidAuditObject () {
+    const err = {}
+    err.error = 'INVALID_AUDIT_OBJECT'
+    err.message = 'The audit_object does not match the organization schema.'
+    return err
+  }
+
+  invalidUUID (fieldName) {
+    const err = {}
+    err.error = 'INVALID_UUID'
+    err.message = `The '${fieldName}' field contains an invalid UUID format.`
+    return err
+  }
+
+  missingRequiredField (fieldName) {
+    const err = {}
+    err.error = 'MISSING_REQUIRED_FIELD'
+    err.message = `Missing required field: '${fieldName}'.`
+    return err
+  }
+
+  invalidNumberOfChanges () {
+    const err = {}
+    err.error = 'INVALID_NUMBER_OF_CHANGES'
+    err.message = 'The number_of_changes parameter must be a positive integer.'
+    return err
+  }
+
+  notAuthorized () {
+    const err = {}
+    err.error = 'NOT_AUTHORIZED'
+    err.message = 'You do not have permission to view this audit history.'
+    return err
+  }
+
+  uuidProvided (creationType) {
+    const err = {}
+    err.error = 'UUID_PROVIDED'
+    err.message = `Providing UUIDs for ${creationType} creation or update is not allowed.`
+    return err
+  }
+}
+
+module.exports = {
+  AuditControllerError
+}

--- a/src/controller/audit.controller/index.js
+++ b/src/controller/audit.controller/index.js
@@ -1,0 +1,53 @@
+const router = require('express').Router()
+const controller = require('./audit.controller')
+const mw = require('../../middleware/middleware')
+const auditMw = require('./audit.middleware')
+
+// Create new audit document (Secretariat only)
+router.post('/audit/org/',
+  mw.validateUser,
+  mw.onlySecretariat,
+  auditMw.parsePostParams,
+  controller.AUDIT_CREATE_SINGLE
+)
+// Get all audit documents (Secretariat only)
+router.get('/audit/org/',
+  mw.validateUser,
+  mw.onlySecretariat,
+  auditMw.parseGetParams,
+  controller.AUDIT_GET_ALL
+)
+
+// Get audit by document UUID (Secretariat only)
+router.get('/audit/org/document/:document_uuid',
+  mw.validateUser,
+  mw.onlySecretariat,
+  auditMw.parseGetParams,
+  controller.AUDIT_GET_BY_UUID
+)
+
+// Get audit by org identifier (Secretariat or Admin)
+router.get('/audit/org/:target_uuid',
+  mw.validateUser,
+  mw.onlySecretariatOrAdmin,
+  auditMw.parseGetParams,
+  controller.AUDIT_GET_BY_TARGET_UUID
+)
+
+// Get last X changes (Secretariat or Org Admin)
+router.get('/audit/org/:target_uuid/:number_of_changes',
+  mw.onlySecretariatOrAdmin,
+  mw.validateUser,
+  auditMw.parseGetParams,
+  controller.AUDIT_GET_LAST
+)
+
+// Push update to audit colleciton history (Secretariat only)
+router.put('/audit/org/',
+  mw.validateUser,
+  mw.onlySecretariat,
+  auditMw.parsePostParams,
+  controller.AUDIT_UPDATE
+)
+
+module.exports = router

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -247,24 +247,10 @@ async function registryCreateOrg (req, res, next) {
       }
 
       // If we get here, we know we are good to create
-      returnValue = await repo.createOrg(req.ctx.body, { session, upsert: true })
+      const userRepo = req.ctx.repositories.getBaseUserRepository()
+      const requestingUserUUID = await userRepo.getUserUUID(req.ctx.user, req.ctx.org, { session })
+      returnValue = await repo.createOrg(req.ctx.body, { session, upsert: true }, false, requestingUserUUID)
 
-      // ADD AUDIT ENTRY AUTOMATICALLY. At this point permissions and object validation have been done.
-      try {
-        const userRepo = req.ctx.repositories.getBaseUserRepository()
-        const auditRepo = req.ctx.repositories.getAuditRepository()
-        const changeAuthorUUID = await userRepo.getUserUUID(req.ctx.user, req.ctx.org, { session })
-        await auditRepo.appendToAuditHistory(
-          returnValue.UUID,
-          returnValue,
-          changeAuthorUUID,
-          { session }
-        )
-        logger.info({ uuid: req.ctx.uuid, message: `Audit entry created for new org ${returnValue.short_name}` })
-      } catch (auditError) {
-        logger.error({ uuid: req.ctx.uuid, message: 'Failed to create audit entry', error: auditError })
-        // Don't fail the transaction if audit fails - just log it
-      }
       await session.commitTransaction()
       logger.info({
         action: 'create_org',
@@ -308,23 +294,6 @@ async function createOrg (req, res, next) {
         return res.status(400).json(error.orgExists(body?.short_name))
       }
       returnValue = await repo.createOrg(req.ctx.body, { session, upsert: true }, true)
-
-      // ADD AUDIT ENTRY AUTOMATICALLY. At this point permissions and object validation have been done.
-      try {
-        const userRepo = req.ctx.repositories.getBaseUserRepository()
-        const auditRepo = req.ctx.repositories.getAuditRepository()
-        const changeAuthorUUID = await userRepo.getUserUUID(req.ctx.user, req.ctx.org, { session })
-        await auditRepo.appendToAuditHistory(
-          returnValue.UUID,
-          returnValue,
-          changeAuthorUUID,
-          { session }
-        )
-        logger.info({ uuid: req.ctx.uuid, message: `Audit entry created for new org ${returnValue.short_name}` })
-      } catch (auditError) {
-        logger.error({ uuid: req.ctx.uuid, message: 'Failed to create audit entry', error: auditError })
-        // Don't fail the transaction if audit fails - just log it
-      }
 
       await session.commitTransaction()
     } catch (error) {
@@ -395,9 +364,10 @@ async function registryUpdateOrg (req, res, next) {
         return res.status(403).json(error.duplicateShortname(queryParametersJson.new_short_name))
       }
 
-      const updatedOrg = await orgRepository.updateOrg(shortNameUrlParameter, queryParametersJson, { session })
+      const userRepo = req.ctx.repositories.getBaseUserRepository()
+      const requestingUserUUID = await userRepo.getUserUUID(req.ctx.user, req.ctx.org, { session })
+      const updatedOrg = await orgRepository.updateOrg(shortNameUrlParameter, queryParametersJson, { session }, false, requestingUserUUID)
 
-      const userRepo = req.ctx.repositories.getUserRepository()
       responseMessage = { message: `${updatedOrg.short_name} organization was successfully updated.`, updated: updatedOrg } // Clarify message
       const payload = { action: 'update_org', change: `${updatedOrg.short_name} organization was successfully updated.`, org: updatedOrg }
       payload.user_UUID = await userRepo.getUserUUID(req.ctx.user, updatedOrg.UUID, { session })

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -248,6 +248,23 @@ async function registryCreateOrg (req, res, next) {
 
       // If we get here, we know we are good to create
       returnValue = await repo.createOrg(req.ctx.body, { session, upsert: true })
+
+      // ADD AUDIT ENTRY AUTOMATICALLY. At this point permissions and object validation have been done.
+      try {
+        const userRepo = req.ctx.repositories.getBaseUserRepository()
+        const auditRepo = req.ctx.repositories.getAuditRepository()
+        const changeAuthorUUID = await userRepo.getUserUUID(req.ctx.user, req.ctx.org, { session })
+        await auditRepo.appendToAuditHistory(
+          returnValue.UUID,
+          returnValue,
+          changeAuthorUUID,
+          { session }
+        )
+        logger.info({ uuid: req.ctx.uuid, message: `Audit entry created for new org ${returnValue.short_name}` })
+      } catch (auditError) {
+        logger.error({ uuid: req.ctx.uuid, message: 'Failed to create audit entry', error: auditError })
+        // Don't fail the transaction if audit fails - just log it
+      }
       await session.commitTransaction()
       logger.info({
         action: 'create_org',
@@ -291,6 +308,23 @@ async function createOrg (req, res, next) {
         return res.status(400).json(error.orgExists(body?.short_name))
       }
       returnValue = await repo.createOrg(req.ctx.body, { session, upsert: true }, true)
+
+      // ADD AUDIT ENTRY AUTOMATICALLY. At this point permissions and object validation have been done.
+      try {
+        const userRepo = req.ctx.repositories.getBaseUserRepository()
+        const auditRepo = req.ctx.repositories.getAuditRepository()
+        const changeAuthorUUID = await userRepo.getUserUUID(req.ctx.user, req.ctx.org, { session })
+        await auditRepo.appendToAuditHistory(
+          returnValue.UUID,
+          returnValue,
+          changeAuthorUUID,
+          { session }
+        )
+        logger.info({ uuid: req.ctx.uuid, message: `Audit entry created for new org ${returnValue.short_name}` })
+      } catch (auditError) {
+        logger.error({ uuid: req.ctx.uuid, message: 'Failed to create audit entry', error: auditError })
+        // Don't fail the transaction if audit fails - just log it
+      }
 
       await session.commitTransaction()
     } catch (error) {

--- a/src/middleware/schemas/Audit.json
+++ b/src/middleware/schemas/Audit.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "/Audit",
+  "type": "object",
+  "title": "CVE Audit Document",
+  "description": "Schema for CVE Organization Audit Collection Document",
+  "definitions": {
+    "uuidType": {
+      "description": "A version 4 (random) universally unique identifier (UUID) as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122#section-4.1.3).",
+      "type": "string",
+      "format": "uuid",
+      "pattern": "^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$"
+    },
+    "timestamp": {
+      "type": "string",
+      "description": "Date/time format based on RFC3339 and ISO ISO8601, with an optional timezone in the format 'yyyy-MM-ddTHH:mm:ss[+-]ZH:ZM'. If timezone offset is not given, GMT (+00:00) is assumed.",
+      "pattern": "^(((2000|2400|2800|(19|2[0-9](0[48]|[2468][048]|[13579][26])))-02-29)|(((19|2[0-9])[0-9]{2})-02-(0[1-9]|1[0-9]|2[0-8]))|(((19|2[0-9])[0-9]{2})-(0[13578]|10|12)-(0[1-9]|[12][0-9]|3[01]))|(((19|2[0-9])[0-9]{2})-(0[469]|11)-(0[1-9]|[12][0-9]|30)))T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})?$"
+    },
+    "historyEntry": {
+      "type": "object",
+      "description": "A single audit history entry recording a change to an organization",
+      "properties": {
+        "timestamp": {
+          "$ref": "#/definitions/timestamp"
+        },
+        "audit_object": {
+          "type": "object",
+          "description": "Complete snapshot of the organization object after the change"
+        },
+        "change_author": {
+          "$ref": "#/definitions/uuidType",
+          "description": "UUID of the user who made the change"
+        }
+      },
+      "required": [
+        "audit_object",
+        "change_author"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "uuid": {
+      "$ref": "#/definitions/uuidType",
+      "description": "UUID of the audit document itself"
+    },
+    "target_uuid": {
+      "$ref": "#/definitions/uuidType",
+      "description": "UUID of the organization being audited"
+    },
+    "history": {
+      "type": "array",
+      "description": "Array of audit history entries, ordered chronologically",
+      "items": {
+        "$ref": "#/definitions/historyEntry"
+      },
+      "default": []
+    }
+  },
+  "required": [
+    "target_uuid"
+  ],
+  "additionalProperties": false
+}

--- a/src/model/audit.js
+++ b/src/model/audit.js
@@ -1,0 +1,47 @@
+const mongoose = require('mongoose')
+const fs = require('fs')
+const aggregatePaginate = require('mongoose-aggregate-paginate-v2')
+const MongoPaging = require('mongo-cursor-pagination')
+const Ajv = require('ajv')
+const addFormats = require('ajv-formats')
+const AuditSchemaJSON = JSON.parse(fs.readFileSync('src/middleware/schemas/Audit.json'))
+
+// Initialize AJV
+const ajv = new Ajv({ allErrors: true })
+addFormats(ajv)
+
+// Compile validation function
+const validate = ajv.compile(AuditSchemaJSON)
+
+const schema = {
+  uuid: { type: String, index: true },
+  target_uuid: { type: String, required: true },
+  history: [{
+    timestamp: { type: Date, default: Date.now },
+    audit_object: { type: mongoose.Schema.Types.Mixed, required: true },
+    change_author: { type: String, required: true }
+  }]
+}
+
+// Create Mongoose Schema
+const AuditSchema = new mongoose.Schema(schema, {
+  collection: 'Audit',
+  timestamps: { createdAt: 'created', updatedAt: 'last_updated' }
+})
+
+AuditSchema.statics.validateAudit = function (record) {
+  const validateObject = {}
+  validateObject.isValid = validate(record)
+
+  if (!validateObject.isValid) {
+    validateObject.errors = validate.errors
+  }
+  return validateObject
+}
+
+AuditSchema.plugin(aggregatePaginate)
+AuditSchema.plugin(MongoPaging.mongoosePlugin)
+
+// Create and export model
+const Audit = mongoose.model('Audit', AuditSchema)
+module.exports = Audit

--- a/src/repositories/auditRepository.js
+++ b/src/repositories/auditRepository.js
@@ -1,0 +1,119 @@
+const Audit = require('../model/audit')
+const BaseRepository = require('./baseRepository')
+const uuid = require('uuid')
+
+class AuditRepository extends BaseRepository {
+  constructor () {
+    super(Audit)
+  }
+
+  validateAudit (audit) {
+    let validateObject = {}
+    validateObject = Audit.validateAudit(audit)
+    return validateObject
+  }
+
+  /**
+   * Create a new audit document
+   */
+  async createAuditDocument (data, options = {}) {
+    const auditData = {
+      uuid: uuid.v4(),
+      target_uuid: data.target_uuid,
+      history: data.history || []
+    }
+
+    const audit = new Audit(auditData)
+    const result = await audit.save(options)
+    return result.toObject()
+  }
+
+  /**
+   * Append a new entry to the audit history
+   * Creates document if it doesn't exist
+   */
+  async appendToAuditHistory (targetUUID, auditObject, changeAuthor, options = {}) {
+    const historyEntry = {
+      timestamp: new Date(),
+      audit_object: auditObject,
+      change_author: changeAuthor
+    }
+
+    // Try to find existing document
+    let audit = await Audit.findOne({ target_uuid: targetUUID })
+
+    if (!audit) {
+      // Create new document if doesn't exist
+      audit = new Audit({
+        uuid: uuid.v4(),
+        target_uuid: targetUUID,
+        history: [historyEntry]
+      })
+    } else {
+      // Append to existing history
+      audit.history.push(historyEntry)
+    }
+
+    const result = await audit.save(options)
+    return result.toObject()
+  }
+
+  /**
+   * Find audit document by target UUID
+   */
+  async findOneByTargetUUID (targetUUID, options = {}) {
+    const query = { target_uuid: targetUUID }
+    return this.collection.findOne(query, null, options)
+  }
+
+  /**
+   * Find audit document by its own UUID
+   */
+  async findOneByUUID (auditUUID, options = {}) {
+    const query = { uuid: auditUUID }
+    return this.collection.findOne(query, null, options)
+  }
+
+  /**
+   * Find all audit documents
+   */
+  async findAllAuditDocuments (options = {}) {
+    const audits = await Audit.find({}, null, options)
+    return audits.map(audit => audit.toObject())
+  }
+
+  /**
+   * Get the last X changes for a target UUID
+   */
+  async getLastXChanges (targetUUID, numberOfChanges, options = {}) {
+    const audit = await Audit.findOne({ target_uuid: targetUUID }, null, options)
+    if (!audit || !audit.history || audit.history.length === 0) {
+      return []
+    }
+
+    // Sort by timestamp descending and take the last X entries
+    const sortedHistory = audit.history
+      .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
+      .slice(0, numberOfChanges)
+
+    return sortedHistory
+  }
+
+  /**
+   * Delete audit document by UUID
+   */
+  async deleteByUUID (auditUUID, options = {}) {
+    const result = await Audit.deleteOne({ uuid: auditUUID }, options)
+    return result.deletedCount
+  }
+
+  /**
+   * Delete audit document by target UUID
+   */
+  async deleteByTargetUUID (targetUUID, options = {}) {
+    const result = await Audit.deleteOne({ target_uuid: targetUUID }, options)
+    return result.deletedCount
+  }
+}
+
+module.exports = AuditRepository

--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -8,6 +8,7 @@ const CveIdRepository = require('./cveIdRepository')
 const uuid = require('uuid')
 const _ = require('lodash')
 const BaseOrg = require('../model/baseorg')
+const AuditRepository = require('./auditRepository')
 const getConstants = require('../constants').getConstants
 
 function setAggregateOrgObj (query) {
@@ -161,11 +162,12 @@ class BaseOrgRepository extends BaseRepository {
  * @param {object} incomingOrg - The raw organization data object. Can be in either legacy or registry format, specified by the `isLegacyObject` flag.
  * @param {object} [options={}] - Optional settings passed to the legacy repository for database operations.
  * @param {boolean} [isLegacyObject=false] - If true, `incomingOrg` is treated as a legacy-formatted object. If false, it's treated as a registry-formatted object.
+ * @param {string|null} [requestingUserUUID=null] - The user UUID representing the requester, used for audit documentation. If null, no audit document is created.
  *
  * @returns {Promise<object>} A promise that resolves to a plain JavaScript object representing the newly created organization. The format of the returned object (legacy or registry) is determined by the `isLegacyObject` parameter. The object is stripped of internal properties and empty values.
  * @throws {string} Throws an error if the organization's authority role is not 'SECRETARIAT' or 'CNA'.
  */
-  async createOrg (incomingOrg, options = {}, isLegacyObject = false) {
+  async createOrg (incomingOrg, options = {}, isLegacyObject = false, requestingUserUUID = null) {
     const { deepRemoveEmpty } = require('../utils/utils')
     const OrgRepository = require('./orgRepository')
     const CONSTANTS = getConstants()
@@ -230,6 +232,21 @@ class BaseOrgRepository extends BaseRepository {
     } else {
       // eslint-disable-next-line no-throw-literal
       throw 'dave you screwed up'
+    }
+
+    // ADD AUDIT ENTRY AUTOMATICALLY for the registry object. At this point permissions and object validation have been done.
+    if (requestingUserUUID) {
+      try {
+        const auditRepo = new AuditRepository()
+        await auditRepo.appendToAuditHistory(
+          registryObjectRaw.UUID,
+          registryObjectRaw,
+          requestingUserUUID,
+          options
+        )
+      } catch (auditError) {
+      // Don't fail the transaction if audit fails - just log it
+      }
     }
 
     // Legacy Write, this will be removed when backwards compatibility is no longer needed.
@@ -302,10 +319,11 @@ class BaseOrgRepository extends BaseRepository {
  * @param {string} [incomingParameters.contact_info.website] - The organization's website URL. (Registry only)
  * @param {object} [options={}] - Optional settings for the repository query.
  * @param {boolean} [isLegacyObject=false] - If true, the function returns the updated legacy organization object. Otherwise, it returns the updated registry organization object.
+ * @param {string|null} [requestingUserUUID=null] - The user UUID representing the requester, used for audit documentation. If null, no audit document is created.
  *
  * @returns {Promise<object>} A promise that resolves to a plain JavaScript object representing the updated organization, stripped of internal properties and empty values.
  */
-  async updateOrg (shortName, incomingParameters, options = {}, isLegacyObject = false) {
+  async updateOrg (shortName, incomingParameters, options = {}, isLegacyObject = false, requestingUserUUID = null) {
     const { deepRemoveEmpty } = require('../utils/utils')
     const OrgRepository = require('./orgRepository')
     // If we get here, we know the org exists
@@ -362,6 +380,21 @@ class BaseOrgRepository extends BaseRepository {
       delete plainJavascriptLegacyOrg.__v
       delete plainJavascriptLegacyOrg._id
       return deepRemoveEmpty(plainJavascriptLegacyOrg)
+    }
+
+    // ADD AUDIT ENTRY AUTOMATICALLY for the registry object. At this point permissions and object validation have been done.
+    if (requestingUserUUID) {
+      try {
+        const auditRepo = new AuditRepository()
+        await auditRepo.appendToAuditHistory(
+          registryOrg.UUID,
+          registryOrg.toObject(),
+          requestingUserUUID,
+          options
+        )
+      } catch (auditError) {
+      // Don't fail the transaction if audit fails - just log it
+      }
     }
 
     const plainJavascriptRegistryOrg = registryOrg.toObject()

--- a/src/repositories/repositoryFactory.js
+++ b/src/repositories/repositoryFactory.js
@@ -53,6 +53,12 @@ class RepositoryFactory {
     const repo = new BaseUserRepository()
     return repo
   }
+
+  getAuditRepository () {
+    const AuditRepository = require('./auditRepository')
+    const repo = new AuditRepository()
+    return repo
+  }
 }
 
 module.exports = RepositoryFactory

--- a/src/routes.config.js
+++ b/src/routes.config.js
@@ -9,6 +9,7 @@ const SystemController = require('./controller/system.controller')
 const UserController = require('./controller/user.controller')
 const RegistryUserController = require('./controller/registry-user.controller')
 const RegistryOrgController = require('./controller/registry-org.controller')
+const AuditController = require('./controller/audit.controller')
 
 var options = {
   swaggerOptions: {
@@ -37,4 +38,5 @@ module.exports = async function configureRoutes (app) {
   app.get('/api-docs/openapi.json', (req, res) => res.json(openApiSpecification))
   app.use('/api-docs', swaggerUi.serveFiles(null, options), swaggerUi.setup(null, setupOptions))
   app.use('/schemas/', SchemasController)
+  app.use('/api/', AuditController)
 }

--- a/test/integration-tests/audit/auditTest.js
+++ b/test/integration-tests/audit/auditTest.js
@@ -315,12 +315,3 @@ describe('Testing Audit Org endpoints', () => {
     })
   })
 })
-
-// TODO:
-// Add tests for permission checks
-// Fix org validations
-//  - need to differentiate between legacy and registry orgs in order to perform correct validations
-// write integration tests for calling auditRepo create/update functions from org create/update endpoints
-// should AUDIT_UPDATE allow for multiple or single additions only
-//  - I used multiple additions in order to validate the audit object using the schema
-// fix parameters and user org short_name identifiers if we want to make things specific to orgs

--- a/test/integration-tests/audit/auditTest.js
+++ b/test/integration-tests/audit/auditTest.js
@@ -1,0 +1,326 @@
+/* eslint-disable no-unused-expressions */
+
+const chai = require('chai')
+chai.use(require('chai-http'))
+const expect = chai.expect
+
+const constants = require('../constants.js')
+const app = require('../../../src/index.js')
+const uuid = require('uuid')
+
+describe('Testing Audit Org endpoints', () => {
+  let orgUuid
+  let testAuditUUID
+  let changeAuthorUUID
+
+  // Setup: Get real org UUID before tests
+  before(async () => {
+    await chai.request(app)
+      .get('/api/org/win_5/users')
+      .set(constants.headers)
+      .then((res, err) => {
+        expect(err).to.be.undefined
+        expect(res).to.have.status(200)
+        orgUuid = res.body.users[0].org_UUID
+        changeAuthorUUID = res.body.users[0].UUID
+      })
+  })
+
+  context('Positive Tests', () => {
+    it('Should create a new audit document', async () => {
+      const auditData = {
+        target_uuid: orgUuid,
+        history: [
+          {
+            audit_object: {
+              ...constants.existingOrg
+            },
+            change_author: changeAuthorUUID
+          }
+        ]
+      }
+
+      await chai.request(app)
+        .post('/api/audit/org/')
+        .set(constants.headers)
+        .send(auditData)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+
+          expect(res.body).to.haveOwnProperty('message')
+          expect(res.body.message).to.include('was successfully created')
+
+          expect(res.body).to.haveOwnProperty('created')
+          expect(res.body.created).to.haveOwnProperty('uuid')
+          expect(res.body.created).to.haveOwnProperty('target_uuid')
+          expect(res.body.created.target_uuid).to.equal(orgUuid)
+          expect(res.body.created).to.haveOwnProperty('history')
+          expect(res.body.created.history).to.be.an('array')
+          expect(res.body.created.history).to.have.lengthOf(1)
+          expect(res.body.created.history[0]).to.haveOwnProperty('timestamp')
+          expect(res.body.created.history[0]).to.haveOwnProperty('audit_object')
+          expect(res.body.created.history[0].audit_object).to.deep.equal(constants.existingOrg)
+          expect(res.body.created.history[0]).to.haveOwnProperty('change_author')
+          expect(res.body.created.history[0].change_author).to.equal(changeAuthorUUID)
+
+          testAuditUUID = res.body.created.uuid
+        })
+    })
+
+    it('Should append a new entry to audit history', async () => {
+      const appendData = {
+        target_uuid: orgUuid,
+        history: [
+          {
+            audit_object: {
+              ...constants.existingOrg,
+              name: 'test-new-org-name'
+            },
+            change_author: changeAuthorUUID
+          }
+        ]
+      }
+
+      await chai.request(app)
+        .put('/api/audit/org/')
+        .set(constants.headers)
+        .send(appendData)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+
+          expect(res.body).to.haveOwnProperty('message')
+          expect(res.body.message).to.include('was successfully appended')
+
+          expect(res.body).to.haveOwnProperty('updated')
+          expect(res.body.updated).to.haveOwnProperty('history')
+          expect(res.body.updated.history).to.be.an('array')
+          expect(res.body.updated.history).to.have.lengthOf(2)
+        })
+    })
+
+    it('Should get all audit documents', async () => {
+      await chai.request(app)
+        .get('/api/audit/org/')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+
+          expect(res.body).to.be.an('array')
+          expect(res.body.length).to.be.at.least(1)
+
+          const testAudit = res.body.find(audit => audit.uuid === testAuditUUID)
+          expect(testAudit).to.exist
+          expect(testAudit.target_uuid).to.equal(orgUuid)
+        })
+    })
+
+    it('Should get audit document by UUID', async () => {
+      await chai.request(app)
+        .get(`/api/audit/org/document/${testAuditUUID}`)
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+
+          expect(res.body).to.haveOwnProperty('uuid')
+          expect(res.body.uuid).to.equal(testAuditUUID)
+          expect(res.body).to.haveOwnProperty('target_uuid')
+          expect(res.body.target_uuid).to.equal(orgUuid)
+          expect(res.body).to.haveOwnProperty('history')
+          expect(res.body.history).to.be.an('array')
+          expect(res.body.history.length).to.be.at.least(2)
+        })
+    })
+
+    it('Should get audit history by target UUID', async () => {
+      await chai.request(app)
+        .get(`/api/audit/org/${orgUuid}`)
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+
+          expect(res.body).to.haveOwnProperty('uuid')
+          expect(res.body).to.haveOwnProperty('target_uuid')
+          expect(res.body.target_uuid).to.equal(orgUuid)
+          expect(res.body).to.haveOwnProperty('history')
+          expect(res.body.history).to.be.an('array')
+          expect(res.body.history.length).to.be.at.least(2)
+        })
+    })
+
+    it('Should get last X changes for an organization', async () => {
+      const numberOfChanges = 1
+
+      await chai.request(app)
+        .get(`/api/audit/org/${orgUuid}/${numberOfChanges}`)
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+
+          expect(res.body).to.haveOwnProperty('target_uuid')
+          expect(res.body.target_uuid).to.equal(orgUuid)
+          expect(res.body).to.haveOwnProperty('changes')
+          expect(res.body.changes).to.be.an('array')
+          expect(res.body.changes).to.have.lengthOf(numberOfChanges)
+
+          // Verify the change has required fields
+          expect(res.body.changes[0]).to.haveOwnProperty('timestamp')
+          expect(res.body.changes[0]).to.haveOwnProperty('audit_object')
+          expect(res.body.changes[0]).to.haveOwnProperty('change_author')
+        })
+    })
+  })
+
+  context('Negative Tests', () => {
+    it('Should fail to create audit document that already exists', async () => {
+      const auditData = {
+        target_uuid: orgUuid,
+        history: [
+          {
+            audit_object: {
+              ...constants.existingOrg
+            },
+            change_author: changeAuthorUUID
+          }
+        ]
+      }
+
+      await chai.request(app)
+        .post('/api/audit/org/')
+        .set(constants.headers)
+        .send(auditData)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+
+          expect(res.body).to.haveOwnProperty('error')
+          expect(res.body.error).to.equal('AUDIT_EXISTS')
+        })
+    })
+
+    it('Should fail to create audit with invalid target_uuid format', async () => {
+      const auditData = {
+        target_uuid: 'invalid-uuid',
+        history: []
+      }
+
+      await chai.request(app)
+        .post('/api/audit/org/')
+        .set(constants.headers)
+        .send(auditData)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+
+          expect(res.body).to.haveOwnProperty('error')
+          expect(res.body.error).to.equal('INVALID_UUID')
+        })
+    })
+
+    it('Should fail to create audit without target_uuid', async () => {
+      const auditData = {
+        history: []
+      }
+
+      await chai.request(app)
+        .post('/api/audit/org/')
+        .set(constants.headers)
+        .send(auditData)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+
+          expect(res.body).to.haveOwnProperty('error')
+          expect(res.body.error).to.equal('MISSING_REQUIRED_FIELD')
+        })
+    })
+
+    it('Should fail to get audit by non-existent document UUID', async () => {
+      const fakeUUID = uuid.v4()
+
+      await chai.request(app)
+        .get(`/api/audit/org/document/${fakeUUID}`)
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(404)
+
+          expect(res.body).to.haveOwnProperty('error')
+          expect(res.body.error).to.equal('AUDIT_DNE_DOCUMENT')
+        })
+    })
+
+    it('Should fail to get last X changes with invalid number', async () => {
+      const invalidNumber = -5
+      await chai.request(app)
+        .get(`/api/audit/org/${orgUuid}/${invalidNumber}`)
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+
+          expect(res.body).to.haveOwnProperty('error')
+          expect(res.body.error).to.equal('INVALID_NUMBER_OF_CHANGES')
+        })
+    })
+
+    it('Should fail to append audit without change_author', async () => {
+      const appendData = {
+        target_uuid: orgUuid,
+        history: [
+          {
+            audit_object: {
+              ...constants.existingOrg
+            }
+          }
+        ]
+      }
+
+      await chai.request(app)
+        .put('/api/audit/org/')
+        .set(constants.headers)
+        .send(appendData)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+
+          expect(res.body).to.haveOwnProperty('error')
+          expect(res.body.error).to.equal('INVALID_AUDIT_OBJECT')
+        })
+    })
+
+    it('Should fail to create audit when uuid is provided', async () => {
+      const auditData = {
+        uuid: uuid.v4(),
+        target_uuid: uuid.v4(),
+        history: []
+      }
+
+      await chai.request(app)
+        .post('/api/audit/org/')
+        .set(constants.headers)
+        .send(auditData)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+
+          expect(res.body).to.haveOwnProperty('error')
+          expect(res.body.error).to.equal('UUID_PROVIDED')
+        })
+    })
+  })
+})
+
+// TODO:
+// Add tests for permission checks
+// Fix org validations
+//  - need to differentiate between legacy and registry orgs in order to perform correct validations
+// write integration tests for calling auditRepo create/update functions from org create/update endpoints
+// should AUDIT_UPDATE allow for multiple or single additions only
+//  - I used multiple additions in order to validate the audit object using the schema
+// fix parameters and user org short_name identifiers if we want to make things specific to orgs


### PR DESCRIPTION

Closes Issue [1531](https://github.com/orgs/CVEProject/projects/67/views/1?pane=issue&itemId=131850322&issue=CVEProject%7Ccve-services%7C1531)
Closes Issue [1532](https://github.com/orgs/CVEProject/projects/67/views/1?pane=issue&itemId=131852897&issue=CVEProject%7Ccve-services%7C1532)
Closes Issue [1533](https://github.com/orgs/CVEProject/projects/67/views/1?pane=issue&itemId=131854080&issue=CVEProject%7Ccve-services%7C1533)


# Notes
Future improvements:
- I don't check if the audit object being added has actually changed before I append to the collection. Perform a quick check that the audit_object has actually changed since the last audit log
- Add integration tests for Audits being added directly when the registry orgs are called
- Check permissions in unit-tests
- allow for org_identifier not just org_uuid in the request (but that's more for testing purposes since functionality should be under the hood)
- make the audit controller function names more specific (ex:'org_audit..')