### PR TITLE
Resolves issue #1784 , Fixes false positives in joint approval change detection due to Date vs String comparison.

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -4788,6 +4788,122 @@
         }
       }
     },
+    "/conversation/{uuid}": {
+      "put": {
+        "tags": [
+          "Conversation"
+        ],
+        "summary": "Updates a conversation by UUID (accessible to Secretariat only)",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role</p>  <h2>Expected Behavior</h2>  <p><b>Secretariat:</b> Updates the conversation with the specified UUID</p>",
+        "operationId": "updateConversationByUUID",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The UUID of the conversation to update"
+          },
+          {
+            "$ref": "#/components/parameters/apiEntityHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiUserHeader"
+          },
+          {
+            "$ref": "#/components/parameters/apiSecretHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns the updated conversation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/conversation/conversation.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/errors/bad-request.json"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not Authenticated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/errors/generic.json"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "../schemas/errors/generic.json"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "body": {
+                    "type": "string",
+                    "description": "The updated content of the conversation message"
+                  },
+                  "visibility": {
+                    "type": "string",
+                    "enum": [
+                      "private",
+                      "public"
+                    ],
+                    "description": "The updated visibility of the conversation message"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/review/byUUID/{uuid}": {
       "get": {
         "tags": [

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
         "start:prd": "node src/swagger.js && NODE_ENV=production node src/scripts/updateOpenapiHost.js && NODE_ENV=production node src/index.js",
         "swagger-autogen": "node src/swagger.js",
         "test": "NODE_ENV=test mocha --recursive --exit || true",
-        "test:integration": "NODE_ENV=test node-dev src/scripts/populate.js y; NODE_ENV=test MONGO_CONN_STRING=mongodb://localhost:27017 MONGO_DB_NAME=cve_test node-dev src/scripts/migrate.js; NODE_ENV=test mocha test/integration-tests --recursive --exit",
+        "test:integration": "NODE_ENV=test node-dev src/scripts/populate.js y; NODE_ENV=test MONGO_CONN_STRING=mongodb://docdb:27017 MONGO_DB_NAME=cve_test node-dev src/scripts/migrate.js; NODE_ENV=test mocha test/integration-tests --recursive --exit",
         "test:unit-tests": "NODE_ENV=test mocha test/unit-tests --recursive --exit || true",
         "test:coverage": "NODE_ENV=test nyc --reporter=text mocha src/* --recursive --exit || true",
         "test:coverage-html": "NODE_ENV=test nyc --reporter=html mocha src/* --recursive --exit || true",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
         "start:prd": "node src/swagger.js && NODE_ENV=production node src/scripts/updateOpenapiHost.js && NODE_ENV=production node src/index.js",
         "swagger-autogen": "node src/swagger.js",
         "test": "NODE_ENV=test mocha --recursive --exit || true",
-        "test:integration": "NODE_ENV=test node-dev src/scripts/populate.js y; NODE_ENV=test MONGO_CONN_STRING=mongodb://docdb:27017 MONGO_DB_NAME=cve_test node-dev src/scripts/migrate.js; NODE_ENV=test mocha test/integration-tests --recursive --exit",
+        "test:integration": "NODE_ENV=test node-dev src/scripts/populate.js y; NODE_ENV=test MONGO_CONN_STRING=mongodb://localhost:27017 MONGO_DB_NAME=cve_test node-dev src/scripts/migrate.js; NODE_ENV=test mocha test/integration-tests --recursive --exit",
         "test:unit-tests": "NODE_ENV=test mocha test/unit-tests --recursive --exit || true",
         "test:coverage": "NODE_ENV=test nyc --reporter=text mocha src/* --recursive --exit || true",
         "test:coverage-html": "NODE_ENV=test nyc --reporter=html mocha src/* --recursive --exit || true",

--- a/schemas/registry-org/RootOrg.json
+++ b/schemas/registry-org/RootOrg.json
@@ -16,6 +16,24 @@
       "maxLength": 32
     },
     "aliases": { "$ref": "/BaseOrg#/properties/aliases" },
+    "private_contacts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "phone": {
+            "type": "string"
+          },
+          "poc": {
+            "type": "string"
+          },
+          "poc_email": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
     "contact_info": {
       "type": "object",
       "properties": {
@@ -38,8 +56,7 @@
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "type": "string",
-        "format": "uuid"
+        "$ref": "/BaseOrg#/definitions/uuidType"
       }
     },
     "partner_role_type": {
@@ -54,9 +71,7 @@
     "advisory_locations": { "$ref": "/BaseOrg#/properties/advisory_locations" },
     "program_data": { "$ref": "/BaseOrg#/properties/program_data" },
     "industry": { "$ref": "/BaseOrg#/properties/industry" },
-    "top_level_root": { "$ref": "/BaseOrg#/properties/top_level_root" },
-    "tl_root_start_date": { "$ref": "/BaseOrg#/properties/tl_root_start_date" },
-    "is_cna_discussion_list": { "$ref": "/BaseOrg#/properties/is_cna_discussion_list" }
+    "top_level_root": { "$ref": "/BaseOrg#/properties/top_level_root" }
   },
   "required": ["short_name"]
 }

--- a/src/model/baseorg.js
+++ b/src/model/baseorg.js
@@ -21,6 +21,7 @@ const schema = {
     website: String
   },
   private_contacts: [{
+    _id: false,
     phone: String,
     poc: String,
     poc_email: String

--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -807,10 +807,15 @@ class BaseOrgRepository extends BaseRepository {
       jointApprovalFields = getConstants().JOINT_APPROVAL_FIELDS
     }
 
+    // Convert Mongoose docs to plain objects and serialize to match stringified formats
+    const originalPlain = orgObjectOriginal.toObject ? orgObjectOriginal.toObject() : orgObjectOriginal
+    const originalSerialized = JSON.parse(JSON.stringify(originalPlain))
+    const updatedSerialized = JSON.parse(JSON.stringify(orgObjectUpdated))
+
     // Filter the list to find only fields that have changed
     const changedFields = _.filter(jointApprovalFields, field => {
       // Check if the value in the original object is different from the updated object
-      return _.get(orgObjectOriginal, field) !== _.get(orgObjectUpdated, field)
+      return !_.isEqual(_.get(originalSerialized, field), _.get(updatedSerialized, field))
     })
 
     // Return the array of fields that had changes (will be empty if none changed)
@@ -932,8 +937,8 @@ class BaseOrgRepository extends BaseRepository {
       // Check if there are actual changes to joint approval fields compared to current org object (not current review)
       // Only compare fields that are actually in the incoming data
       const incomingJointApprovalKeys = Object.keys(_.pick(registryObjectRaw, jointApprovalFieldsRegistry))
-      const currentJointApprovalData = _.pick(registryOrg.toObject(), incomingJointApprovalKeys)
-      const incomingJointApprovalData = _.pick(registryObjectRaw, incomingJointApprovalKeys)
+      const currentJointApprovalData = JSON.parse(JSON.stringify(_.pick(registryOrg.toObject(), incomingJointApprovalKeys)))
+      const incomingJointApprovalData = JSON.parse(JSON.stringify(_.pick(registryObjectRaw, incomingJointApprovalKeys)))
       const hasJointApprovalChanges = !_.isEqual(currentJointApprovalData, incomingJointApprovalData)
 
       if (hasJointApprovalChanges) {

--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -938,7 +938,7 @@ class BaseOrgRepository extends BaseRepository {
 
       if (hasJointApprovalChanges) {
         // write the joint approval to the database
-        jointApprovalRegistry = _.merge({}, registryOrg.toObject(), registryObjectRaw)
+        jointApprovalRegistry = _.mergeWith({}, registryOrg.toObject(), registryObjectRaw, skipNulls)
         if (reviewObject) {
           await reviewObjectRepo.updateReviewOrgObject(jointApprovalRegistry, reviewObject.uuid, options)
         } else {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -309,8 +309,7 @@ function deepRemoveEmpty (obj) {
       // This will catch both initially empty fields and nested objects that became empty.
       if (
         value === null ||
-        (_.isObject(value) && !_.isDate(value) && _.isEmpty(value)) ||
-        (_.isArray(value) && _.isEmpty(value))
+        (_.isObject(value) && !_.isArray(value) && !_.isDate(value) && _.isEmpty(value))
       ) {
         delete currentObj[key]
       }

--- a/test/integration-tests/conversation/editConversationTest.js
+++ b/test/integration-tests/conversation/editConversationTest.js
@@ -31,6 +31,8 @@ describe('Testing Conversation edit by index endpoint', () => {
         delete org.admins
         delete org.users
         delete org.top_level_root
+        delete org.oversees
+        delete org.program_data
       })
 
     await chai

--- a/test/integration-tests/registry-org/registryOrgCRUDTest.js
+++ b/test/integration-tests/registry-org/registryOrgCRUDTest.js
@@ -71,6 +71,8 @@ describe('Testing /registryOrg endpoints', () => {
             createdOrg = res.body.created
             delete createdOrg.created
             delete createdOrg.last_updated
+            delete createdOrg.users
+            delete createdOrg.admins
           })
       })
     })

--- a/test/integration-tests/registry-org/rootOrgTest.js
+++ b/test/integration-tests/registry-org/rootOrgTest.js
@@ -33,6 +33,9 @@ describe('Testing ROOT Organization Type', () => {
           delete createdOrg.created
           delete createdOrg.last_updated
           delete createdOrg.program_data
+          delete createdOrg.users
+          delete createdOrg.admins
+          delete createdOrg.oversees
         })
     })
 
@@ -85,7 +88,7 @@ describe('Testing ROOT Organization Type', () => {
           long_name: 'Updated Root Org Test'
         })
         .then((res) => {
-          if (res.status === 400) console.log(JSON.stringify(res.body, null, 2))
+          if (res.status !== 200) console.log('403 Response:', JSON.stringify(res.body, null, 2))
           expect(res).to.have.status(200)
         })
     })


### PR DESCRIPTION


Closes Issue #1784 

# Summary
This PR addresses an issue where `hasJointApprovalChanges` was incorrectly evaluating to `true` when submitting a complete BaseOrg document update even if no actual joint approval fields were modified. This was caused by comparing Mongoose `Date` objects against ISO date strings (e.g., `tl_root_start_date`), which lodash's `_.isEqual` evaluated as strictly `false`. This fix rectifies the logic by converting the compared data objects into primitive JSON representations prior to executing lodash deep equality checks.

# Important Changes
`src/repositories/baseOrgRepository.js`
- Updated `getJointApprovalFields` to convert the original and updated document subsets to stringified JSON formats before running the `_.isEqual` strict equality check.
- Updated `updateOrgFull` to perform the same `JSON.parse(JSON.stringify(...))` conversion when checking for changes via `incomingJointApprovalKeys`, successfully preventing an erroneous `hasJointApprovalChanges = true` flag.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run `npm run test:integration` to ensure all existing organization update behaviors remain functional and pass.
- [ ] 2) Send a `PUT` request to update an organization using a full BaseOrg JSON payload containing `tl_root_start_date`, ensuring the date value is unchanged.
- [ ] 3) Verify that no unnecessary review objects are created, meaning `hasJointApprovalChanges` correctly evaluated to `false`.

# Notes
- Using `JSON.parse(JSON.stringify(...))` safely handles the conversion of native `Date` objects to their API-compliant ISO string representations, and safely drops `undefined` values to treat missing keys consistently.
