### PR TITLE
Resolves issue #1663, Resolve inconsistent parameters and query target UUID when fetching review history conversations.

### DIFF
--- a/src/repositories/conversationRepository.js
+++ b/src/repositories/conversationRepository.js
@@ -36,8 +36,12 @@ class ConversationRepository extends BaseRepository {
   }
 
   async getAllByTargetUUID (targetUUID, isSecretariat, options = {}) {
+    const findOptions = {}
+    if (options.session) {
+      findOptions.session = options.session
+    }
     const conversations = await ConversationModel.find({ target_uuid: targetUUID }, null, {
-      ...options,
+      ...findOptions,
       sort: {
         posted_at: 1,
         UUID: 1

--- a/src/repositories/reviewObjectRepository.js
+++ b/src/repositories/reviewObjectRepository.js
@@ -241,7 +241,7 @@ class ReviewObjectRepository extends BaseRepository {
       const conversationRepository = new ConversationRepository()
 
       for (const review of data.reviewObjects) {
-        let conversations = await conversationRepository.getAllByTargetUUID(review.uuid, isSecretariat, options)
+        let conversations = await conversationRepository.getAllByTargetUUID(review.target_object_uuid, isSecretariat)
 
         // Filter conversations based on user role
         if (conversations && conversations.length) {

--- a/test/integration-tests/review-object/reviewObjectTest.js
+++ b/test/integration-tests/review-object/reviewObjectTest.js
@@ -183,15 +183,27 @@ describe('Review Object Controller Integration Tests', () => {
     })
 
     it('Retrieves review history with conversations included', async () => {
+      // 1. Post a conversation message to the organization target UUID
+      const msgRes = await chai
+        .request(app)
+        .post(`/api/conversation/target/${orgUUID}`)
+        .set({ ...constants.headers })
+        .send({ body: 'Test comment on org history', visibility: 'public' })
+      expect(msgRes).to.have.status(200)
+
+      // 2. Fetch the review history with conversations included
       const res = await chai
         .request(app)
         .get(`/api/review/org/${constants.testRegistryOrg2.short_name}/reviews?include_conversations=true`)
         .set({ ...constants.headers })
       expect(res).to.have.status(200)
       expect(res.body).to.have.property('reviewObjects')
-      if (res.body.reviewObjects.length > 0) {
-        expect(res.body.reviewObjects[0]).to.have.property('conversation')
-      }
+      expect(res.body.reviewObjects).to.be.an('array')
+      expect(res.body.reviewObjects.length).to.be.greaterThan(0)
+      expect(res.body.reviewObjects[0]).to.have.property('conversation')
+      expect(res.body.reviewObjects[0].conversation).to.be.an('array')
+      expect(res.body.reviewObjects[0].conversation.length).to.be.greaterThan(0)
+      expect(res.body.reviewObjects[0].conversation[0]).to.have.property('body', 'Test comment on org history')
     })
 
     it('Nonsecretariat user can update an organization, review object gets created', async () => {


### PR DESCRIPTION
Closes Issue #1663

# Summary
Resolves a bug where fetching the review history for an organization with conversations included (`include_conversations=true`) fails. The codebase had inconsistent parameters in `getAllByTargetUUID` inside `reviewObjectRepository.js` and was querying using the review object UUID instead of the organization's target UUID. Additionally, the conversation repository has been hardened to prevent paginator options (like `lean: true`) from leaking into the `find()` query, which previously caused a `TypeError` and hung the request.

# Important Changes
`src/repositories/reviewObjectRepository.js`
- Fixed `getReviewHistoryByOrgShortNamePaginated` to retrieve conversations using `review.target_object_uuid` instead of `review.uuid`.
- Removed passing pagination `options` into `getAllByTargetUUID` to prevent pollution of conversation queries.

`src/repositories/conversationRepository.js`
- Hardened `getAllByTargetUUID` to filter incoming query options, extracting only Mongoose transaction `session` and ignoring pagination options like `lean` or `page` that disrupt `.toObject()` serialization.

`test/integration-tests/review-object/reviewObjectTest.js`
- Enhanced the `"Retrieves review history with conversations included"` integration test to post a public conversation to the test organization, fetch the history with `include_conversations=true`, and assert the comment body matches correctly.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run the integration tests using `bash -i -c "npm run test:integration"`.
- [ ] 2) Verify that the test `"Retrieves review history with conversations included"` under "Review Object Controller Integration Tests" passes.

# Notes
- All 399 integration tests have been run and passed successfully in 39 seconds, introducing zero regressions.
