### PR TITLE
#1644 - Fixed mongoose options objects being double wrapped

### DIFF
--- a/src/repositories/auditRepository.js
+++ b/src/repositories/auditRepository.js
@@ -27,7 +27,7 @@ class AuditRepository extends BaseRepository {
 
     try {
     // Try to find existing document
-      let audit = await this.findOneByTargetUUID(targetUUID, { options })
+      let audit = await this.findOneByTargetUUID(targetUUID, options)
       if (!audit) {
       // Create new document if doesn't exist
       // Assuming 'uuid' is available for generating a new UUID
@@ -41,7 +41,7 @@ class AuditRepository extends BaseRepository {
         audit.history.push(historyEntry)
       }
 
-      await audit.save({ options })
+      await audit.save(options)
       return audit.toObject()
     } catch (error) {
       throw new Error('Failed to save audit history entry.')

--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -377,7 +377,7 @@ class BaseOrgRepository extends BaseRepository {
       if (isSecretariat) {
         registryObject = await SecretariatObjectToSave.save(options)
       } else {
-        await reviewObjectRepo.createReviewOrgObject(registryObjectRaw, { options })
+        await reviewObjectRepo.createReviewOrgObject(registryObjectRaw, options)
       }
     } else if (registryObjectRaw.authority.includes('CNA')) {
       // A special case, we should make sure we have the default quota if it is not set
@@ -391,7 +391,7 @@ class BaseOrgRepository extends BaseRepository {
       if (isSecretariat) {
         registryObject = await CNAObjectToSave.save(options)
       } else {
-        await reviewObjectRepo.createReviewOrgObject(registryObjectRaw, { options })
+        await reviewObjectRepo.createReviewOrgObject(registryObjectRaw, options)
       }
     } else if (registryObjectRaw.authority.includes('ADP')) {
       registryObjectRaw.hard_quota = 0
@@ -399,7 +399,7 @@ class BaseOrgRepository extends BaseRepository {
       if (isSecretariat) {
         registryObject = await adpObjectToSave.save(options)
       } else {
-        await reviewObjectRepo.createReviewOrgObject(registryObjectRaw, { options })
+        await reviewObjectRepo.createReviewOrgObject(registryObjectRaw, options)
       }
     } else if (registryObjectRaw.authority.includes('BULK_DOWNLOAD')) {
       registryObjectRaw.hard_quota = 0
@@ -407,7 +407,7 @@ class BaseOrgRepository extends BaseRepository {
       if (isSecretariat) {
         registryObject = await bulkDownloadObjectToSave.save(options)
       } else {
-        await reviewObjectRepo.createReviewOrgObject(registryObjectRaw, { options })
+        await reviewObjectRepo.createReviewOrgObject(registryObjectRaw, options)
       }
     } else {
       // Throw an Error instance so callers can catch and handle it properly
@@ -658,8 +658,8 @@ class BaseOrgRepository extends BaseRepository {
     }
 
     // Save changes
-    await legacyOrg.save({ options })
-    await registryOrg.save({ options })
+    await legacyOrg.save(options)
+    await registryOrg.save(options)
     if (isLegacyObject) {
       const plainJavascriptLegacyOrg = legacyOrg.toObject()
       delete plainJavascriptLegacyOrg.__v
@@ -772,14 +772,14 @@ class BaseOrgRepository extends BaseRepository {
         // write the joint approval to the database
         jointApprovalRegistry = _.merge({}, registryOrg.toObject(), registryObjectRaw)
         if (reviewObject) {
-          await reviewObjectRepo.updateReviewOrgObject(jointApprovalRegistry, reviewObject.uuid, { options })
+          await reviewObjectRepo.updateReviewOrgObject(jointApprovalRegistry, reviewObject.uuid, options)
         } else {
-          await reviewObjectRepo.createReviewOrgObject(jointApprovalRegistry, { options })
+          await reviewObjectRepo.createReviewOrgObject(jointApprovalRegistry, options)
         }
       } else {
         // If no changes between org and new object but a review object exists, remove it since joint approval is no longer needed
         if (reviewObject) {
-          await reviewObjectRepo.rejectReviewOrgObject(reviewObject.uuid, { options })
+          await reviewObjectRepo.rejectReviewOrgObject(reviewObject.uuid, options)
         }
       }
       updatedRegistryOrg = _.merge(registryOrg, _.omit(registryObjectRaw, jointApprovalFieldsRegistry))
@@ -789,7 +789,7 @@ class BaseOrgRepository extends BaseRepository {
     // handle conversation
     const requestingUser = await userRepo.findUserByUUID(requestingUserUUID, options)
     if (conversation) {
-      await conversationRepo.createConversation(registryOrg.UUID, conversation, requestingUser, isSecretariat, { options })
+      await conversationRepo.createConversation(registryOrg.UUID, conversation, requestingUser, isSecretariat, options)
     }
 
     // ADD AUDIT ENTRY AUTOMATICALLY for the registry object before it gets saved.

--- a/src/repositories/baseUserRepository.js
+++ b/src/repositories/baseUserRepository.js
@@ -209,7 +209,7 @@ class BaseUserRepository extends BaseRepository {
       if (Array.isArray(org.admins)) {
         org.admins = org.admins.filter(a => a !== uuid)
       }
-      await org.save({ options })
+      await org.save(options)
     }
 
     return deleteResult.deletedCount
@@ -440,7 +440,7 @@ class BaseUserRepository extends BaseRepository {
     if (rolesToAdd.includes('ADMIN') && !incomingParameters?.org_short_name) {
       const orgUpdates = await baseOrgRepository.getOrgObject(orgShortname)
       orgUpdates.admins = [..._.get(orgUpdates, 'admins', []), registryUser.UUID]
-      await orgUpdates.save({ options })
+      await orgUpdates.save(options)
     }
 
     const initialRoles = legacyUser.authority?.active_roles ?? []
@@ -461,12 +461,12 @@ class BaseUserRepository extends BaseRepository {
       }
 
       legacyUser.org_UUID = newOrg.UUID
-      await registryOrg.save({ options })
-      await newOrg.save({ options })
+      await registryOrg.save(options)
+      await newOrg.save(options)
     }
 
-    await legacyUser.save({ options })
-    await registryUser.save({ options })
+    await legacyUser.save(options)
+    await registryUser.save(options)
 
     if (!isRegistryObject) {
       const plainJavascriptLegacyUser = legacyUser.toObject()
@@ -560,12 +560,12 @@ class BaseUserRepository extends BaseRepository {
         updatedLegacyUser.org_UUID = newOrg.UUID
 
         // Save org changes
-        await currentOrg.save({ options })
-        await newOrg.save({ options })
+        await currentOrg.save(options)
+        await newOrg.save(options)
       }
 
-      await updatedLegacyUser.save({ options })
-      await updatedRegistryUser.save({ options })
+      await updatedLegacyUser.save(options)
+      await updatedRegistryUser.save(options)
     } catch (error) {
       throw new Error('Failed to update user: ' + error.message)
     }
@@ -610,8 +610,8 @@ class BaseUserRepository extends BaseRepository {
     const secret = await argon2.hash(randomKey)
     legUser.secret = secret
     regUser.secret = secret
-    await legUser.save({ options })
-    await regUser.save({ options })
+    await legUser.save(options)
+    await regUser.save(options)
 
     return randomKey
   }

--- a/src/repositories/conversationRepository.js
+++ b/src/repositories/conversationRepository.js
@@ -47,7 +47,7 @@ class ConversationRepository extends BaseRepository {
     const latestConversation = await ConversationModel.findOne({ target_uuid: targetUUID, next_conversation_uuid: null }, null, options)
     if (latestConversation) {
       latestConversation.next_conversation_uuid = newUUID
-      await latestConversation.save({ options })
+      await latestConversation.save(options)
     }
     const conversationObj = {
       UUID: newUUID,

--- a/src/repositories/reviewObjectRepository.js
+++ b/src/repositories/reviewObjectRepository.js
@@ -146,7 +146,7 @@ class ReviewObjectRepository extends BaseRepository {
     }
 
     const reviewObject = new ReviewObjectModel(reviewObjectRaw)
-    await reviewObject.save({ options })
+    await reviewObject.save(options)
     return reviewObject.toObject()
   }
 
@@ -159,7 +159,7 @@ class ReviewObjectRepository extends BaseRepository {
 
     reviewObject.new_review_data = body
 
-    const result = await reviewObject.save({ options })
+    const result = await reviewObject.save(options)
     return result.toObject()
   }
 


### PR DESCRIPTION
Closes Issue #1644

# Summary
There were many places where options objects being passed to mongoose functions were being erroneously wrapped in an outer object, causing session/transaction execution to be skipped. This fix corrects those instances.

# Important Changes
- Fixed all places where mongoose options objects were being double wrapped.

