### PR TITLE
Resolves Issue #1735 and #1736, Preventing UUID changes on update requests

### DIFF
--- a/src/controller/registry-org.controller/registry-org.controller.js
+++ b/src/controller/registry-org.controller/registry-org.controller.js
@@ -294,6 +294,13 @@ async function updateOrg (req, res, next) {
 
         // Eventually we should validate this, but this is a bit tricky.
         if (reviewOrg) {
+          // For review objects, verify the provided UUID matches the target review object's UUID
+          const providedUUID = body?.UUID || body?.uuid
+          if (providedUUID && providedUUID !== reviewOrg.uuid) {
+            await session.abortTransaction()
+            return res.status(400).json(error.uuidProvided('org'))
+          }
+
           const updateResult = await reviewRepo.updateReviewOrgObject(body, reviewOrg.uuid, { session })
           if (updateResult) {
             updatedOrg = reviewOrg
@@ -304,6 +311,15 @@ async function updateOrg (req, res, next) {
           logger.info({ uuid: req.ctx.uuid, message: shortName + ' organization could not be updated because it does not exist.' })
           await session.abortTransaction()
           return res.status(404).json(error.orgDnePathParam(shortName))
+        }
+      }
+
+      // Verify that the provided UUID matches the existing organization's immutable database UUID
+      if (org) {
+        const providedUUID = body?.UUID || body?.uuid
+        if (providedUUID && providedUUID !== org.UUID) {
+          await session.abortTransaction()
+          return res.status(400).json(error.uuidProvided('org'))
         }
       }
 

--- a/src/controller/registry-user.controller/registry-user.controller.js
+++ b/src/controller/registry-user.controller/registry-user.controller.js
@@ -295,6 +295,19 @@ async function updateUser (req, res, next) {
     }
   }
 
+  // Allow existing UUIDs to be passed, but block any attempts to mutate them
+  if (userToEdit) {
+    if (body?.UUID || body?.uuid) {
+      if (body.UUID) body.UUID = userToEdit.UUID
+      if (body.uuid) body.uuid = userToEdit.UUID
+    }
+
+    if (body?.org_UUID || body?.org_uuid) {
+      if (body.org_UUID) body.org_UUID = userToEdit.org_UUID
+      if (body.org_uuid) body.org_uuid = userToEdit.org_UUID
+    }
+  }
+
   if (body.org_short_name && !isSecretariat) {
     logger.info({ uuid: req.ctx.uuid, message: 'Only Secretariat can reassign user organization.' })
     return res.status(403).json(error.notAllowedToChangeOrganization())


### PR DESCRIPTION
Closes Issue #1735 and #1736 

# Summary
UUID changes were technically allowed by the update user and org function calls. These changes allow for UUIDs to still be passed into the request if they match the existing values, while preventing attempts to update existing UUID values.

# Important Changes
`src/controller/registry-user.controller/registry-user.controller.js`
- Added verification to allow for matching incoming UUIDs on update requests, while ignoring attempts to change UUIDs on update requests
`src/controller/registry-org.controller/registry-org.controller.js`
- Added verification to allow for matching incoming UUIDs on update requests, while ignoring attempts to change UUIDs on update requests

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run `npm run test:integration` and ensure all tests pass
- [ ] 2) Run `npm run test:unit-tests` and ensure all tests pass 