### PR TITLE
Resolves issue #1748, Adds quota bounds to Org JSON schemas to prevent MongoDB constraint errors.

### DIFF
--- a/src/middleware/schemas/CNAOrg.json
+++ b/src/middleware/schemas/CNAOrg.json
@@ -20,11 +20,13 @@
         },
         "hard_quota": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "maximum": 100000
         },
         "soft_quota": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "maximum": 100000
         },
         "charter_or_scope": {
           "$ref": "/BaseOrg#/definitions/uriType"

--- a/src/middleware/schemas/SecretariatOrg.json
+++ b/src/middleware/schemas/SecretariatOrg.json
@@ -20,11 +20,13 @@
         },
         "hard_quota": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "maximum": 100000
         },
         "soft_quota": {
           "type": "integer",
-          "minimum": 0
+          "minimum": 0,
+          "maximum": 100000
         }
       },
       "required": ["hard_quota"]

--- a/test/integration-tests/registry-org/registryOrgCRUDTest.js
+++ b/test/integration-tests/registry-org/registryOrgCRUDTest.js
@@ -324,6 +324,19 @@ describe('Testing /registryOrg endpoints', () => {
             expect(res.body.details[0].msg).to.equal('reports_to must not be present')
           })
       })
+      it('Fails to update a registry organization with an invalidly high quota', async () => {
+        await chai.request(app)
+          .put(`/api/registryOrg/${createdOrg.short_name}`)
+          .set(secretariatHeaders)
+          .send({
+            ...createdOrg,
+            hard_quota: 1000000
+          })
+          .then((res) => {
+            expect(res).to.have.status(400)
+            expect(res.body.message).to.equal('Parameters were invalid')
+          })
+      })
     })
   })
   context('Testing DELETE /registryOrg endpoint', () => {


### PR DESCRIPTION
Closes Issue #1748

# Summary
This PR adds `maximum` bounds checking to `hard_quota` and `soft_quota` properties in the `CNAOrg.json` and `SecretariatOrg.json` schemas. Previously, unbound quota values bypassed initial validation and instead crashed during Mongoose validation, resulting in a database constraint error and an unhandled `500` status. The schema now correctly intercepts these invalid payloads and returns a `400 Bad Request`.
# Important Changes
`src/middleware/schemas/CNAOrg.json`
- Added `"maximum": 100000` to `hard_quota` and `soft_quota`.
`src/middleware/schemas/SecretariatOrg.json`
- Added `"maximum": 100000` to `hard_quota` and `soft_quota`.
`test/integration-tests/registry-org/registryOrgCRUDTest.js`
- Added an integration test simulating a PUT to `/registry/org/:short_name` with an invalidly high quota (`1000000`) asserting it fails accurately with a `400` status.
# Testing
Steps to manually test updated functionality, if possible
- [ ] 1) Authenticate as a Secretariat user and send a `PUT` request to `/api/registryOrg/{short_name}`.
- [ ] 2) Include `hard_quota: 1000000` in the request body.
- [ ] 3) Verify that the server responds with a `400 Bad Request` and message `Parameters were invalid`, instead of a `500 Internal Server Error`.
- [ ] 4) Run the org integration tests locally: `npm run test:integration` and verify they pass.
# Notes
- The maximum bound of `100000` corresponds directly with Mongoose's existing configuration `CONSTANTS.MONGOOSE_VALIDATION.Org_policies_id_quota_max`.