### PR TITLE
DRAFT: Refactor /registry/ endpoints to use the new Crud endpoints.

### DIFF
--- a/src/controller/audit.controller/audit.controller.js
+++ b/src/controller/audit.controller/audit.controller.js
@@ -78,7 +78,7 @@ async function createAuditDocumentForOrg (req, res, next) {
             body.target_uuid,
             entry.audit_object,
             entry.change_author,
-            { session }
+            { session, upsert: true }
           )
         }
       } else {
@@ -87,7 +87,7 @@ async function createAuditDocumentForOrg (req, res, next) {
           body.target_uuid,
           body.audit_object || {},
           body.change_author || req.ctx.org,
-          { session }
+          { session, upsert: true }
         )
       }
 

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -3,6 +3,7 @@ const router = express.Router()
 const mw = require('../../middleware/middleware')
 const errorMsgs = require('../../middleware/errorMessages')
 const controller = require('./org.controller')
+const registryOrgController = require('../registry-org.controller/registry-org.controller.js')
 const { body, param, query } = require('express-validator')
 const { parseGetParams, parsePostParams, parsePutParams, parseError, isUserRole, isValidUsername, isOrgRole, validateUpdateOrgParameters } = require('./org.middleware')
 // Only God and Javascript know swhy its saying it is not used when it is.....
@@ -86,7 +87,7 @@ router.get('/registry/org',
   query(['page']).optional().isInt({ min: CONSTANTS.PAGINATOR_PAGE }),
   parseError,
   parseGetParams,
-  controller.ORG_ALL
+  registryOrgController.ALL_ORGS
 )
 
 router.get('/registry/org/:shortname/users',
@@ -166,9 +167,9 @@ router.get('/registry/org/:shortname/users',
   query(['page']).optional().isInt({ min: CONSTANTS.PAGINATOR_PAGE }),
   parseError,
   parseGetParams,
-  controller.USER_ALL)
+  registryOrgController.USER_ALL)
 
-router.get('/registry/org/:shortname/id_quota',
+router.get(['/registry/org/:shortname/id_quota', '/registry/org/:shortname/hard_quota'],
   /*
   #swagger.tags = ['Registry Organization']
   #swagger.operationId = 'orgIdQuota'
@@ -317,8 +318,9 @@ router.get('/registry/org/:identifier',
   query().custom((query) => { return mw.validateQueryParameterNames(query, ['']) }),
   parseError,
   parseGetParams,
-  controller.ORG_SINGLE
+  registryOrgController.SINGLE_ORG
 )
+
 router.get('/registry/org/:shortname/user/:username',
   /*
   #swagger.tags = ['Registry User']
@@ -403,6 +405,7 @@ router.get('/registry/org/:shortname/user/:username',
   parseGetParams,
   controller.USER_SINGLE
 )
+
 router.post('/registry/org',
   /*
   #swagger.tags = ['Registry Organization']
@@ -490,7 +493,7 @@ router.post('/registry/org',
   query().custom((query) => { return mw.validateQueryParameterNames(query, ['']) }),
   parsePostParams,
   parseError,
-  controller.ORG_CREATE_SINGLE
+  registryOrgController.CREATE_ORG
 )
 
 router.put('/registry/org/:shortname',
@@ -568,10 +571,9 @@ router.put('/registry/org/:shortname',
   mw.useRegistry(),
   mw.validateUser,
   mw.onlySecretariat,
-  validateUpdateOrgParameters(),
   parseError,
   parsePutParams,
-  controller.ORG_UPDATE_SINGLE
+  registryOrgController.UPDATE_ORG
 )
 
 router.post('/registry/org/:shortname/user',
@@ -668,8 +670,9 @@ router.post('/registry/org/:shortname/user',
     .custom(isUserRole),
   parseError,
   parsePostParams,
-  controller.USER_CREATE_SINGLE
+  registryOrgController.USER_CREATE_SINGLE
 )
+
 router.put('/registry/org/:shortname/user/:username',
   /*
   #swagger.tags = ['Registry User']

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -28,7 +28,7 @@ async function getOrgs (req, res, next) {
     options.page = req.ctx.query.page ? parseInt(req.ctx.query.page) : CONSTANTS.PAGINATOR_PAGE // if 'page' query parameter is not defined, set 'page' to the default page value
 
     try {
-      returnValue = await repo.getAllOrgs({ ...options, session }, !req.useRegistry)
+      returnValue = await repo.getAllOrgs({ ...options, session }, true)
     } finally {
       await session.endSession()
     }
@@ -42,7 +42,9 @@ async function getOrgs (req, res, next) {
 
 /**
  * Get the details of a single org for the specified shortname/UUID
- * Called by GET /api/registry/org/{identifier}, GET /api/org/{identifier}
+ * Called by GET /api/org/{identifier}
+ *
+ * When Switched over to user registry only - This to be deleted
  **/
 async function getOrg (req, res, next) {
   try {
@@ -51,20 +53,21 @@ async function getOrg (req, res, next) {
     const requesterOrgShortName = req.ctx.org
     const identifier = req.ctx.params.identifier
     const identifierIsUUID = validateUUID(identifier)
+    const returnLegacyFormat = true
     let returnValue
 
     try {
       session.startTransaction()
-      const requesterOrg = await repo.findOneByShortName(requesterOrgShortName, { session }, !req.useRegistry)
+      const requesterOrg = await repo.findOneByShortName(requesterOrgShortName, { session }, returnLegacyFormat)
       const requesterOrgIdentifier = identifierIsUUID ? requesterOrg.UUID : requesterOrgShortName
-      const isSecretariat = await repo.isSecretariat(requesterOrg, { session }, !req.useRegistry)
+      const isSecretariat = await repo.isSecretariat(requesterOrg, { session }, returnLegacyFormat)
 
       if (requesterOrgIdentifier !== identifier && !isSecretariat) {
         logger.info({ uuid: req.ctx.uuid, message: identifier + ' organization can only be viewed by the users of the same organization or the Secretariat.' })
         return res.status(403).json(error.notSameOrgOrSecretariat())
       }
 
-      returnValue = await repo.getOrg(identifier, identifierIsUUID, { session }, !req.useRegistry)
+      returnValue = await repo.getOrg(identifier, identifierIsUUID, { session }, returnLegacyFormat)
     } catch (error) {
       await session.abortTransaction()
       // Handle the specific error thrown by BaseOrgRepository.createOrg

--- a/src/controller/registry-org.controller/registry-org.controller.js
+++ b/src/controller/registry-org.controller/registry-org.controller.js
@@ -84,6 +84,10 @@ async function getOrg (req, res, next) {
       returnValue = await repo.getOrg(identifier, identifierIsUUID, { session })
     } catch (error) {
       await session.abortTransaction()
+      // Handle the specific error thrown by BaseOrgRepository.createOrg
+      if (error.message && error.message.includes('Unknown Org type requested')) {
+        return res.status(400).json({ message: error.message })
+      }
       throw error
     } finally {
       await session.endSession()
@@ -116,11 +120,8 @@ async function createOrg (req, res, next) {
   try {
     const session = await mongoose.startSession()
     const repo = req.ctx.repositories.getBaseOrgRepository()
-    const userRepo = req.ctx.repositories.getBaseUserRepository()
     const body = req.ctx.body
     const isSecretariat = await repo.isSecretariatByShortName(req.ctx.org, { session })
-    const requestingUserUUID = await userRepo.getUserUUID(req.ctx.user, req.ctx.org, { session })
-
     let createdOrg
 
     // Do not allow the user to pass in a UUID
@@ -134,15 +135,10 @@ async function createOrg (req, res, next) {
       if (!result.isValid) {
         logger.error(JSON.stringify({ uuid: req.ctx.uuid, message: 'CVE JSON schema validation FAILED.' }))
         await session.abortTransaction()
-
-        // TODO: Investigate this, right now we are accepting either a one one-dimensional array of strings or just a string.
-        // However, we are taking the "highest" authority
-        //
-        //
-        // if (!Array.isArray(body?.authority) || body?.authority.some(item => typeof item !== 'string')) {
-        //   return res.status(400).json({ message: 'Parameters were invalid', details: [{ param: 'authority', msg: 'Parameter must be a one-dimensional array of strings' }] })
-        // }
-        return res.status(400).json({ message: 'Parameters were invalid', errors: result.errors })
+        if (!Array.isArray(body?.authority) || body?.authority.some(item => typeof item !== 'string')) {
+          return res.status(400).json({ error: 'BAD_INPUT', message: 'Parameters were invalid', details: [{ param: 'authority', msg: 'Parameter must be a one-dimensional array of strings' }] })
+        }
+        return res.status(400).json({ error: 'BAD_INPUT', message: 'Parameters were invalid', errors: result.errors })
       }
 
       // Check for duplicate short_name
@@ -155,6 +151,8 @@ async function createOrg (req, res, next) {
         return res.status(400).json(error.orgExists(body?.short_name))
       }
 
+      const userRepo = req.ctx.repositories.getBaseUserRepository()
+      const requestingUserUUID = await userRepo.getUserUUID(req.ctx.user, req.ctx.org, { session })
       // Create the org – repo.createOrg will handle field mapping
       createdOrg = await repo.createOrg(body, { session, upsert: true }, false, requestingUserUUID, isSecretariat)
 
@@ -415,7 +413,7 @@ async function getUsers (req, res, next) {
     const orgRepo = req.ctx.repositories.getBaseOrgRepository()
     const userRepo = req.ctx.repositories.getBaseUserRepository()
     const orgUUID = await orgRepo.getOrgUUID(orgShortName)
-    const isSecretariat = await orgRepo.isSecretariat(shortName)
+    const isSecretariat = await orgRepo.isSecretariatByShortName(shortName)
 
     if (!orgUUID) {
       logger.info({ uuid: req.ctx.uuid, message: orgShortName + ' organization does not exist.' })
@@ -427,7 +425,8 @@ async function getUsers (req, res, next) {
       return res.status(403).json(error.notSameOrgOrSecretariat())
     }
 
-    const payload = await userRepo.getAllUsersByOrgShortname(orgShortName, options, false)
+    // This should always return Registry typed
+    const payload = await userRepo.getAllUsersByOrgShortname(orgShortName, options, true)
 
     logger.info({ uuid: req.ctx.uuid, message: `The users of ${orgShortName} organization were sent to the user.` })
     return res.status(200).json(payload)

--- a/src/controller/user.controller/index.js
+++ b/src/controller/user.controller/index.js
@@ -3,6 +3,7 @@ const router = express.Router()
 const mw = require('../../middleware/middleware')
 const { query, param } = require('express-validator')
 const controller = require('./user.controller')
+const registryUserController = require('../registry-user.controller/registry-user.controller.js')
 const { parseGetParams, parseError } = require('./user.middleware')
 // Only God and Javascript know why its saying it is not used when it is.....
 // eslint-disable-next-line no-unused-vars
@@ -86,7 +87,7 @@ router.get('/registry/users',
   query(['page']).custom((val) => { return mw.containsNoInvalidCharacters(val) }),
   parseError,
   parseGetParams,
-  controller.ALL_USERS
+  registryUserController.ALL_USERS
 )
 
 router.get('/users',

--- a/src/repositories/auditRepository.js
+++ b/src/repositories/auditRepository.js
@@ -28,7 +28,6 @@ class AuditRepository extends BaseRepository {
     try {
     // Try to find existing document
       let audit = await this.findOneByTargetUUID(targetUUID, options)
-
       if (!audit) {
       // Create new document if doesn't exist
       // Assuming 'uuid' is available for generating a new UUID
@@ -42,8 +41,8 @@ class AuditRepository extends BaseRepository {
         audit.history.push(historyEntry)
       }
 
-      const result = await audit.save(options)
-      return result.toObject()
+      await audit.save({ options })
+      return audit.toObject()
     } catch (error) {
       throw new Error('Failed to save audit history entry.')
     }

--- a/src/repositories/auditRepository.js
+++ b/src/repositories/auditRepository.js
@@ -27,7 +27,7 @@ class AuditRepository extends BaseRepository {
 
     try {
     // Try to find existing document
-      let audit = await this.findOneByTargetUUID(targetUUID, options)
+      let audit = await this.findOneByTargetUUID(targetUUID, { options })
       if (!audit) {
       // Create new document if doesn't exist
       // Assuming 'uuid' is available for generating a new UUID

--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -12,6 +12,13 @@ const AuditRepository = require('./auditRepository')
 const ConversationRepository = require('./conversationRepository')
 const getConstants = require('../constants').getConstants
 
+const skipNulls = (objValue, srcValue) => {
+  if (_.isArray(objValue)) {
+    return srcValue
+  }
+  return undefined
+}
+
 /**
  * @function setAggregateOrgObj
  * @description Constructs the aggregation pipeline for legacy organization objects.
@@ -702,10 +709,15 @@ class BaseOrgRepository extends BaseRepository {
     let updatedRegistryOrg = null
     let updatedLegacyOrg = null
     let jointApprovalRegistry = null
+
     // If there are no joint approval fields, merge the original and updated objects. Otherwise, update the registry object and legacy object separately considering joint approval.
+
+    // Dealing with roles requires a bit of extra control.
+    const originalRoles = registryOrg.authority
+
     if (isSecretariat || _.isEmpty(jointApprovalFieldsRegistry)) {
-      updatedLegacyOrg = _.merge(legacyOrg, legacyObjectRaw)
-      updatedRegistryOrg = _.merge(registryOrg, registryObjectRaw)
+      updatedLegacyOrg = _.mergeWith(legacyOrg, legacyObjectRaw, skipNulls)
+      updatedRegistryOrg = _.mergeWith(registryOrg, registryObjectRaw, skipNulls)
     } else {
       // write the joint approval to the database
       jointApprovalRegistry = _.merge({}, registryOrg.toObject(), registryObjectRaw)
@@ -762,7 +774,7 @@ class BaseOrgRepository extends BaseRepository {
 
     // Handle possible authority (discriminator) changes that require a different Mongoose model
     let roleChange = false
-    if (!_.isEqual([...registryOrg?.authority].sort(), [...updatedRegistryOrg?.authority].sort())) {
+    if (!_.isEqual([...originalRoles].sort(), [...updatedRegistryOrg?.authority].sort())) {
       roleChange = true
     }
 

--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -747,7 +747,7 @@ class BaseOrgRepository extends BaseRepository {
             registryOrg.UUID,
             currentRegistryOrg.toObject(),
             requestingUserUUID,
-            options
+            { ...options, upsert: true }
           )
         }
         // Get the org state before save for comparison
@@ -765,9 +765,10 @@ class BaseOrgRepository extends BaseRepository {
             registryOrg.UUID,
             registryOrg.toObject(),
             requestingUserUUID,
-            options
+            { ...options, upsert: true }
           )
         }
+        console.log('Audit entry created for registry object')
       } catch (auditError) {
       }
     }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -290,10 +290,10 @@ function deepRemoveEmpty (obj) {
       if (_.isObject(value) && !_.isArray(value) && !_.isDate(value)) {
         clean(value)
       }
-
       // 2. After recursion, check if the key's value is an empty object or array.
       // This will catch both initially empty fields and nested objects that became empty.
       if (
+        value === null ||
         (_.isObject(value) && !_.isDate(value) && _.isEmpty(value)) ||
         (_.isArray(value) && _.isEmpty(value))
       ) {

--- a/test/integration-tests/audit/registryOrgCreatesAuditTest.js
+++ b/test/integration-tests/audit/registryOrgCreatesAuditTest.js
@@ -109,8 +109,13 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
 
     // Now update with same values
     const updateResAgain = await chai.request(app)
-      .put(`/api/registry/org/${org.shortName}?name=${org.longName}`)
+      .put(`/api/registry/org/${org.shortName}`)
       .set(secretariatHeaders)
+      .send({
+        short_name: org.shortName,
+        hard_quota: 1500,
+        long_name: org.longName
+      })
     expect(updateResAgain).to.have.status(200)
     expect(updateResAgain.body.updated.long_name).to.equal(org.longName)
 
@@ -130,8 +135,13 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
 
     // Update org name
     const updateRes = await chai.request(app)
-      .put(`/api/registry/org/${testOrg.shortName}?id_quota=100`)
+      .put(`/api/registry/org/${testOrg.shortName}`)
       .set(secretariatHeaders)
+      .send({
+        long_name: testOrg.longName,
+        short_name: testOrg.shortName,
+        hard_quota: 100
+      })
 
     expect(updateRes).to.have.status(200)
 
@@ -156,18 +166,33 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
     })
     // Make sequential updates
     const updatedRes1 = await chai.request(app)
-      .put(`/api/registry/org/${testOrg.shortName}?id_quota=2000`)
+      .put(`/api/registry/org/${testOrg.shortName}`)
       .set(secretariatHeaders)
+      .send({
+        short_name: testOrg.shortName,
+        long_name: testOrg.longName,
+        hard_quota: 2000
+      })
     expect(updatedRes1).to.have.status(200)
 
     const updatedRes2 = await chai.request(app)
-      .put(`/api/registry/org/${testOrg.shortName}?id_quota=3000`)
+      .put(`/api/registry/org/${testOrg.shortName}`)
       .set(secretariatHeaders)
+      .send({
+        short_name: testOrg.shortName,
+        long_name: testOrg.longName,
+        hard_quota: 3000
+      })
     expect(updatedRes2).to.have.status(200)
 
     const updatedRes3 = await chai.request(app)
-      .put(`/api/registry/org/${testOrg.shortName}?id_quota=4000`)
+      .put(`/api/registry/org/${testOrg.shortName}`)
       .set(secretariatHeaders)
+      .send({
+        short_name: testOrg.shortName,
+        long_name: testOrg.longName,
+        hard_quota: 4000
+      })
     expect(updatedRes3).to.have.status(200)
     // Check audit history
     const auditRes = await chai.request(app)
@@ -188,7 +213,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
     }
   })
 
-  it('Should create an audit when updating an Org if it does not exist', async () => {
+  it.only('Should create an audit when updating an Org if it does not exist', async () => {
     const testOrg = await createTestOrg({
       hard_quota: 1500,
       authority: ['CNA']
@@ -203,8 +228,13 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
     expect(auditRes).to.have.status(404)
     // Now update org to trigger audit creation
     const updateRes = await chai.request(app)
-      .put(`/api/registry/org/${testOrg.shortName}?id_quota=2500`)
+      .put(`/api/registry/org/${testOrg.shortName}`)
       .set(secretariatHeaders)
+      .send({
+        short_name: testOrg.shortName,
+        long_name: testOrg.longName,
+        hard_quota: 2500
+      })
     expect(updateRes).to.have.status(200)
     // Check audit history
     const auditResCreation = await chai.request(app)

--- a/test/integration-tests/audit/registryOrgCreatesAuditTest.js
+++ b/test/integration-tests/audit/registryOrgCreatesAuditTest.js
@@ -213,7 +213,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
     }
   })
 
-  it.only('Should create an audit when updating an Org if it does not exist', async () => {
+  it('Should create an audit when updating an Org if it does not exist', async () => {
     const testOrg = await createTestOrg({
       hard_quota: 1500,
       authority: ['CNA']
@@ -233,6 +233,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
       .send({
         short_name: testOrg.shortName,
         long_name: testOrg.longName,
+        authority: ['CNA'],
         hard_quota: 2500
       })
     expect(updateRes).to.have.status(200)

--- a/test/integration-tests/org/registryOrg.js
+++ b/test/integration-tests/org/registryOrg.js
@@ -42,7 +42,6 @@ const createNewUserWithNewOrg = async () => {
 
   return { orgShortName, username }
 }
-
 describe('Testing Secretariat functionality for Orgs', () => {
   context('Positive Tests', () => {
     it('Secretariat can request a list of all organizations', async () => {
@@ -114,8 +113,14 @@ describe('Testing Secretariat functionality for Orgs', () => {
           expect(res).to.have.status(200)
         })
       await chai.request(app)
-        .put('/api/registry/org/test_registry_org_cna?id_quota=100000')
+        .put('/api/registry/org/test_registry_org_cna')
         .set(secretariatHeaders)
+        .send({
+          short_name: 'test_registry_org_cna',
+          long_name: 'Testing Registry Org CNA',
+          hard_quota: 100000,
+          authority: ['CNA']
+        })
         .then((res) => {
           expect(res).to.have.status(200)
           expect(res.body.updated.hard_quota).to.equal(100000)
@@ -424,31 +429,13 @@ describe('Testing Secretariat functionality for Orgs', () => {
     it('Fails to update an org that does not exist', async () => {
       const nonExistentOrg = 'nonexistent_org'
       await chai.request(app)
-        .put(`/api/registry/org/${nonExistentOrg}?id_quota=100`)
+        .put(`/api/registry/org/${nonExistentOrg}`)
         .set(secretariatHeaders)
+        .send({ hard_quota: 100 })
         .then((res) => {
           expect(res).to.have.status(404)
           expect(res.body.error).to.equal('ORG_DNE_PARAM')
         })
-    })
-
-    const malformedRolesQuery = [
-      'active_roles.add[][a]=CNA',
-      'active_roles.add[][CNA]'
-    ]
-
-    malformedRolesQuery.forEach((query) => {
-      it('Fails to update an org with malformed roles in query', async () => {
-        await chai.request(app)
-          .put(`/api/registry/org/mitre?${query}`)
-          .set(secretariatHeaders)
-          .then((res) => {
-            expect(res).to.have.status(400)
-            expect(res.body.message).to.equal('Parameters were invalid')
-            expect(res.body.details[0].param).to.equal('active_roles.add')
-            expect(res.body.details[0].msg).to.equal('Parameter must be a one-dimensional array of strings')
-          })
-      })
     })
 
     it('should fail requests from a user that does not exist', async () => {

--- a/test/integration-tests/registry-org/createUserByOrgTest.js
+++ b/test/integration-tests/registry-org/createUserByOrgTest.js
@@ -82,30 +82,6 @@ describe('Testing POST /api/registryOrg/:shortname/user endpoint', () => {
       })
   })
 
-  // Negative test: Requester not admin or secretariat
-  // Right now we are locking down to just secretariat
-  it.skip('Should not create a user if requester is not an admin or secretariat', (done) => {
-    const orgShortName = 'mitre'
-    const newUser = {
-      username: 'testuser3@example.com',
-      name: {
-        first: 'Test',
-        last: 'User'
-      }
-    }
-
-    chai.request(app)
-      .post(`/api/registryOrg/${orgShortName}/user`)
-      .set(constants.nonSecretariatUserHeaders)
-      .send(newUser)
-      .end((err, res) => {
-        expect(err).to.be.null
-        expect(res).to.have.status(403)
-        expect(res.body).to.have.property('message').equal('Users can only be created by the Secretariat or Org Admin.')
-        done()
-      })
-  })
-
   // Negative test: Validation error (missing username)
   it('Should not create a user with a missing username', (done) => {
     const orgShortName = 'mitre'

--- a/test/unit-tests/org/orgCreateADPTest.js
+++ b/test/unit-tests/org/orgCreateADPTest.js
@@ -106,30 +106,4 @@ describe('Testing creating orgs with the ADP role', () => {
     expect(mockSession.commitTransaction.calledOnce).to.be.true
     expect(mockSession.endSession.calledOnce).to.be.true
   })
-
-  // This is OBE
-  it.skip('Should have nonzero id_quota when created with ADP and CNA role', async () => {
-    const req = {
-      ctx: {
-        uuid: faker.datatype.uuid(),
-        repositories: {
-          getBaseOrgRepository,
-          getBaseUserRepository
-        },
-        body: {
-          ...stubAdpCnaOrg
-        }
-      },
-      query: {
-        registry: 'false' // query parameters are strings
-      }
-    }
-
-    await ORG_CREATE_SINGLE(req, res, next)
-
-    expect(status.args[0][0]).to.equal(200)
-    expect(updateOrg.args[0][1].policies.id_quota).to.equal(200)
-    expect(updateOrg.args[0][1].authority.active_roles[0]).to.equal('ADP')
-    expect(updateOrg.args[0][1].authority.active_roles[1]).to.equal('CNA')
-  })
 })


### PR DESCRIPTION
With the new /registry/ endpoints, we are going to be enforcing proper GET, POST, PUT, DELETE, and PATCH standards going forward.

We have updated the endpoints to start working that way. I.E: when hitting a POST endpoint, you must post the WHOLE OBJECT with the changes.  