### PR TITLE
Resolves issue #1666, Authenticate vs Authorize ordering on routes in controllers

### DIFF
--- a/src/controller/audit.controller/index.js
+++ b/src/controller/audit.controller/index.js
@@ -36,8 +36,8 @@ router.get('/audit/org/:org_identifier',
 
 // Get last X changes (Secretariat or Org Admin)
 router.get('/audit/org/:org_identifier/:number_of_changes',
-  mw.onlySecretariat,
   mw.validateUser,
+  mw.onlySecretariat,
   auditMw.parseGetParams,
   controller.AUDIT_GET_LAST
 )

--- a/src/controller/registry-org.controller/index.js
+++ b/src/controller/registry-org.controller/index.js
@@ -212,8 +212,8 @@ router.post('/registryOrg',
   }
   */
   mw.useRegistry(),
-  mw.onlySecretariat,
   mw.validateUser,
+  mw.onlySecretariat,
   body(['reports_to']).not().exists().withMessage('reports_to must not be present'),
   parseError,
   parsePostParams,


### PR DESCRIPTION
Closes Issue #1666 

# Summary
One route in both the Registry Org and Audit controllers was verifying if a user is authorized ( if they are secretariat) before authenticating the user. The order of these operations has been correctly flipped to ensure that the user is authenticated first, then evaluated for authority to call the route in question.

# Important Changes
`registry-org.controller/index.js`
- Updated authentication vs authorization order on the POST endpoint

`audit.controller/index.js`
- Updated authentication vs authorization order on the GET last 'x' changes endpoint

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run `npm run test:integration` and ensure all tests pass as expected