### PR TITLE
Resolves issue #1697, Ensures that the registry origin endpoint consistently returns pagination metadata on its responses.

### DIFF
--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -283,7 +283,7 @@ class BaseOrgRepository extends BaseRepository {
     }
 
     const data = { organizations: pg.itemsList }
-    if (pg.itemCount >= options.limit) {
+    if (!returnLegacyFormat || pg.itemCount >= options.limit) {
       data.totalCount = pg.itemCount
       data.itemsPerPage = pg.itemsPerPage
       data.pageCount = pg.pageCount

--- a/test/integration-tests/registry-org/registryOrgCRUDTest.js
+++ b/test/integration-tests/registry-org/registryOrgCRUDTest.js
@@ -112,6 +112,12 @@ describe('Testing /registryOrg endpoints', () => {
           .set(secretariatHeaders)
           .then((res) => {
             expect(res).to.have.status(200)
+            expect(res.body).to.have.property('totalCount')
+            expect(res.body).to.have.property('itemsPerPage')
+            expect(res.body).to.have.property('pageCount')
+            expect(res.body).to.have.property('currentPage')
+            expect(res.body).to.have.property('prevPage')
+            expect(res.body).to.have.property('nextPage')
             expect(res.body.organizations).to.be.an('array').that.is.not.empty
           })
       })


### PR DESCRIPTION
Closes Issue #1697

# Summary
This PR fixes an issue where the `GET /api/registry/org` endpoint resulted in inconsistent response properties depending on the total number of organizations in the database. Specifically, pagination metadata was omitted if the item count fell short of the paginator limit. These changes ensure that fields such as `totalCount` and related pagination properties are consistently present in the response layout for all registry endpoints, regardless of item count.
# Important Changes
`src/repositories/baseOrgRepository.js`
- Updated the logic inside `getAllOrgs` to unconditionally return pagination fields (e.g. `totalCount`, `itemsPerPage`, etc.) if `returnLegacyFormat` is evaluated as false.
`test/integration-tests/registry-org/registryOrgCRUDTest.js`
- Added assertions to the positive `GET /registryOrg` test case to ensure all pagination properties are present in the response body.  
# Testing
Steps to manually test updated functionality, if possible
- [ ] 1) Authenticate and send a `GET` request to `/api/registry/org` (on your local or testing environment where the number of organizations does not exceed the limit of 500).
- [ ] 2) Retrieve the output JSON schema.
- [ ] 3) Verify that the metadata properties: `totalCount`, `itemsPerPage`, `pageCount`, `currentPage`, `prevPage`, and `nextPage` all exist alongside the `organizations` array.
# Notes
- Branch testing has been covered via the automated registry integration scripts suite.