### PR TITLE
Resolves issues #1554, #1555, #1556, #1557 Various purl validation fixes

### DIFF
--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -218,10 +218,18 @@ function purlValidateHelper (affected) {
     if (purlObj.version !== undefined) {
       throw new Error('The PURL version component is currently not supported by the CVE schema: ' + purlStr)
     }
+
+    // Check for versions within qualifiers
     if (purlObj.qualifiers !== undefined) {
       if (Object.keys(purlObj.qualifiers).includes('vers')) {
         throw new Error('PURL versions are currently not supported by the CVE schema: ' + purlStr)
       }
+    }
+
+    // PackageURL does not properly prevent encoded ':', so check for that here
+    const encColon = /%3a/i
+    if (encColon.test(purlStr)) {
+      throw new Error('Percent-encoded colons are not allowed in a PURL: ' + purlStr)
     }
 
     // PackageURL does not properly account for certain Subpath situations

--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -218,9 +218,10 @@ function purlValidateHelper (affected) {
     if (purlObj.version !== undefined) {
       throw new Error('The PURL version component is currently not supported by the CVE schema: ' + purlStr)
     }
-
-    if (Object.keys(purlObj.qualifiers).includes('vers')) {
-      throw new Error('PURL versions are currently not supported by the CVE schema: ' + purlStr)
+    if (purlObj.qualifiers !== undefined) {
+      if (Object.keys(purlObj.qualifiers).includes('vers')) {
+        throw new Error('PURL versions are currently not supported by the CVE schema: ' + purlStr)
+      }
     }
 
     // PackageURL does not properly account for certain Subpath situations

--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -219,10 +219,16 @@ function purlValidateHelper (affected) {
       throw new Error('The PURL version component is currently not supported by the CVE schema: ' + purlStr)
     }
 
-    // Check for versions within qualifiers
+    // Handle qualifier cases
     if (purlObj.qualifiers !== undefined) {
+      // Check for versions within qualifiers
       if (Object.keys(purlObj.qualifiers).includes('vers')) {
         throw new Error('PURL versions are currently not supported by the CVE schema: ' + purlStr)
+      }
+
+      // Check for qualifier with key but no value
+      if ((Array.from(parsedPurlArray[4].values()).includes(''))) {
+        throw new Error('Qualifier keys must have a value: ' + purlStr)
       }
     }
 

--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -225,7 +225,9 @@ function purlValidateHelper (affected) {
       if (Object.keys(purlObj.qualifiers).includes('vers')) {
         throw new Error('PURL versions are currently not supported by the CVE schema: ' + purlStr)
       }
+    }
 
+    if (parsedPurlArray[4] !== undefined) {
       // Check for qualifier with key but no value
       if ((Array.from(parsedPurlArray[4].values()).includes(''))) {
         throw new Error('Qualifier keys must have a value: ' + purlStr)

--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -216,7 +216,7 @@ function purlValidateHelper (affected) {
 
     // PURL's with versions are not allowed
     if (purlObj.version !== undefined) {
-      throw new Error('The PURL version component is currently not supported by the CVE schema:' + purlStr)
+      throw new Error('The PURL version component is currently not supported by the CVE schema: ' + purlStr)
     }
 
     // PackageURL does not properly account for certain Subpath situations

--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -216,22 +216,27 @@ function purlValidateHelper (affected) {
 
     // PURL's with versions are not allowed
     if (purlObj.version !== undefined) {
-      throw new Error('The PURL version component is currently not supported by the CVE schema: "' + purlStr + '"')
+      throw new Error('The PURL version component is currently not supported by the CVE schema:' + purlStr)
     }
 
     // PackageURL does not properly account for certain Subpath situations
     // so adding additional validation to account for them
+    // Handles PURLs that include a # but no subpath
+    if (purlObj.subpath === undefined && purlStr.includes('#')) {
+      throw new Error('Subpaths cannot be empty or contain only a /: ' + purlStr)
+    }
+
     if (purlObj.subpath !== undefined) {
       // Checks if any subpaths contain invalid characters
       // Subpaths cannot be '.' or '..'
       const parsedSubpaths = subpathHelper(parsedPurlArray[5])
 
       if (parsedSubpaths.includes('..') || parsedSubpaths.includes('.')) {
-        throw new Error('Subpaths cannot be "." or "..": "' + purlStr + '"')
+        throw new Error('Subpaths cannot be "." or "..": ' + purlStr)
       }
 
       if (parsedSubpaths.includes('')) {
-        throw new Error('Subpaths cannot be empty or contain only a "/": "' + purlStr + '"')
+        throw new Error('Subpaths cannot be empty or contain only a /: ' + purlStr)
       }
     }
   }

--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -197,9 +197,9 @@ function purlValidateHelper (affected) {
   for (const affObj of affected) {
     const purlStr = affObj.packageURL
 
-    // If no PURL string provided, skip validation
+    // If no PURL string provided, skip validation and continue through loop
     if (!purlStr) {
-      return true
+      continue
     }
     let purlObj
     let parsedPurlArray

--- a/src/controller/cve.controller/cve.middleware.js
+++ b/src/controller/cve.controller/cve.middleware.js
@@ -219,6 +219,10 @@ function purlValidateHelper (affected) {
       throw new Error('The PURL version component is currently not supported by the CVE schema: ' + purlStr)
     }
 
+    if (Object.keys(purlObj.qualifiers).includes('vers')) {
+      throw new Error('PURL versions are currently not supported by the CVE schema: ' + purlStr)
+    }
+
     // PackageURL does not properly account for certain Subpath situations
     // so adding additional validation to account for them
     // Handles PURLs that include a # but no subpath

--- a/test/unit-tests/cve/validatePurlTest.js
+++ b/test/unit-tests/cve/validatePurlTest.js
@@ -48,6 +48,11 @@ const PurlRecordVersion = [
   }
 ]
 
+const RecordQualifierVersionPurl = [
+  {
+    packageURL: 'pkg:pypi/django?vers=vers:pypi%2F%3E%3D1.11.0%7C%21%3D1.11.1%7C%3C2.0.0'
+  }
+]
 const PurlRecordEmptySubpath = [
   {
     packageURL: 'pkg:npm/foo/bar?q=1&s=2#test//'
@@ -154,6 +159,10 @@ describe('Testing validatePURL middleware', () => {
 
     it('Should fail to validate when at least one PURL object in an array is invalid ', () => {
       expect(() => purlValidateHelper(MultipleRecordsOneInvalid)).to.throw('Subpaths cannot be "." or "..": ' + PurlRecordOnlySinglePeriodSubpath[0].packageURL)
+    })
+
+    it('Should fail to validate when a version is passed in the qualifier component ', () => {
+      expect(() => purlValidateHelper(RecordQualifierVersionPurl)).to.throw('PURL versions are currently not supported by the CVE schema: ' + RecordQualifierVersionPurl[0].packageURL)
     })
   })
 })

--- a/test/unit-tests/cve/validatePurlTest.js
+++ b/test/unit-tests/cve/validatePurlTest.js
@@ -123,7 +123,7 @@ describe('Testing validatePURL middleware', () => {
     })
 
     it('Should fail to validate a PURL object with a version component ', () => {
-      expect(() => purlValidateHelper(PurlRecordVersion)).to.throw('The PURL version component is currently not supported by the CVE schema: "' + PurlRecordVersion[0].packageURL + '"')
+      expect(() => purlValidateHelper(PurlRecordVersion)).to.throw('The PURL version component is currently not supported by the CVE schema: ' + PurlRecordVersion[0].packageURL)
     })
 
     it('Should fail to validate a PURL object with one non-empty subpath and at least one empty subpath ', () => {

--- a/test/unit-tests/cve/validatePurlTest.js
+++ b/test/unit-tests/cve/validatePurlTest.js
@@ -127,23 +127,23 @@ describe('Testing validatePURL middleware', () => {
     })
 
     it('Should fail to validate a PURL object with one non-empty subpath and at least one empty subpath ', () => {
-      expect(() => purlValidateHelper(PurlRecordEmptySubpath)).to.throw('Subpaths cannot be empty or contain only a "/": "' + PurlRecordEmptySubpath[0].packageURL + '"')
+      expect(() => purlValidateHelper(PurlRecordEmptySubpath)).to.throw('Subpaths cannot be empty or contain only a /: ' + PurlRecordEmptySubpath[0].packageURL)
     })
 
     it('Should fail to validate a PURL object with a subpath containing only a "/" ', () => {
-      expect(() => purlValidateHelper(PurlRecordOnlySlashSubpath)).to.throw('Subpaths cannot be empty or contain only a "/": "' + PurlRecordOnlySlashSubpath[0].packageURL + '"')
+      expect(() => purlValidateHelper(PurlRecordOnlySlashSubpath)).to.throw('Subpaths cannot be empty or contain only a /: ' + PurlRecordOnlySlashSubpath[0].packageURL)
     })
 
     it('Should fail to validate a PURL object with a subpath equal to "." ', () => {
-      expect(() => purlValidateHelper(PurlRecordOnlySinglePeriodSubpath)).to.throw('Subpaths cannot be "." or "..": "' + PurlRecordOnlySinglePeriodSubpath[0].packageURL + '"')
+      expect(() => purlValidateHelper(PurlRecordOnlySinglePeriodSubpath)).to.throw('Subpaths cannot be "." or "..": ' + PurlRecordOnlySinglePeriodSubpath[0].packageURL)
     })
 
     it('Should fail to validate a PURL object with a subpath equal to ".." ', () => {
-      expect(() => purlValidateHelper(PurlRecordOnlyDoublePeriodSubpath)).to.throw('Subpaths cannot be "." or "..": "' + PurlRecordOnlyDoublePeriodSubpath[0].packageURL + '"')
+      expect(() => purlValidateHelper(PurlRecordOnlyDoublePeriodSubpath)).to.throw('Subpaths cannot be "." or "..": ' + PurlRecordOnlyDoublePeriodSubpath[0].packageURL)
     })
 
     it('Should fail to validate when at least one PURL object in an array is invalid ', () => {
-      expect(() => purlValidateHelper(MultipleRecordsOneInvalid)).to.throw('Subpaths cannot be "." or "..": "' + PurlRecordOnlySinglePeriodSubpath[0].packageURL + '"')
+      expect(() => purlValidateHelper(MultipleRecordsOneInvalid)).to.throw('Subpaths cannot be "." or "..": ' + PurlRecordOnlySinglePeriodSubpath[0].packageURL)
     })
   })
 })

--- a/test/unit-tests/cve/validatePurlTest.js
+++ b/test/unit-tests/cve/validatePurlTest.js
@@ -116,6 +116,12 @@ const RecordNoPurl = [
   }
 ]
 
+const PurlQualifierKeyNoValueRecord = [
+  {
+    packageURL: 'pkg:npm/package-name?qualifier&test=value'
+  }
+]
+
 describe('Testing validatePURL middleware', () => {
   context('Positive Tests', () => {
     it('Should validate a correctly formatted PURL ', () => {
@@ -169,6 +175,10 @@ describe('Testing validatePURL middleware', () => {
 
     it('Should fail to validate when a version is passed in the qualifier component ', () => {
       expect(() => purlValidateHelper(RecordQualifierVersionPurl)).to.throw('PURL versions are currently not supported by the CVE schema: ' + RecordQualifierVersionPurl[0].packageURL)
+    })
+
+    it('Should fail to validate when a qualifier has a key and no value ', () => {
+      expect(() => purlValidateHelper(PurlQualifierKeyNoValueRecord)).to.throw('Qualifier keys must have a value: ' + PurlQualifierKeyNoValueRecord[0].packageURL)
     })
 
     it('Should fail to validate when a PURL contain an encoded colon ', () => {

--- a/test/unit-tests/cve/validatePurlTest.js
+++ b/test/unit-tests/cve/validatePurlTest.js
@@ -72,6 +72,12 @@ const PurlRecordOnlySinglePeriodSubpath = [
   }
 ]
 
+const PurlRecordPoundSymbolEmpty = [
+  {
+    packageURL: 'pkg:npm/foo/bar?q=1&s=2#'
+  }
+]
+
 const MultipleRecordsOneInvalid = [
   {
     packageURL: 'pkg:npm/foo/bar?q=1&s=2#./'
@@ -140,6 +146,10 @@ describe('Testing validatePURL middleware', () => {
 
     it('Should fail to validate a PURL object with a subpath equal to ".." ', () => {
       expect(() => purlValidateHelper(PurlRecordOnlyDoublePeriodSubpath)).to.throw('Subpaths cannot be "." or "..": ' + PurlRecordOnlyDoublePeriodSubpath[0].packageURL)
+    })
+
+    it('Should fail to validate a PURL object with a # symbol but no subpath ', () => {
+      expect(() => purlValidateHelper(PurlRecordPoundSymbolEmpty)).to.throw('Subpaths cannot be empty or contain only a /: ' + PurlRecordPoundSymbolEmpty[0].packageURL)
     })
 
     it('Should fail to validate when at least one PURL object in an array is invalid ', () => {

--- a/test/unit-tests/cve/validatePurlTest.js
+++ b/test/unit-tests/cve/validatePurlTest.js
@@ -104,6 +104,12 @@ const MultipleRecordsOneInvalid = [
   }
 ]
 
+const PurlEncodedColonRecord = [
+  {
+    packageURL: 'pkg:pypi/django#%3A'
+  }
+]
+
 const RecordNoPurl = [
   {
     test: 'testing String'
@@ -163,6 +169,10 @@ describe('Testing validatePURL middleware', () => {
 
     it('Should fail to validate when a version is passed in the qualifier component ', () => {
       expect(() => purlValidateHelper(RecordQualifierVersionPurl)).to.throw('PURL versions are currently not supported by the CVE schema: ' + RecordQualifierVersionPurl[0].packageURL)
+    })
+
+    it('Should fail to validate when a PURL contain an encoded colon ', () => {
+      expect(() => purlValidateHelper(PurlEncodedColonRecord)).to.throw('Percent-encoded colons are not allowed in a PURL: ' + PurlEncodedColonRecord[0].packageURL)
     })
   })
 })


### PR DESCRIPTION
Closes Issues #1554, #1555, #1556, #1557

# Summary
Addresses various purl validation edge cases and bugs: 

- Added a check for purls with a # but no subpath text
- Added a check for encoded ":"s, which are not permitted by the purl specification
- Added logic to prevent versions from being included in qualifiers
- Fixed bug causing records with multiple 'affected' objects to incorrectly validate when the first object does not have a packageURL while the second one has an invalid packageURL.

# Important Changes
`cve.middleware.js`

