### PR TITLE
Resolves Issue #1667, Org controller middleware registry flag parsing

### DIFF
--- a/src/controller/org.controller/org.middleware.js
+++ b/src/controller/org.controller/org.middleware.js
@@ -177,7 +177,7 @@ function validateCreateOrgParameters () {
 
 function validateUserIdOrUsername () {
   return async (req, res, next) => {
-    const useRegistry = req.useRegistry === 'true'
+    const useRegistry = req.query.registry === 'true'
     const validations = []
     if (useRegistry) {
       validations.push(
@@ -204,7 +204,7 @@ function validateUserIdOrUsername () {
 
 function validateUpdateOrgParameters () {
   return async (req, res, next) => {
-    const useRegistry = req.query === 'true'
+    const useRegistry = req.query.registry === 'true'
     const allowedParams = [...QUERY_PARAMETERS.shared]
     const registryParametersOnly = [...QUERY_PARAMETERS.registryOnly]
 


### PR DESCRIPTION
Closes Issue #1667 

# Summary
The org controller middleware was incorrectly parsing the incoming registry flag value, leading to conditional logic that always evaluated as false regardless of what the flag was set to.

# Important Changes
`src/controller/org.controller/org.middleware.js`
- Updated conditional logic in `validateUserIdOrUsername()` and `validateUpdateOrgParameters()`

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run `npm run test:integration` and ensure all tests pass
- [ ] 2) Run `npm run test:unit-tests` and ensure all tests pass 