### PR TITLE
Refactor conversations

### DIFF
--- a/src/controller/conversation.controller/conversation.controller.js
+++ b/src/controller/conversation.controller/conversation.controller.js
@@ -46,15 +46,7 @@ async function createConversationForTargetUUID (req, res, next) {
       return res.status(400).json({ message: 'Missing required field body' })
     }
 
-    const conversationBody = {
-      target_uuid: targetUUID,
-      author_id: user.UUID,
-      author_name: [user.name.first, user.name.last].join(' '),
-      author_role: 'Secretariat',
-      visibility: body.visibility ? body.visibility.toLowerCase() : 'private',
-      body: body.body
-    }
-    const result = await repo.createConversation(conversationBody, { session })
+    const result = await repo.createConversation(targetUUID, body, user, true, { session })
     await session.commitTransaction()
     if (!result) {
       return res.status(500).json({ message: 'Failed to create conversation' })
@@ -81,22 +73,8 @@ async function createConversationForTargetUUID (req, res, next) {
   }
 }
 
-async function updateMessage (req, res, next) {
-  const repo = req.ctx.repositories.getConversationRepository()
-  const targetUUID = req.params.uuid
-  const body = req.body
-
-  if (!body.body) {
-    return res.status(400).json({ message: 'Missing required field body' })
-  }
-
-  const result = await repo.updateConversation(body, targetUUID)
-  return res.status(200).json(result)
-}
-
 module.exports = {
   getAllConversations,
   getConversationsForTargetUUID,
-  createConversationForTargetUUID,
-  updateMessage
+  createConversationForTargetUUID
 }

--- a/src/controller/conversation.controller/conversation.controller.js
+++ b/src/controller/conversation.controller/conversation.controller.js
@@ -23,7 +23,7 @@ async function getConversationsForTargetUUID (req, res, next) {
   const repo = req.ctx.repositories.getConversationRepository()
   const targetUUID = req.params.uuid
 
-  const response = await repo.getAllByTargetUUID(targetUUID)
+  const response = await repo.getAllByTargetUUID(targetUUID, true)
   return res.status(200).json(response)
 }
 

--- a/src/controller/conversation.controller/index.js
+++ b/src/controller/conversation.controller/index.js
@@ -33,12 +33,4 @@ router.post('/conversation/target/:uuid',
   controller.createConversationForTargetUUID
 )
 
-// Update conversation message - SEC only
-router.put('/conversation/:uuid/message',
-  mw.validateUser,
-  mw.onlySecretariat,
-  param(['uuid']).isUUID(4),
-  controller.updateMessage
-)
-
 module.exports = router

--- a/src/controller/registry-org.controller/registry-org.controller.js
+++ b/src/controller/registry-org.controller/registry-org.controller.js
@@ -23,7 +23,7 @@ async function getAllOrgs (req, res, next) {
     const session = await mongoose.startSession()
     const repo = req.ctx.repositories.getBaseOrgRepository()
     const conversationRepo = req.ctx.repositories.getConversationRepository()
-    const isSecretariat = await repo.isSecretariat(req.ctx.org, { session })
+    const isSecretariat = await repo.isSecretariatByShortName(req.ctx.org, { session })
     const CONSTANTS = getConstants()
     let returnValue
 
@@ -40,12 +40,10 @@ async function getAllOrgs (req, res, next) {
     try {
       returnValue = await repo.getAllOrgs({ ...options, session })
       // fetch conversations
-      await Promise.all(returnValue.map(org => {
-        return async () => {
-          const conversation = await conversationRepo.getAllByTargetUUID(org.UUID, isSecretariat, { session })
-          org.conversation = conversation?.length ? conversation : undefined
-        }
-      }))
+      for (let i = 0; i < returnValue.organizations.length; i++) {
+        const conversation = await conversationRepo.getAllByTargetUUID(returnValue.organizations[i].UUID, isSecretariat, { session })
+        returnValue.organizations[i].conversation = conversation?.length ? conversation : undefined
+      }
     } finally {
       await session.endSession()
     }
@@ -93,7 +91,7 @@ async function getOrg (req, res, next) {
 
       returnValue = await repo.getOrg(identifier, identifierIsUUID, { session })
 
-      if (!!returnValue) {
+      if (returnValue) {
         // fetch conversation
         const conversation = await conversationRepo.getAllByTargetUUID(returnValue.UUID, isSecretariat, { session })
         returnValue.conversation = conversation?.length ? conversation : undefined

--- a/src/controller/registry-org.controller/registry-org.controller.js
+++ b/src/controller/registry-org.controller/registry-org.controller.js
@@ -41,10 +41,10 @@ async function getAllOrgs (req, res, next) {
       returnValue = await repo.getAllOrgs({ ...options, session })
       // fetch conversations
       await Promise.all(returnValue.map(org => {
-        return (async () => {
+        return async () => {
           const conversation = await conversationRepo.getAllByTargetUUID(org.UUID, isSecretariat, { session })
           org.conversation = conversation?.length ? conversation : undefined
-        })
+        }
       }))
     } finally {
       await session.endSession()
@@ -238,7 +238,6 @@ async function updateOrg (req, res, next) {
     const shortName = req.ctx.params.shortname
     const repo = req.ctx.repositories.getBaseOrgRepository()
     const userRepo = req.ctx.repositories.getBaseUserRepository()
-    // const conversationRepo = req.ctx.repositories.getConversationRepository()
     const { conversation, ...body } = req.ctx.body
     let updatedOrg
     let jointApprovalRequired
@@ -268,9 +267,6 @@ async function updateOrg (req, res, next) {
           const updateResult = await reviewRepo.updateReviewOrgObject(body, reviewOrg.uuid, { session })
           if (updateResult) {
             updatedOrg = reviewOrg
-            // if (conversation && conversation.length) {
-            //   await conversationRepo.processConversationHistory(conversation, updateResult.uuid, requestingUser, isSecretariat, { session })
-            // }
             await session.commitTransaction()
             return res.status(200).json({ message: 'Review object updated successfully' })
           }

--- a/src/controller/registry-org.controller/registry-org.controller.js
+++ b/src/controller/registry-org.controller/registry-org.controller.js
@@ -22,6 +22,8 @@ async function getAllOrgs (req, res, next) {
   try {
     const session = await mongoose.startSession()
     const repo = req.ctx.repositories.getBaseOrgRepository()
+    const conversationRepo = req.ctx.repositories.getConversationRepository()
+    const isSecretariat = await repo.isSecretariat(req.ctx.org, { session })
     const CONSTANTS = getConstants()
     let returnValue
 
@@ -37,6 +39,13 @@ async function getAllOrgs (req, res, next) {
 
     try {
       returnValue = await repo.getAllOrgs({ ...options, session })
+      // fetch conversations
+      await Promise.all(returnValue.map(org => {
+        return (async () => {
+          const conversation = await conversationRepo.getAllByTargetUUID(org.UUID, isSecretariat, { session })
+          org.conversation = conversation?.length ? conversation : undefined
+        })
+      }))
     } finally {
       await session.endSession()
     }
@@ -64,6 +73,7 @@ async function getOrg (req, res, next) {
   try {
     const session = await mongoose.startSession()
     const repo = req.ctx.repositories.getBaseOrgRepository()
+    const conversationRepo = req.ctx.repositories.getConversationRepository()
     // User passed in parameter to filter for
     const identifier = req.ctx.params.identifier
     const requesterOrgShortName = req.ctx.org
@@ -82,6 +92,12 @@ async function getOrg (req, res, next) {
       }
 
       returnValue = await repo.getOrg(identifier, identifierIsUUID, { session })
+
+      if (!!returnValue) {
+        // fetch conversation
+        const conversation = await conversationRepo.getAllByTargetUUID(returnValue.UUID, isSecretariat, { session })
+        returnValue.conversation = conversation?.length ? conversation : undefined
+      }
     } catch (error) {
       await session.abortTransaction()
       throw error
@@ -222,7 +238,7 @@ async function updateOrg (req, res, next) {
     const shortName = req.ctx.params.shortname
     const repo = req.ctx.repositories.getBaseOrgRepository()
     const userRepo = req.ctx.repositories.getBaseUserRepository()
-    const conversationRepo = req.ctx.repositories.getConversationRepository()
+    // const conversationRepo = req.ctx.repositories.getConversationRepository()
     const { conversation, ...body } = req.ctx.body
     let updatedOrg
     let jointApprovalRequired
@@ -252,9 +268,9 @@ async function updateOrg (req, res, next) {
           const updateResult = await reviewRepo.updateReviewOrgObject(body, reviewOrg.uuid, { session })
           if (updateResult) {
             updatedOrg = reviewOrg
-            if (conversation && conversation.length) {
-              await conversationRepo.processConversationHistory(conversation, updateResult.uuid, requestingUser, isSecretariat, { session })
-            }
+            // if (conversation && conversation.length) {
+            //   await conversationRepo.processConversationHistory(conversation, updateResult.uuid, requestingUser, isSecretariat, { session })
+            // }
             await session.commitTransaction()
             return res.status(200).json({ message: 'Review object updated successfully' })
           }

--- a/src/model/conversation.js
+++ b/src/model/conversation.js
@@ -5,6 +5,8 @@ const MongoPaging = require('mongo-cursor-pagination')
 const schema = {
   UUID: String,
   target_uuid: String,
+  previous_conversation_uuid: String,
+  next_conversation_uuid: String,
   author_id: String,
   author_name: String,
   author_role: String,
@@ -16,6 +18,8 @@ const schema = {
 const ConversationSchema = new mongoose.Schema(schema, { collection: 'Conversation', timestamps: { createdAt: 'posted_at', updatedAt: 'last_updated' } })
 
 ConversationSchema.index({ target_uuid: 1 })
+ConversationSchema.index({ previous_conversation_uuid: 1 })
+ConversationSchema.index({ next_conversation_uuid: 1 })
 ConversationSchema.index({ author_id: 1 })
 ConversationSchema.index({ posted_at: 1 })
 

--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -718,7 +718,7 @@ class BaseOrgRepository extends BaseRepository {
       // handle conversation
       const requestingUser = await userRepo.findUserByUUID(requestingUserUUID)
       if (conversation && conversation.length) {
-        await conversationRepo.processConversationHistory(conversation, registryOrg.UUID, requestingUser, isSecretariat, { options })
+        await conversationRepo.createConversation(registryOrg.UUID, conversation, requestingUser, isSecretariat, { options })
       }
       updatedRegistryOrg = _.merge(registryOrg, _.omit(registryObjectRaw, jointApprovalFieldsRegistry))
       updatedLegacyOrg = _.merge(legacyOrg, _.omit(legacyObjectRaw, jointApprovalFieldsLegacy))

--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -709,11 +709,10 @@ class BaseOrgRepository extends BaseRepository {
     } else {
       // write the joint approval to the database
       jointApprovalRegistry = _.merge({}, registryOrg.toObject(), registryObjectRaw)
-      let updatedReviewObj
       if (reviewObject) {
-        updatedReviewObj = await reviewObjectRepo.updateReviewOrgObject(jointApprovalRegistry, reviewObject.uuid, { options })
+        await reviewObjectRepo.updateReviewOrgObject(jointApprovalRegistry, reviewObject.uuid, { options })
       } else {
-        updatedReviewObj = await reviewObjectRepo.createReviewOrgObject(jointApprovalRegistry, { options })
+        await reviewObjectRepo.createReviewOrgObject(jointApprovalRegistry, { options })
       }
       // handle conversation
       const requestingUser = await userRepo.findUserByUUID(requestingUserUUID)

--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -716,7 +716,7 @@ class BaseOrgRepository extends BaseRepository {
       }
       // handle conversation
       const requestingUser = await userRepo.findUserByUUID(requestingUserUUID)
-      if (conversation && conversation.length) {
+      if (conversation) {
         await conversationRepo.createConversation(registryOrg.UUID, conversation, requestingUser, isSecretariat, { options })
       }
       updatedRegistryOrg = _.merge(registryOrg, _.omit(registryObjectRaw, jointApprovalFieldsRegistry))

--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -718,7 +718,7 @@ class BaseOrgRepository extends BaseRepository {
       // handle conversation
       const requestingUser = await userRepo.findUserByUUID(requestingUserUUID)
       if (conversation && conversation.length) {
-        await conversationRepo.processConversationHistory(conversation, updatedReviewObj.uuid, requestingUser, isSecretariat, { options })
+        await conversationRepo.processConversationHistory(conversation, registryOrg.UUID, requestingUser, isSecretariat, { options })
       }
       updatedRegistryOrg = _.merge(registryOrg, _.omit(registryObjectRaw, jointApprovalFieldsRegistry))
       updatedLegacyOrg = _.merge(legacyOrg, _.omit(legacyObjectRaw, jointApprovalFieldsLegacy))

--- a/src/repositories/conversationRepository.js
+++ b/src/repositories/conversationRepository.js
@@ -1,7 +1,6 @@
 const uuid = require('uuid')
 const ConversationModel = require('../model/conversation')
 const BaseRepository = require('./baseRepository')
-const utils = require('../utils/utils')
 
 class ConversationRepository extends BaseRepository {
   constructor () {
@@ -42,22 +41,23 @@ class ConversationRepository extends BaseRepository {
   }
 
   async createConversation (targetUUID, body, user, isSecretariat, options = {}) {
+    const { getUserFullName } = require('../utils/utils')
     const newUUID = uuid.v4()
     // Find latest message in chain for target
-    const latestConversation = await ConversationModel.find({ target_uuid: targetUUID, next_conversation_uuid: null }, null, options)
+    const latestConversation = await ConversationModel.findOne({ target_uuid: targetUUID, next_conversation_uuid: null }, null, options)
     if (latestConversation) {
       latestConversation.next_conversation_uuid = newUUID
-      await latestConversation.save(options)
+      await latestConversation.save({ options })
     }
     const conversationObj = {
       UUID: newUUID,
       target_uuid: targetUUID,
-      previous_conversation_uuid: latestConversation?.UUID,
+      previous_conversation_uuid: latestConversation?.UUID || null,
       next_conversation_uuid: null,
       author_id: user.UUID,
-      author_name: utils.getUserFullName(user),
+      author_name: getUserFullName(user),
       author_role: isSecretariat ? 'Secretariat' : 'Partner',
-      visibility: !isSecretariat ? 'public' : (['public', 'private'].includes(body.visibility.toLowerCase()) ? body.visibility.toLowerCase() : 'private'),
+      visibility: !isSecretariat ? 'public' : (['public', 'private'].includes(body.visibility?.toLowerCase()) ? body.visibility.toLowerCase() : 'private'),
       body: body.body
     }
     const newConversation = new ConversationModel(conversationObj)

--- a/src/repositories/conversationRepository.js
+++ b/src/repositories/conversationRepository.js
@@ -1,6 +1,7 @@
 const uuid = require('uuid')
 const ConversationModel = require('../model/conversation')
 const BaseRepository = require('./baseRepository')
+const utils = require('../utils/utils')
 
 class ConversationRepository extends BaseRepository {
   constructor () {
@@ -40,45 +41,28 @@ class ConversationRepository extends BaseRepository {
     return conversations.map(convo => convo.toObject()).filter(conv => isSecretariat || conv.visibility === 'public')
   }
 
-  async createConversation (body, options = {}) {
-    body.UUID = uuid.v4()
-    const newConversation = new ConversationModel(body)
+  async createConversation (targetUUID, body, user, isSecretariat, options = {}) {
+    const newUUID = uuid.v4()
+    // Find latest message in chain for target
+    const latestConversation = await ConversationModel.find({ target_uuid: targetUUID, next_conversation_uuid: null }, null, options)
+    if (latestConversation) {
+      latestConversation.next_conversation_uuid = newUUID
+      await latestConversation.save(options)
+    }
+    const conversationObj = {
+      UUID: newUUID,
+      target_uuid: targetUUID,
+      previous_conversation_uuid: latestConversation?.UUID,
+      next_conversation_uuid: null,
+      author_id: user.UUID,
+      author_name: utils.getUserFullName(user),
+      author_role: isSecretariat ? 'Secretariat' : 'Partner',
+      visibility: !isSecretariat ? 'public' : (['public', 'private'].includes(body.visibility.toLowerCase()) ? body.visibility.toLowerCase() : 'private'),
+      body: body.body
+    }
+    const newConversation = new ConversationModel(conversationObj)
     const result = await newConversation.save(options)
     return result.toObject()
-  }
-
-  async updateConversation (body, UUID, options = {}) {
-    const conversation = await this.findOneByUUID(UUID)
-
-    // Only allow updates to message body for now
-    conversation.body = body.body
-
-    const result = await conversation.save(options)
-    return result.toObject()
-  }
-
-  // Takes in a list of conversations representing the conversation history for
-  // an org and creates/updates the objects as necessary
-  async processConversationHistory (conversationList, targetUUID, user, isSecretariat, options = {}) {
-    const promises = conversationList.map(convo => {
-      return (async () => {
-        const populatedConvo = {
-          UUID: convo.UUID || undefined,
-          author_id: convo.author_id || user.UUID,
-          author_name: convo.author_name || (isSecretariat ? 'Secretariat' : [user.name?.first, user.name?.last].join(' ')),
-          author_role: convo.author_role || (isSecretariat ? 'Secretariat' : 'Partner'),
-          visibility: !isSecretariat ? 'public' : (convo.visibility || 'private'),
-          body: convo.body
-        }
-        if (populatedConvo.UUID) return await this.updateConversation(populatedConvo, populatedConvo.UUID, options)
-        const newConvo = {
-          ...populatedConvo,
-          target_uuid: targetUUID
-        }
-        return await this.createConversation(newConvo, options)
-      })()
-    })
-    return await Promise.all(promises)
   }
 }
 

--- a/src/repositories/conversationRepository.js
+++ b/src/repositories/conversationRepository.js
@@ -35,9 +35,9 @@ class ConversationRepository extends BaseRepository {
     return data
   }
 
-  async getAllByTargetUUID (targetUUID, options = {}) {
+  async getAllByTargetUUID (targetUUID, isSecretariat, options = {}) {
     const conversations = await ConversationModel.find({ target_uuid: targetUUID }, null, options)
-    return conversations.map(convo => convo.toObject())
+    return conversations.map(convo => convo.toObject()).filter(conv => isSecretariat || conv.visibility === 'public')
   }
 
   async createConversation (body, options = {}) {

--- a/src/repositories/reviewObjectRepository.js
+++ b/src/repositories/reviewObjectRepository.js
@@ -28,8 +28,8 @@ class ReviewObjectRepository extends BaseRepository {
     const reviewObjectRaw = await ReviewObjectModel.findOne({ uuid: UUID }, null, options)
     if (reviewObjectRaw) {
       reviewObject = reviewObjectRaw.toObject()
-      const conversations = await conversationRepository.getAllByTargetUUID(reviewObject.uuid)
-      if (conversations && conversations.length) reviewObject.conversation = conversations.filter(conv => isSecretariat || conv.visibility === 'public')
+      const conversations = await conversationRepository.getAllByTargetUUID(reviewObject.target_object_uuid, isSecretariat, options)
+      reviewObject.conversation = conversations?.length ? conversations : undefined
     }
 
     return reviewObject || null
@@ -63,8 +63,8 @@ class ReviewObjectRepository extends BaseRepository {
     const reviewObjectRaw = await ReviewObjectModel.findOne({ target_object_uuid: org.UUID }, null, options)
     if (reviewObjectRaw) {
       reviewObject = reviewObjectRaw.toObject()
-      const conversations = await conversationRepository.getAllByTargetUUID(reviewObject.uuid)
-      if (conversations.length) reviewObject.conversation = conversations.filter(conv => isSecretariat || conv.visibility === 'public')
+      const conversations = await conversationRepository.getAllByTargetUUID(org.UUID, isSecretariat, options)
+      reviewObject.conversation = conversations?.length ? conversations : undefined
     }
 
     return reviewObject || null
@@ -82,8 +82,8 @@ class ReviewObjectRepository extends BaseRepository {
     const reviewObjectRaw = await ReviewObjectModel.findOne({ target_object_uuid: org.UUID }, null, options)
     if (reviewObjectRaw) {
       reviewObject = reviewObjectRaw.toObject()
-      const conversations = await conversationRepository.getAllByTargetUUID(reviewObject.uuid)
-      if (conversations.length) reviewObject.conversation = conversations.filter(conv => isSecretariat || conv.visibility === 'public')
+      const conversations = await conversationRepository.getAllByTargetUUID(org.UUID, isSecretariat, options)
+      reviewObject.conversation = conversations?.length ? conversations : undefined
     }
 
     return reviewObject || null

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -48,6 +48,14 @@ async function getUserUUID (userIdentifier, orgUUID, useRegistry = false, option
   }
 }
 
+async function getUserFullName (user) {
+  if (!user.name) return 'Unknown User'
+  if (!user.name.first && !user.name.last) return 'Unknown User'
+  else if (!user.name.first) return `Unknown ${user.name.last}`
+  else if (!user.name.last) return `${user.name.first} Unknown`
+  else return `${user.name.first} ${user.name.last}`
+}
+
 async function isSecretariat (shortName, useRegistry = false, options = {}) {
   let result = false
   let orgUUID = null
@@ -316,9 +324,9 @@ module.exports = {
   isEnrichedContainer,
   getOrgUUID,
   getUserUUID,
+  getUserFullName,
   reqCtxMapping,
   booleanIsTrue,
   toDate,
   convertDatesToISO
-
 }

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -48,7 +48,7 @@ async function getUserUUID (userIdentifier, orgUUID, useRegistry = false, option
   }
 }
 
-async function getUserFullName (user) {
+function getUserFullName (user) {
   if (!user.name) return 'Unknown User'
   if (!user.name.first && !user.name.last) return 'Unknown User'
   else if (!user.name.first) return `Unknown ${user.name.last}`

--- a/test/integration-tests/conversation/conversationTest.js
+++ b/test/integration-tests/conversation/conversationTest.js
@@ -9,22 +9,33 @@ const app = require('../../../src/index.js')
 
 describe('Testing Conversation endpoints', () => {
   let orgUUID
-  let conversationUUID
+  let secUserUUID
+  let rootConvoUUID
 
   before(async () => {
     await chai
       .request(app)
-      .get('/api/org/win_5')
+      .get('/api/registry/org/win_5')
       .set(constants.headers)
       .then((res, err) => {
         expect(err).to.be.undefined
         expect(res).to.have.status(200)
         orgUUID = res.body.UUID
       })
+
+    await chai
+      .request(app)
+      .get('/api/registry/org/mitre/user/test_secretariat_0@mitre.org')
+      .set(constants.headers)
+      .then((res, err) => {
+        expect(err).to.be.undefined
+        expect(res).to.have.status(200)
+        secUserUUID = res.body.UUID
+      })
   })
 
   context('Positive Tests', () => {
-    it('Should create a conversation', async () => {
+    it('Should create a public conversation as Secretariat', async () => {
       const conversation = {
         visibility: 'public',
         body: 'test'
@@ -38,13 +49,21 @@ describe('Testing Conversation endpoints', () => {
           expect(res).to.have.status(200)
 
           expect(res.body).to.haveOwnProperty('UUID')
-          conversationUUID = res.body.UUID
+          rootConvoUUID = res.body.UUID
 
           expect(res.body).to.haveOwnProperty('target_uuid')
           expect(res.body.target_uuid).to.equal(orgUUID)
 
+          expect(res.body).to.haveOwnProperty('previous_conversation_uuid')
+          expect(res.body.previous_conversation_uuid).to.be.null
+          expect(res.body).to.haveOwnProperty('next_conversation_uuid')
+          expect(res.body.next_conversation_uuid).to.be.null
+
           expect(res.body).to.haveOwnProperty('author_id')
+          expect(res.body.author_id).to.equal(secUserUUID)
+
           expect(res.body).to.haveOwnProperty('author_name')
+          expect(res.body.author_name).to.equal('Unknown User')
 
           expect(res.body).to.haveOwnProperty('author_role')
           expect(res.body.author_role).to.equal('Secretariat')
@@ -56,6 +75,47 @@ describe('Testing Conversation endpoints', () => {
           expect(res.body.body).to.equal('test')
         })
     })
+    it('Should append a private conversation as Secretariat', async () => {
+      const conversation = {
+        visibility: 'private',
+        body: 'test 2'
+      }
+      const res = await chai
+        .request(app)
+        .post(`/api/conversation/target/${orgUUID}`)
+        .set(constants.headers)
+        .send(conversation)
+
+      expect(res).to.have.status(200)
+
+      expect(res.body).to.haveOwnProperty('UUID')
+      const secondUUID = res.body.UUID
+
+      expect(res.body).to.haveOwnProperty('target_uuid')
+      expect(res.body.target_uuid).to.equal(orgUUID)
+
+      expect(res.body).to.haveOwnProperty('visibility')
+      expect(res.body.visibility).to.equal('private')
+
+      const convoRes = await chai.request(app)
+        .get(`/api/conversation/target/${orgUUID}`)
+        .set(constants.headers)
+
+      expect(convoRes).to.have.status(200)
+
+      expect(convoRes.body).to.be.an('array')
+      expect(convoRes.body).to.have.lengthOf(2)
+
+      const rootMessage = convoRes.body.filter(convo => convo.UUID === rootConvoUUID)[0]
+      expect(rootMessage).to.exist
+      expect(rootMessage.previous_conversation_uuid).to.be.null
+      expect(rootMessage.next_conversation_uuid).to.be.equal(secondUUID)
+
+      expect(res.body).to.haveOwnProperty('previous_conversation_uuid')
+      expect(res.body.previous_conversation_uuid).to.be.equal(rootConvoUUID)
+      expect(res.body).to.haveOwnProperty('next_conversation_uuid')
+      expect(res.body.next_conversation_uuid).to.be.null
+    })
     it('Should get all conversations', async () => {
       await chai.request(app)
         .get('/api/conversation')
@@ -66,10 +126,10 @@ describe('Testing Conversation endpoints', () => {
 
           expect(res.body).to.haveOwnProperty('conversations')
           expect(res.body.conversations).to.be.an('array')
-          expect(res.body.conversations).to.have.lengthOf(1)
+          expect(res.body.conversations).to.have.lengthOf(2)
         })
     })
-    it('Should get all conversations for target UUID', async () => {
+    it('Should get and see all conversations for target UUID as Secretariat', async () => {
       await chai.request(app)
         .get(`/api/conversation/target/${orgUUID}`)
         .set(constants.headers)
@@ -78,27 +138,11 @@ describe('Testing Conversation endpoints', () => {
           expect(res).to.have.status(200)
 
           expect(res.body).to.be.an('array')
-          expect(res.body).to.have.lengthOf(1)
-          expect(res.body[0]).to.haveOwnProperty('target_uuid')
-          expect(res.body[0].target_uuid).to.equal(orgUUID)
-        })
-    })
-    it('Should update the message for a conversation', async () => {
-      const updateBody = {
-        body: 'test update'
-      }
-      await chai.request(app)
-        .put(`/api/conversation/${conversationUUID}/message`)
-        .set(constants.headers)
-        .send(updateBody)
-        .then((res, err) => {
-          expect(err).to.be.undefined
-          expect(res).to.have.status(200)
-
-          expect(res.body).to.haveOwnProperty('UUID')
-          expect(res.body.UUID).to.equal(conversationUUID)
-          expect(res.body).to.haveOwnProperty('body')
-          expect(res.body.body).to.equal('test update')
+          expect(res.body).to.have.lengthOf(2)
+          res.body.forEach(convo => {
+            expect(convo).to.haveOwnProperty('target_uuid')
+            expect(convo.target_uuid).to.equal(orgUUID)
+          })
         })
     })
   })
@@ -107,19 +151,6 @@ describe('Testing Conversation endpoints', () => {
     it('Should fail to post a conversation with no body', async () => {
       await chai.request(app)
         .post(`/api/conversation/target/${orgUUID}`)
-        .set(constants.headers)
-        .send({})
-        .then((res, err) => {
-          expect(err).to.be.undefined
-          expect(res).to.have.status(400)
-
-          expect(res.body).to.haveOwnProperty('message')
-          expect(res.body.message).to.equal('Missing required field body')
-        })
-    })
-    it('Should fail to update a conversation message with no body', async () => {
-      await chai.request(app)
-        .put(`/api/conversation/${conversationUUID}/message`)
         .set(constants.headers)
         .send({})
         .then((res, err) => {

--- a/test/integration-tests/registry-org/registryOrgWithJointReviewTest.js
+++ b/test/integration-tests/registry-org/registryOrgWithJointReviewTest.js
@@ -252,7 +252,7 @@ describe('Testing Joint approval', () => {
     })
     it('Secretariat leaves a public comment on the org review', async () => {
       await chai.request(app)
-        .post(`/api/conversation/target/${reviewUUID}`)
+        .post(`/api/conversation/target/${orgUUID}`)
         .set(secretariatHeaders)
         .send({
           visibility: 'public',
@@ -266,9 +266,9 @@ describe('Testing Joint approval', () => {
           expect(res.body.body).to.equal('This is a comment left by the secretariat.')
         })
     })
-    it('Secretariat leaves a private on the org review', async () => {
+    it('Secretariat leaves a private comment on the org review', async () => {
       await chai.request(app)
-        .post(`/api/conversation/target/${reviewUUID}`)
+        .post(`/api/conversation/target/${orgUUID}`)
         .set(secretariatHeaders)
         .send({
           visibility: 'private',


### PR DESCRIPTION
Closes Issues #1603, #1604, #1605, #1607

# Summary
Refactors conversations to be targeted to organizations, not reviews. Makes conversations append-only with a linked-list structure.

# Important Changes
`src/controller/conversation.controller/conversation.controller.js`, `src/controller/conversation.controller/index.js`
- Removed endpoint for updating conversations.

`src/controller/registry-org.controller/registry-org.controller.js`
- Attach conversations to return object when calling get org endpoints

`src/model/conversation.js`
- Added `previous_conversation_uuid` and `next_conversation_uuid` for linked list structure

`src/repositories/conversationRepository.js`
- Refactored logic to create and append conversations

`src/utils/utils.js`
- Added util function for safely constructing a user's full name

`test/integration-tests/conversation/conversationTest.js`
- Updated integration tests for conversation endpoints

# Testing

- [ ] 1) Ensure that secretariat can hit all secretariat-only conversation CRUD endpoints (get all, get for target org, post for target org)
- [ ] 2) Ensure that secretariat and org admins can include conversations in org updates and that those conversations are properly created/appended, and reflect the correct visibility status.
- [ ] 3) Ensure that conversations are properly attached to the return object when hitting GET org endpoints, and that secretariat can view all conversations for an org and org admins can only view public conversations for an org.

