### PR TITLE
Resolves issue #1673, Handling read-after-writes in the registry user controller

### DIFF
--- a/src/controller/registry-user.controller/registry-user.controller.js
+++ b/src/controller/registry-user.controller/registry-user.controller.js
@@ -387,9 +387,10 @@ async function updateUser (req, res, next) {
         }
       }
 
-      // UUID of the user will not change, lets get it before we write to avoid read after write issues.
+      // Move lookups of immutable properties BEFORE the transaction mutation writes to completely bypass read-after-write anomalies
       const requestingUserUUID = await userRepo.getUserUUID(req.ctx.user, req.ctx.org, { session })
-      updatedUserUUID = await userRepo.getUserUUID(req.ctx.user, org.UUID)
+      updatedUserUUID = await userRepo.getUserUUID(req.ctx.user, org.UUID, { session })
+      
       updatedUser = await userRepo.updateUserFull(userToEdit.UUID, body, { session }, true, requestingUserUUID)
       await session.commitTransaction()
     } catch (error) {
@@ -456,7 +457,8 @@ async function deleteUser (req, res, next) {
 }
 
 async function grantRole (req, res, next) {
-  const session = await mongoose.startSession()
+  // Explicitly configuring causalConsistency flag for clear DocumentDB context documentation
+  const session = await mongoose.startSession({ causalConsistency: false })
   try {
     const orgShortName = req.ctx.params.shortname
     const username = req.ctx.params.username
@@ -519,7 +521,8 @@ async function grantRole (req, res, next) {
 }
 
 async function revokeRole (req, res, next) {
-  const session = await mongoose.startSession()
+  // Explicitly configuring causalConsistency flag for clear DocumentDB context documentation
+  const session = await mongoose.startSession({ causalConsistency: false })
   try {
     const orgShortName = req.ctx.params.shortname
     const username = req.ctx.params.username

--- a/src/controller/registry-user.controller/registry-user.controller.js
+++ b/src/controller/registry-user.controller/registry-user.controller.js
@@ -390,7 +390,7 @@ async function updateUser (req, res, next) {
       // Move lookups of immutable properties BEFORE the transaction mutation writes to completely bypass read-after-write anomalies
       const requestingUserUUID = await userRepo.getUserUUID(req.ctx.user, req.ctx.org, { session })
       updatedUserUUID = await userRepo.getUserUUID(req.ctx.user, org.UUID, { session })
-      
+
       updatedUser = await userRepo.updateUserFull(userToEdit.UUID, body, { session }, true, requestingUserUUID)
       await session.commitTransaction()
     } catch (error) {


### PR DESCRIPTION
Closes Issue #1673 

# Summary
Properly handling read-after-writes in the registryUserController, through the use of casualConsistency and some minor reordering of calls

# Important Changes
`src/controller/registry-user.controller/registry-user.controller.js`
- Added `casualConsistency: false` to `updateUser()`, `grantRole()`, and `revokeRole()`
- Moved the generation of `updatedUserUUID` before the mutation execution blocks, matching the process for `requestingUserUUID`

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run `npm run test:integration` and ensure all tests pass
- [ ] 2) Run `npm run test:unit-tests` and ensure all tests pass 