### PR TITLE
DRAFT: Closes: #1685 and #1687

### DIFF
--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -945,6 +945,10 @@ class BaseOrgRepository extends BaseRepository {
    * @returns {object} The validation result object.
    */
   validateOrg (org) {
+    if (!org.authority || (Array.isArray(org.authority) && org.authority.length === 0)) {
+      return { isValid: false, errors: [{ instancePath: '/authority', message: 'authority is required' }] }
+    }
+
     let validateObject = {}
     if (Array.isArray(org.authority)) {
       // User passed in an array, we need to decide how we handle this.

--- a/test/integration-tests/audit/registryOrgCreatesAuditTest.js
+++ b/test/integration-tests/audit/registryOrgCreatesAuditTest.js
@@ -114,6 +114,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
       .send({
         short_name: org.shortName,
         hard_quota: 1500,
+        authority: ['CNA'],
         long_name: org.longName
       })
     expect(updateResAgain).to.have.status(200)
@@ -140,6 +141,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
       .send({
         long_name: testOrg.longName,
         short_name: testOrg.shortName,
+        authority: ['CNA'],
         hard_quota: 100
       })
 
@@ -171,6 +173,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
       .send({
         short_name: testOrg.shortName,
         long_name: testOrg.longName,
+        authority: ['CNA'],
         hard_quota: 2000
       })
     expect(updatedRes1).to.have.status(200)
@@ -181,6 +184,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
       .send({
         short_name: testOrg.shortName,
         long_name: testOrg.longName,
+        authority: ['CNA'],
         hard_quota: 3000
       })
     expect(updatedRes2).to.have.status(200)
@@ -191,6 +195,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
       .send({
         short_name: testOrg.shortName,
         long_name: testOrg.longName,
+        authority: ['CNA'],
         hard_quota: 4000
       })
     expect(updatedRes3).to.have.status(200)

--- a/test/integration-tests/org/registryOrg.js
+++ b/test/integration-tests/org/registryOrg.js
@@ -20,6 +20,7 @@ const postNewOrg = async (shortName, name, quota = 1000) => {
     .send({
       short_name: shortName,
       long_name: name,
+      authority: ['CNA'],
       hard_quota: quota
     })
 }
@@ -355,7 +356,7 @@ describe('Testing Secretariat functionality for Orgs', () => {
       await chai.request(app)
         .post('/api/registry/org')
         .set(secretariatHeaders)
-        .send({ long_name: 'MITRE Corporation', short_name: 'mitre', hard_quota: 1000 })
+        .send({ long_name: 'MITRE Corporation', authority: ['SECRETARIAT'], short_name: 'mitre', hard_quota: 1000 })
         .then((res) => {
           expect(res).to.have.status(400)
           expect(res.body.message).to.equal('The \'mitre\' organization already exists.')

--- a/test/integration-tests/registry-org/registryOrgWithJointReviewTest.js
+++ b/test/integration-tests/registry-org/registryOrgWithJointReviewTest.js
@@ -148,7 +148,7 @@ describe('Testing Joint approval', () => {
         })
     })
     it('Secretariat can approve the ORG review with body parameter', async function () {
-      const newBody = { short_name: 'final_non_secretariat_org', hard_quota: 20000, long_name: 'Final Non Secretariat Organization' }
+      const newBody = { short_name: 'final_non_secretariat_org', authority: ['SECRETARIAT'], hard_quota: 20000, long_name: 'Final Non Secretariat Organization' }
       await chai.request(app)
         .put(`/api/review/${reviewUUID}/approve`)
         .set(secretariatHeaders)

--- a/test/integration-tests/review-object/reviewObjectTest.js
+++ b/test/integration-tests/review-object/reviewObjectTest.js
@@ -188,6 +188,7 @@ describe('Review Object Controller Integration Tests', () => {
       updateData.short_name = constants.existingOrg.short_name
       updateData.long_name = 'Approve Test Organization'
       updateData.hard_quota = 123
+      updateData.authority = ['CNA']
       const res = await chai
         .request(app)
         .put(`/api/registry/org/${constants.existingOrg.short_name}`)
@@ -231,6 +232,7 @@ describe('Review Object Controller Integration Tests', () => {
       const updateData = {}
       updateData.short_name = constants.existingOrg.short_name
       updateData.long_name = 'Reject Test Organization'
+      updateData.authority = ['CNA']
       updateData.hard_quota = 456
       const res = await chai
         .request(app)
@@ -285,6 +287,7 @@ describe('Review Object Controller Integration Tests', () => {
       const updateData = {
         short_name: constants.existingOrg.short_name,
         long_name: 'Auto Approve Test Org',
+        authority: ['CNA'],
         hard_quota: 789
       }
       const res = await chai
@@ -310,6 +313,7 @@ describe('Review Object Controller Integration Tests', () => {
       const updateData = {
         short_name: constants.existingOrg.short_name,
         long_name: 'Auto Approve Test Org',
+        authority: ['CNA'],
         hard_quota: 789
       }
       const res = await chai
@@ -334,6 +338,7 @@ describe('Review Object Controller Integration Tests', () => {
       const updateData = {
         short_name: constants.existingOrg.short_name,
         long_name: 'Auto Reject Pending Org',
+        authority: ['CNA'],
         hard_quota: 999
       }
       const res = await chai
@@ -359,6 +364,7 @@ describe('Review Object Controller Integration Tests', () => {
       const updateData = {
         short_name: constants.existingOrg.short_name,
         long_name: 'Test Organization',
+        authority: ['CNA'],
         hard_quota: 111
       }
       const res = await chai


### PR DESCRIPTION
Closes Issues #1685 and #1687

Because the PUT request expects a whole org object, we need to trigger an invalid parameters when it is not passed into the body.