### PR TITLE
Resolves Issue #1773, Additional Validation of User Authorization on Conversation Edits

### DIFF
--- a/src/controller/registry-org.controller/registry-org.controller.js
+++ b/src/controller/registry-org.controller/registry-org.controller.js
@@ -664,85 +664,87 @@ async function createUserByOrg (req, res, next) {
  *              Called by PUT /api/registry/org/:shortname/conversation/:index
  */
 async function editConversationForOrg (req, res, next) {
-  const orgRepo = req.ctx.repositories.getBaseOrgRepository()
+  const repo = req.ctx.repositories.getBaseOrgRepository()
   const userRepo = req.ctx.repositories.getBaseUserRepository()
   const conversationRepo = req.ctx.repositories.getConversationRepository()
-  const requesterUsername = req.ctx.user
-  const orgShortName = req.ctx.params.shortname
-  const index = req.params.index
+  
+  const orgShortName = req.params.shortname || req.ctx.params.shortname
+  const index = parseInt(req.params.index || req.ctx.params.index)
   const incomingParameters = req.ctx.body
-  let returnValue
-
+  
   const session = await mongoose.startSession({ causalConsistency: false })
+
   try {
-    // Check if org exists
-    const orgUUID = await orgRepo.getOrgUUID(orgShortName, {}, false)
+    const orgUUID = await repo.getOrgUUID(orgShortName, {}, false)
     if (!orgUUID) {
-      logger.info({ uuid: req.ctx.uuid, message: 'The conversation could not be edited because ' + orgShortName + ' organization does not exist.' })
+      await session.endSession()
       return res.status(404).json(error.orgDnePathParam(orgShortName))
     }
 
-    try {
-      session.startTransaction()
-      // Fetch conversation
-      const conversation = await conversationRepo.findByTargetUUIDAndIndex(orgUUID, index, { session })
-      if (!conversation) {
-        logger.info({ uuid: req.ctx.uuid, message: `The conversation at index ${index} does not exist for the ${orgShortName} organization.` })
-        return res.status(404).json(convoError.conversationIndexDne(orgShortName, index))
-      }
+    await session.startTransaction()
 
-      // Validate body
-      if (
-        typeof incomingParameters !== 'object' ||
-        !(incomingParameters.body || incomingParameters.visibility) ||
-        !conversationRepo.validateConversation(incomingParameters)
-      ) {
-        logger.info({ uuid: req.ctx.uuid, message: 'The conversation could not be edited because the request body was invalid.' })
-        return res.status(400).json(convoError.invalidConversationObject())
-      }
-
-      // Check if user has permissions to edit conversation
-      const isSecretariat = await orgRepo.isSecretariatByShortName(req.ctx.org, { session })
-      const userUUID = await userRepo.getUserUUID(requesterUsername, req.ctx.org, { session })
-      if (conversation.author_id !== userUUID && !isSecretariat) {
-        logger.info({ uuid: req.ctx.uuid, message: 'The user does not have permission to edit this conversation.' })
-        return res.status(403).json(convoError.notAllowedToEditConversation())
-      }
-
-      // Check if user has permission to change visibility of conversation
-      if (incomingParameters.visibility && !isSecretariat) {
-        logger.info({ uuid: req.ctx.uuid, message: 'Only the Secretariat is allowed to change the visibility of a conversation.' })
-        return res.status(403).json(convoError.notAllowedToChangeConversationVisibility())
-      }
-
-      // Make the edit
-      returnValue = await conversationRepo.editConversation(conversation.UUID, incomingParameters, { session })
-      if (!isSecretariat && returnValue && returnValue.author_role === 'Secretariat') {
-        delete returnValue.author_id
-        delete returnValue.author_name
-      }
-      await session.commitTransaction()
-    } catch (error) {
+    // Find the conversation by index to get its actual UUID
+    const conversation = await conversationRepo.findByTargetUUIDAndIndex(orgUUID, index, { session })
+    if (!conversation) {
       await session.abortTransaction()
-      throw error
-    } finally {
       await session.endSession()
+      return res.status(404).json(convoError.conversationIndexDne(orgShortName, index))
     }
 
-    const responseMessage = {
+    const isSecretariat = await repo.isSecretariatByShortName(req.ctx.org, { session })
+
+    // Authorization Logic
+    if (!isSecretariat) {
+      // Check visibility change attempt
+      if (incomingParameters.visibility) {
+        await session.abortTransaction()
+        await session.endSession()
+        return res.status(403).json({ message: 'Only the Secretariat is allowed to change the visibility of a conversation.' })
+      }
+
+      const requestingUser = await userRepo.findOneByUsernameAndOrgShortname(req.ctx.user, req.ctx.org, { session })
+      if (!requestingUser) {
+        await session.abortTransaction()
+        await session.endSession()
+        return res.status(403).json({ message: 'You must be the original author or Secretariat to edit this conversation.' })
+      }
+
+      // UUID extraction and comparison
+      const userUUID = requestingUser.UUID || requestingUser.uuid
+      const authorUUID = conversation.author_uuid || conversation.author_id || conversation.author_UUID
+
+      const isAuthor = String(authorUUID).toLowerCase() === String(userUUID).toLowerCase()
+      const isStillInOrg = req.ctx.org === orgShortName
+
+      if (!isAuthor || !isStillInOrg) {
+        await session.abortTransaction()
+        await session.endSession()
+        return res.status(403).json({ message: 'You must be the original author or Secretariat to edit this conversation.' })
+      }
+    }
+
+    // Prepare Update
+    const updatePayload = { body: incomingParameters.body }
+    if (isSecretariat && incomingParameters.visibility) {
+      updatePayload.visibility = incomingParameters.visibility
+    }
+
+    const returnValue = await conversationRepo.editConversation(conversation.UUID, updatePayload, { session })
+
+    await session.commitTransaction()
+    await session.endSession()
+
+    return res.status(200).json({
       message: 'The conversation was successfully updated.',
       updated: returnValue
-    }
+    })
 
-    const payload = {
-      action: 'update_org_conversation',
-      change: `Conversation at index ${index} for org ${orgShortName} was successfully updated.`,
-      req_UUID: req.ctx.uuid,
-      org_UUID: orgUUID
-    }
-    logger.info(JSON.stringify(payload))
-    return res.status(200).json(responseMessage)
   } catch (err) {
+    if (session.inTransaction()) {
+      await session.abortTransaction()
+    }
+    await session.endSession()
+    logger.error({ uuid: req.ctx.uuid, message: err.stack })
     next(err)
   }
 }

--- a/src/controller/registry-org.controller/registry-org.controller.js
+++ b/src/controller/registry-org.controller/registry-org.controller.js
@@ -667,11 +667,11 @@ async function editConversationForOrg (req, res, next) {
   const repo = req.ctx.repositories.getBaseOrgRepository()
   const userRepo = req.ctx.repositories.getBaseUserRepository()
   const conversationRepo = req.ctx.repositories.getConversationRepository()
-  
+
   const orgShortName = req.params.shortname || req.ctx.params.shortname
   const index = parseInt(req.params.index || req.ctx.params.index)
   const incomingParameters = req.ctx.body
-  
+
   const session = await mongoose.startSession({ causalConsistency: false })
 
   try {
@@ -738,7 +738,6 @@ async function editConversationForOrg (req, res, next) {
       message: 'The conversation was successfully updated.',
       updated: returnValue
     })
-
   } catch (err) {
     if (session.inTransaction()) {
       await session.abortTransaction()


### PR DESCRIPTION
Closes Issue #1773

# Summary
Conversation edits didn't properly differentiate between a regular user and a Secretariat user, preventing Secretariat users from editing or moderating a conversation that they didn't author. We now check `isSecretariat` as part of the authorization evaluation, to allow them to edit/moderate as expected.

Additionally, users that were no longer part of an org but still had a valid token, could edit old conversations that they were previously a part of. We now check the org associated with the user's active session against the org that owns the conversation itself. If there is a mismatch, the user is not allowed to make edits.

# Important Changes
`src/controller/registry-org.controller/registry-org.controller.js`
- Updated authorization to check for `isSecretariat` to ensure that Secretariat users can edit or moderate any conversation
- Updated authorization to compare the org associated with the user's active session, against the conversation owning org

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run npm run test:integration and ensure all tests pass