### PR TITLE
Resolves issue #1731, #1733 Fixes Mongoose document replacement failures during user updates and appropriately routes inactive users as unauthenticated.

### DIFF
--- a/src/controller/registry-user.controller/registry-user.controller.js
+++ b/src/controller/registry-user.controller/registry-user.controller.js
@@ -258,17 +258,17 @@ async function updateUser (req, res, next) {
     return res.status(404).json(error.orgDnePathParam(userToEditParameters.org))
   }
 
+  if (body.org_short_name && !isSecretariat) {
+    logger.info({ uuid: req.ctx.uuid, message: 'Only Secretariat can reassign user organization.' })
+    return res.status(403).json(error.notAllowedToChangeOrganization())
+  }
+
   if (body.org_short_name) {
     const targetOrg = await orgRepo.findOneByShortName(body.org_short_name)
     if (!targetOrg) {
       logger.info({ uuid: req.ctx.uuid, message: `Target organization ${body.org_short_name} does not exist.` })
       return res.status(404).json(error.orgDnePathParam(body.org_short_name))
     }
-  }
-
-  if (body.org_short_name && !isSecretariat) {
-    logger.info({ uuid: req.ctx.uuid, message: 'Only Secretariat can reassign user organization.' })
-    return res.status(403).json(error.notAllowedToChangeOrganization())
   }
 
   if (body.org_short_name && isSecretariat && userToEditParameters.org === org.short_name && body.org_short_name === org.short_name) {

--- a/src/controller/registry-user.controller/registry-user.controller.js
+++ b/src/controller/registry-user.controller/registry-user.controller.js
@@ -253,6 +253,18 @@ async function updateUser (req, res, next) {
     : await userRepo.findOneByUsernameAndOrgShortname(userToEditParameters.username, userToEditParameters.org, { session })
 
   const org = await orgRepo.findOneByShortName(userToEditParameters.org)
+  if (!org) {
+    logger.info({ uuid: req.ctx.uuid, message: `Target organization ${userToEditParameters.org} does not exist.` })
+    return res.status(404).json(error.orgDnePathParam(userToEditParameters.org))
+  }
+
+  if (body.org_short_name) {
+    const targetOrg = await orgRepo.findOneByShortName(body.org_short_name)
+    if (!targetOrg) {
+      logger.info({ uuid: req.ctx.uuid, message: `Target organization ${body.org_short_name} does not exist.` })
+      return res.status(404).json(error.orgDnePathParam(body.org_short_name))
+    }
+  }
 
   if (body.org_short_name && !isSecretariat) {
     logger.info({ uuid: req.ctx.uuid, message: 'Only Secretariat can reassign user organization.' })

--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -61,7 +61,7 @@ async function optionallyValidateUser (req, res, next) {
         authenticated = false
       } else {
         result = await userRepo.findOneByUserNameAndOrgUUID(user, orgUUID)
-        if (!result || !result.active) {
+        if (!result || result.status === 'inactive') {
           authenticated = false
         } else {
           const isPwd = await argon2.verify(result.secret, key)
@@ -133,7 +133,7 @@ async function validateUser (req, res, next) {
       return res.status(401).json(error.unauthorized())
     }
 
-    if (result.active === false || result.status === 'inactive') {
+    if (result.status === 'inactive') {
       logger.warn(JSON.stringify({ uuid: req.ctx.uuid, message: 'User deactivated. Authentication failed for ' + user }))
       return res.status(401).json(error.unauthorized())
     }

--- a/src/repositories/baseUserRepository.js
+++ b/src/repositories/baseUserRepository.js
@@ -7,8 +7,15 @@ const BaseOrgModel = require('../model/baseorg')
 const RegistryUser = require('../model/registryuser')
 const cryptoRandomString = require('crypto-random-string')
 const UserRepository = require('./userRepository')
-const _ = require('lodash')
 const getConstants = require('../constants').getConstants
+const _ = require('lodash')
+
+const skipNulls = (objValue, srcValue) => {
+  if (_.isArray(objValue)) {
+    return srcValue
+  }
+  return undefined
+}
 
 /**
  * @function setAggregateUserObj
@@ -514,19 +521,23 @@ class BaseUserRepository extends BaseRepository {
       throw new Error('Legacy user not found')
     }
 
+    const { ...incomingUserBody } = incomingUser
     let legacyObjectRaw
     let registryObjectRaw
 
     if (!isRegistryObject) {
-      legacyObjectRaw = incomingUser
-      registryObjectRaw = this.convertLegacyToRegistry(incomingUser)
+      legacyObjectRaw = incomingUserBody
+      registryObjectRaw = this.convertLegacyToRegistry(incomingUserBody)
     } else {
-      registryObjectRaw = incomingUser
-      legacyObjectRaw = this.convertRegistryToLegacy(incomingUser)
+      registryObjectRaw = incomingUserBody
+      legacyObjectRaw = this.convertRegistryToLegacy(incomingUserBody)
     }
 
-    const updatedLegacyUser = _.merge(legacyUser, legacyObjectRaw)
-    const updatedRegistryUser = _.merge(registryUser, registryObjectRaw)
+    const protectedFieldsRegistry = ['_id', 'UUID', '__v', 'secret', 'created', 'last_updated']
+    const protectedFieldsLegacy = ['_id', 'UUID', '__v', 'secret', 'time', 'org_UUID']
+
+    const updatedRegistryUser = registryUser.overwrite(_.mergeWith(_.pick(registryUser.toObject(), protectedFieldsRegistry), registryObjectRaw, skipNulls))
+    const updatedLegacyUser = legacyUser.overwrite(_.mergeWith(_.pick(legacyUser.toObject(), protectedFieldsLegacy), legacyObjectRaw, skipNulls))
 
     try {
       if (incomingUser.org_short_name) {

--- a/test/integration-tests/cve-id/getCveIdTest.js
+++ b/test/integration-tests/cve-id/getCveIdTest.js
@@ -188,6 +188,53 @@ describe('Testing Get CVE-ID endpoint', () => {
           expect(cveIdObject.requested_by.user).to.equal(constants.nonSecretariatUserHeaders['CVE-API-USER'])
         })
     })
+    it('For Secretariat users, should return full information when getting a single RESERVED CVE ID', async () => {
+      const cveId = await helpers.cveIdReserveHelper(1, '2023', constants.nonSecretariatUserHeaders['CVE-API-ORG'], 'non-sequential')
+
+      await chai.request(app)
+        .get(`/api/cve-id/${cveId}`)
+        .set(constants.headers)
+        .then(async (res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.cve_id).to.equal(cveId)
+          expect(res.body.state).to.equal('RESERVED')
+          // Secretariat user should see owning org details
+          expect(res.body.owning_cna).to.equal(constants.nonSecretariatUserHeaders['CVE-API-ORG'])
+        })
+    })
+
+    it('For owning CNA users, should return full information when getting a single RESERVED CVE ID', async () => {
+      const cveId = await helpers.cveIdReserveHelper(1, '2023', constants.nonSecretariatUserHeaders['CVE-API-ORG'], 'non-sequential')
+
+      await chai.request(app)
+        .get(`/api/cve-id/${cveId}`)
+        .set(constants.nonSecretariatUserHeaders)
+        .then(async (res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.cve_id).to.equal(cveId)
+          expect(res.body.state).to.equal('RESERVED')
+          // Non-secretariat user from owning org should see owning org details
+          expect(res.body.owning_cna).to.equal(constants.nonSecretariatUserHeaders['CVE-API-ORG'])
+        })
+    })
+
+    it('For non-owning CNA users, should return partial information and redacted owning_cna when getting a single RESERVED CVE ID', async function () {
+      const cveId = await helpers.cveIdReserveHelper(1, '2023', constants.nonSecretariatUserHeaders['CVE-API-ORG'], 'non-sequential')
+
+      await chai.request(app)
+        .get(`/api/cve-id/${cveId}`)
+        .set(constants.nonSecretariatUserHeaders3) // evidence_15
+        .then(async (res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.cve_id).to.equal(cveId)
+          expect(res.body.state).to.equal('RESERVED')
+          expect(res.body.owning_cna).to.equal('[REDACTED]')
+          expect(res.body).to.not.have.property('requested_by')
+        })
+    })
   })
   context('negative tests', () => {
     it('Feb 29 2100 should not be valid', async () => {

--- a/test/integration-tests/cve-id/getCveIdTest.js
+++ b/test/integration-tests/cve-id/getCveIdTest.js
@@ -237,6 +237,43 @@ describe('Testing Get CVE-ID endpoint', () => {
     })
   })
   context('negative tests', () => {
+    it('An inactive user should be treated as unauthenticated for optionallyValidateUser endpoints (GET /api/cve-id/:id)', async function () {
+      const cveId = await helpers.cveIdReserveHelper(1, '2023', constants.nonSecretariatUserHeaders['CVE-API-ORG'], 'non-sequential')
+
+      // Deactivate user
+      await helpers.userDeactivateAsSecHelper(constants.nonSecretariatUserHeaders['CVE-API-USER'], constants.nonSecretariatUserHeaders['CVE-API-ORG'])
+
+      await chai.request(app)
+        .get(`/api/cve-id/${cveId}`)
+        .set(constants.nonSecretariatUserHeaders)
+        .then(async (res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.cve_id).to.equal(cveId)
+          expect(res.body.owning_cna).to.equal('[REDACTED]') // Should be redacted because user is treated as unauthenticated
+
+          // Reactivate user for other tests
+          await helpers.userReactivateAsSecHelper(constants.nonSecretariatUserHeaders['CVE-API-USER'], constants.nonSecretariatUserHeaders['CVE-API-ORG'])
+        })
+    })
+
+    it('An inactive user should be denied access for validateUser endpoints (GET /api/cve-id)', async function () {
+      // Deactivate user
+      await helpers.userDeactivateAsSecHelper(constants.nonSecretariatUserHeaders['CVE-API-USER'], constants.nonSecretariatUserHeaders['CVE-API-ORG'])
+
+      await chai.request(app)
+        .get('/api/cve-id')
+        .set(constants.nonSecretariatUserHeaders)
+        .then(async (res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(401)
+          expect(res.body.error).to.equal('UNAUTHORIZED')
+
+          // Reactivate user for other tests
+          await helpers.userReactivateAsSecHelper(constants.nonSecretariatUserHeaders['CVE-API-USER'], constants.nonSecretariatUserHeaders['CVE-API-ORG'])
+        })
+    })
+
     it('Feb 29 2100 should not be valid', async () => {
       await chai.request(app)
         .get('/api/cve-id?time_modified.gt=2100-02-29T00:00:00Z')

--- a/test/integration-tests/helpers.js
+++ b/test/integration-tests/helpers.js
@@ -116,6 +116,40 @@ async function updateOwningOrgAsSecHelper (cveId, newOrgShortName) {
     })
 }
 
+async function userDeactivateAsSecHelper (userName, orgShortName) {
+  const user = await chai.request(app)
+    .get(`/api/registry/org/${orgShortName}/user/${userName}`)
+    .set(constants.headers)
+    .then(res => res.body)
+
+  await chai.request(app)
+    .put(`/api/registry/org/${orgShortName}/user/${userName}`)
+    .set(constants.headers)
+    .send({ ...user, status: 'inactive' })
+    .then((res, err) => {
+      // Safety Expect
+      expect(res).to.have.status(200)
+    })
+}
+
+async function userReactivateAsSecHelper (userName, orgShortName) {
+  const user = await chai.request(app)
+    .get(`/api/registry/org/${orgShortName}/user/${userName}`)
+    .set(constants.headers)
+    .then(res => res.body)
+
+  user.status = 'active'
+
+  await chai.request(app)
+    .put(`/api/registry/org/${orgShortName}/user/${userName}`)
+    .set(constants.headers)
+    .send(user)
+    .then((res, err) => {
+      // Safety Expect
+      expect(res).to.have.status(200)
+    })
+}
+
 module.exports = {
   cveIdReserveHelper,
   cveIdBulkReserveHelper,
@@ -126,5 +160,7 @@ module.exports = {
   cveUpdateAsSecHelper,
   cveUpdateAsCnaHelperWithAdpContainer,
   userOrgUpdateAsSecHelper,
-  updateOwningOrgAsSecHelper
+  updateOwningOrgAsSecHelper,
+  userDeactivateAsSecHelper,
+  userReactivateAsSecHelper
 }

--- a/test/integration-tests/user/updateUserTest.js
+++ b/test/integration-tests/user/updateUserTest.js
@@ -205,5 +205,36 @@ describe('Testing Edit user endpoint', () => {
           expect(res.body.error).to.equal('SECRET_UPDATE_NOT_ALLOWED')
         })
     })
+    it('Should return 404 when target organization in path does not exist', async () => {
+      const user = constants.headers['CVE-API-USER']
+      await chai.request(app)
+        .put(`/api/registry/org/non_existent_org/user/${user}`)
+        .set(constants.headers)
+        .send({
+          name: {
+            first: 'NewFirst',
+            last: 'NewLast'
+          }
+        })
+        .then((res) => {
+          expect(res).to.have.status(404)
+          expect(res.body.error).to.contain('ORG_DNE_PARAM')
+        })
+    })
+
+    it('Should return 404 when target organization in body does not exist', async () => {
+      const user = constants.headers['CVE-API-USER']
+      const org = constants.headers['CVE-API-ORG']
+      await chai.request(app)
+        .put(`/api/registry/org/${org}/user/${user}`)
+        .set(constants.headers)
+        .send({
+          org_short_name: 'non_existent_org'
+        })
+        .then((res) => {
+          expect(res).to.have.status(404)
+          expect(res.body.error).to.contain('ORG_DNE_PARAM')
+        })
+    })
   })
 })

--- a/test/unit-tests/middleware/mockObjects.middleware.js
+++ b/test/unit-tests/middleware/mockObjects.middleware.js
@@ -34,7 +34,8 @@ const existentUser = {
   },
   secret: '$argon2i$v=19$m=4096,t=3,p=1$+qGHEfH5h4/tk404iWBxFw$xV96/b4NvQVvlZIq57wTS8s7gfKzsfMXRiOyf3ffgcw',
   username: 'cpadro',
-  active: true
+  active: true,
+  status: 'active'
 }
 
 const deactivatedUser = {
@@ -49,7 +50,8 @@ const deactivatedUser = {
   },
   secret: '$argon2i$v=19$m=4096,t=3,p=1$+qGHEfH5h4/tk404iWBxFw$xV96/b4NvQVvlZIq57wTS8s7gfKzsfMXRiOyf3ffgcw',
   username: 'flast',
-  active: false
+  active: false,
+  status: 'inactive'
 }
 
 module.exports = {


### PR DESCRIPTION
Closes Issue #1731, #1733

# Summary
This pull request brings robust fixes to how legacy user representations map values during Mongoose `overwrite()` merges. It patches an active exception where replacing the legacy user payload inadvertently dropped the `org_UUID` reference and caused cascade 500 errors. Additionally, it strengthens the system's middleware to actively deny inactive/disabled users, serving them explicitly as unauthenticated identities in optionally-authenticated pipelines.

# Important Changes
`src/repositories/baseUserRepository.js`
- Fixed a bug where `legacyUser.org_UUID` was wiped when calling `overwrite(_.mergeWith(...))` by including `org_UUID` in the `protectedFieldsLegacy` array.
- Refactored `incomingUserBody` pulling logic to safely remap variables for Mongoose operations.

`src/middleware/middleware.js`
- Updated the `validateUser` and `optionallyValidateUser` middleware to correctly intercept `status === 'inactive'`. Inactive users are now accurately rejected with an `401 Unauthorized` or flagged as `authenticated = false` on endpoints allowing optional validation.

`test/integration-tests/cve-id/getCveIdTest.js` & `helpers.js`
- Added comprehensive authentication scoping tests on `GET /api/cve-id/:id` ensuring Secretariat, owning CNA, and non-owning CNA users get accurate visibility on `RESERVED` vulnerabilities.
- Added tests asserting that deactivated users are cleanly locked out of `validateUser` flows and see appropriately redacted details on `optionallyValidateUser` flows.
- Added `userDeactivateAsSecHelper` and `userReactivateAsSecHelper` test helper functions.

# Testing

Steps to manually test updated functionality:
- [ ] 1) Attempt to update a user's details or organization to verify that it succeeds successfully (200 status code) rather than returning a 500 error.
- [ ] 2) Deactivate a local user via API and attempt to reach an optionally authenticated / GET route (like `/api/cve-id/:id`) to verify the payload reflects an unauthenticated profile (redacted fields).
- [ ] 3) Run the full integration test suite `npm run test:integration` and confirm all 334+ tests pass cleanly.