### PR TITLE
Resolves issue #1819: Return object for GET requests of non existent reviews

### DIFF
--- a/src/controller/review-object.controller/review-object.controller.js
+++ b/src/controller/review-object.controller/review-object.controller.js
@@ -10,7 +10,7 @@ const _ = require('lodash')
  * Retrieves the PENDING review object for an organization by identifier (short_name or UUID).
  * Returns only review objects with status='pending'.
  */
-async function getReviewObjectByOrgIdentifier(req, res, next) {
+async function getReviewObjectByOrgIdentifier (req, res, next) {
   const repo = req.ctx.repositories.getReviewObjectRepository()
   const orgRepo = req.ctx.repositories.getBaseOrgRepository()
   const isSecretariat = await orgRepo.isSecretariatByShortName(req.ctx.org)
@@ -42,7 +42,7 @@ async function getReviewObjectByOrgIdentifier(req, res, next) {
   return res.status(200).json(value)
 }
 
-async function getReviewObjectByUUID(req, res, next) {
+async function getReviewObjectByUUID (req, res, next) {
   const repo = req.ctx.repositories.getReviewObjectRepository()
   const orgRepo = req.ctx.repositories.getBaseOrgRepository()
   const isSecretariat = await orgRepo.isSecretariatByShortName(req.ctx.org)
@@ -63,7 +63,7 @@ async function getReviewObjectByUUID(req, res, next) {
   return res.status(200).json(value)
 }
 
-async function getAllReviewObjects(req, res, next) {
+async function getAllReviewObjects (req, res, next) {
   const repo = req.ctx.repositories.getReviewObjectRepository()
   const CONSTANTS = getConstants()
   const status = req.query?.status || null
@@ -79,7 +79,7 @@ async function getAllReviewObjects(req, res, next) {
   return res.status(200).json(response)
 }
 
-async function approveReviewObject(req, res, next) {
+async function approveReviewObject (req, res, next) {
   const reviewRepo = req.ctx.repositories.getReviewObjectRepository()
   const baseOrgRepo = req.ctx.repositories.getBaseOrgRepository()
   const userRepo = req.ctx.repositories.getBaseUserRepository()
@@ -139,7 +139,7 @@ async function approveReviewObject(req, res, next) {
   return res.status(200).json(updatedOrgObj)
 }
 
-async function updateReviewObjectByReviewUUID(req, res, next) {
+async function updateReviewObjectByReviewUUID (req, res, next) {
   const repo = req.ctx.repositories.getReviewObjectRepository()
   const UUID = req.params.uuid
   const orgRepo = req.ctx.repositories.getBaseOrgRepository()
@@ -174,7 +174,7 @@ async function updateReviewObjectByReviewUUID(req, res, next) {
   return res.status(200).json(updatedReviewObj)
 }
 
-async function createReviewObject(req, res, next) {
+async function createReviewObject (req, res, next) {
   const baseOrgRepo = req.ctx.repositories.getBaseOrgRepository()
   const repo = req.ctx.repositories.getReviewObjectRepository()
   const body = req.body
@@ -206,7 +206,7 @@ async function createReviewObject(req, res, next) {
 /**
  * Retrieves the review history for an organization.
  */
-async function getReviewHistoryByOrgShortNamePaginated(req, res, next) {
+async function getReviewHistoryByOrgShortNamePaginated (req, res, next) {
   const reviewRepo = req.ctx.repositories.getReviewObjectRepository()
   const orgRepo = req.ctx.repositories.getBaseOrgRepository()
   const orgShortName = req.params.identifier
@@ -239,7 +239,7 @@ async function getReviewHistoryByOrgShortNamePaginated(req, res, next) {
   return res.status(200).json(response)
 }
 
-async function rejectReviewObject(req, res, next) {
+async function rejectReviewObject (req, res, next) {
   const reviewRepo = req.ctx.repositories.getReviewObjectRepository()
   const baseOrgRepo = req.ctx.repositories.getBaseOrgRepository()
   const UUID = req.params.uuid

--- a/src/controller/review-object.controller/review-object.controller.js
+++ b/src/controller/review-object.controller/review-object.controller.js
@@ -10,7 +10,7 @@ const _ = require('lodash')
  * Retrieves the PENDING review object for an organization by identifier (short_name or UUID).
  * Returns only review objects with status='pending'.
  */
-async function getReviewObjectByOrgIdentifier (req, res, next) {
+async function getReviewObjectByOrgIdentifier(req, res, next) {
   const repo = req.ctx.repositories.getReviewObjectRepository()
   const orgRepo = req.ctx.repositories.getBaseOrgRepository()
   const isSecretariat = await orgRepo.isSecretariatByShortName(req.ctx.org)
@@ -37,12 +37,12 @@ async function getReviewObjectByOrgIdentifier (req, res, next) {
     value = await repo.getOrgReviewObjectByOrgShortname(identifier, isSecretariat, {})
   }
   if (!value) {
-    return res.status(404).json({ message: 'No pending review object exists for this organization' })
+    return res.status(200).json({ pendingReview: null })
   }
   return res.status(200).json(value)
 }
 
-async function getReviewObjectByUUID (req, res, next) {
+async function getReviewObjectByUUID(req, res, next) {
   const repo = req.ctx.repositories.getReviewObjectRepository()
   const orgRepo = req.ctx.repositories.getBaseOrgRepository()
   const isSecretariat = await orgRepo.isSecretariatByShortName(req.ctx.org)
@@ -63,7 +63,7 @@ async function getReviewObjectByUUID (req, res, next) {
   return res.status(200).json(value)
 }
 
-async function getAllReviewObjects (req, res, next) {
+async function getAllReviewObjects(req, res, next) {
   const repo = req.ctx.repositories.getReviewObjectRepository()
   const CONSTANTS = getConstants()
   const status = req.query?.status || null
@@ -79,7 +79,7 @@ async function getAllReviewObjects (req, res, next) {
   return res.status(200).json(response)
 }
 
-async function approveReviewObject (req, res, next) {
+async function approveReviewObject(req, res, next) {
   const reviewRepo = req.ctx.repositories.getReviewObjectRepository()
   const baseOrgRepo = req.ctx.repositories.getBaseOrgRepository()
   const userRepo = req.ctx.repositories.getBaseUserRepository()
@@ -139,7 +139,7 @@ async function approveReviewObject (req, res, next) {
   return res.status(200).json(updatedOrgObj)
 }
 
-async function updateReviewObjectByReviewUUID (req, res, next) {
+async function updateReviewObjectByReviewUUID(req, res, next) {
   const repo = req.ctx.repositories.getReviewObjectRepository()
   const UUID = req.params.uuid
   const orgRepo = req.ctx.repositories.getBaseOrgRepository()
@@ -174,7 +174,7 @@ async function updateReviewObjectByReviewUUID (req, res, next) {
   return res.status(200).json(updatedReviewObj)
 }
 
-async function createReviewObject (req, res, next) {
+async function createReviewObject(req, res, next) {
   const baseOrgRepo = req.ctx.repositories.getBaseOrgRepository()
   const repo = req.ctx.repositories.getReviewObjectRepository()
   const body = req.body
@@ -206,7 +206,7 @@ async function createReviewObject (req, res, next) {
 /**
  * Retrieves the review history for an organization.
  */
-async function getReviewHistoryByOrgShortNamePaginated (req, res, next) {
+async function getReviewHistoryByOrgShortNamePaginated(req, res, next) {
   const reviewRepo = req.ctx.repositories.getReviewObjectRepository()
   const orgRepo = req.ctx.repositories.getBaseOrgRepository()
   const orgShortName = req.params.identifier
@@ -239,7 +239,7 @@ async function getReviewHistoryByOrgShortNamePaginated (req, res, next) {
   return res.status(200).json(response)
 }
 
-async function rejectReviewObject (req, res, next) {
+async function rejectReviewObject(req, res, next) {
   const reviewRepo = req.ctx.repositories.getReviewObjectRepository()
   const baseOrgRepo = req.ctx.repositories.getBaseOrgRepository()
   const UUID = req.params.uuid

--- a/test/integration-tests/review-object/reviewObjectTest.js
+++ b/test/integration-tests/review-object/reviewObjectTest.js
@@ -520,18 +520,18 @@ describe('Review Object Controller Integration Tests', () => {
         .send({})
       expect(rejectRes).to.have.status(200)
     })
-  })
 
-  context('Negative Tests', () => {
-    it('Returns 404 for non-existent review object GET', async () => {
+    it('Returns 200 with pendingReview set to null for non-existent review object GET', async () => {
       const res = await chai
         .request(app)
         .get('/api/review/org/nonexistent-org')
         .set({ ...constants.headers })
-      expect(res).to.have.status(404)
-      expect(res.body.message).to.contain('No pending review object exists for this organization')
+      expect(res).to.have.status(200)
+      expect(res.body).to.have.property('pendingReview', null)
     })
+  })
 
+  context('Negative Tests', () => {
     it('Returns 404 when approving non-existent review object', async () => {
       const fakeUUID = '00000000-0000-0000-0000-000000000000'
       const res = await chai

--- a/test/unit-tests/review-object/review-object.controller.test.js
+++ b/test/unit-tests/review-object/review-object.controller.test.js
@@ -83,7 +83,7 @@ describe('Review Object Controller', function () {
       repoStub.getOrgReviewObjectByOrgUUID = sinon.stub().resolves(null)
       await controller.getReviewObjectByOrgIdentifier(req, res, next)
       expect(res.status.calledWith(200)).to.be.true
-      expect(res.json.calledWith({ 'pendingReview': null })).to.be.true
+      expect(res.json.calledWith({ pendingReview: null })).to.be.true
     })
 
     it('should return 200 with pendingReview set to null if no pending review object exists for short_name', async () => {
@@ -92,7 +92,7 @@ describe('Review Object Controller', function () {
       repoStub.getOrgReviewObjectByOrgShortname = sinon.stub().resolves(null)
       await controller.getReviewObjectByOrgIdentifier(req, res, next)
       expect(res.status.calledWith(200)).to.be.true
-      expect(res.json.calledWith({ 'pendingReview': null })).to.be.true
+      expect(res.json.calledWith({ pendingReview: null })).to.be.true
     })
   })
 

--- a/test/unit-tests/review-object/review-object.controller.test.js
+++ b/test/unit-tests/review-object/review-object.controller.test.js
@@ -77,22 +77,22 @@ describe('Review Object Controller', function () {
       expect(res.json.calledWith({ name: short })).to.be.true
     })
 
-    it('should return 404 if no pending review object exists for UUID', async () => {
+    it('should return 200 with pendingReview set to null if no pending review object exists for UUID', async () => {
       const uuid = '123e4567-e89b-12d3-a456-426614174000'
       req.params.identifier = uuid
       repoStub.getOrgReviewObjectByOrgUUID = sinon.stub().resolves(null)
       await controller.getReviewObjectByOrgIdentifier(req, res, next)
-      expect(res.status.calledWith(404)).to.be.true
-      expect(res.json.calledWith({ message: 'No pending review object exists for this organization' })).to.be.true
+      expect(res.status.calledWith(200)).to.be.true
+      expect(res.json.calledWith({ 'pendingReview': null })).to.be.true
     })
 
-    it('should return 404 if no pending review object exists for short_name', async () => {
+    it('should return 200 with pendingReview set to null if no pending review object exists for short_name', async () => {
       const short = 'myorg'
       req.params.identifier = short
       repoStub.getOrgReviewObjectByOrgShortname = sinon.stub().resolves(null)
       await controller.getReviewObjectByOrgIdentifier(req, res, next)
-      expect(res.status.calledWith(404)).to.be.true
-      expect(res.json.calledWith({ message: 'No pending review object exists for this organization' })).to.be.true
+      expect(res.status.calledWith(200)).to.be.true
+      expect(res.json.calledWith({ 'pendingReview': null })).to.be.true
     })
   })
 


### PR DESCRIPTION
Closes Issue #1819 

# Summary
GET requests for non existent reviews will now return a 200 with pendingReview set to null, instead of the previous behavior where it 404s.

# Important Changes
`src/controller/review-object.controller/review-object.controller.js`
- Updated response provided by the getReviewObjectByOrgIdentifier() function

`src/test/integration-tests/review-object/reviewObjectTest.js`
- Updated integration test to now expect the updated response from the GET review call

`src/test/unit-tests/review-object/review-object.controller.test.js`
- Updated unit tests to now expect the updated response from the GET review call

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run `npm run test:integration` and ensure all tests pass
- [ ] 2) Run `npm run test:unit-tests` and ensure all tests pass