### PR TITLE
Resolves issue #1729, Ensures Secretariat organization audit entries store authority in the same array format as BaseOrg documents.

### DIFF
--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -595,8 +595,6 @@ class BaseOrgRepository extends BaseRepository {
     // Write - use org type specific model
     if (registryObjectRaw.authority.includes('SECRETARIAT')) {
       // Write
-      // testing:
-      registryObjectRaw.authority = 'SECRETARIAT'
       const SecretariatObjectToSave = new SecretariatOrgModel(registryObjectRaw)
       if (isSecretariat) {
         registryObject = await SecretariatObjectToSave.save(options)

--- a/test/integration-tests/audit/registryOrgCreatesAuditTest.js
+++ b/test/integration-tests/audit/registryOrgCreatesAuditTest.js
@@ -73,6 +73,20 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
     expect(auditObject.UUID).to.equal(org.uuid)
   })
 
+  it('Should keep Secretariat audit authority consistent with stored org authority', async () => {
+    const org = await createTestOrg({
+      authority: ['SECRETARIAT']
+    })
+
+    const auditRes = await chai.request(app)
+      .get(`/api/audit/org/${org.uuid}`)
+      .set(constants.headers)
+
+    expect(auditRes).to.have.status(200)
+    expect(auditRes.body.history).to.be.an('array').with.lengthOf(1)
+    expect(auditRes.body.history[0].audit_object.authority).to.deep.equal(['SECRETARIAT'])
+  })
+
   it('Should create separate audit documents for multiple orgs', async () => {
     // Create multiple orgs
     const [org1, org2, org3] = await Promise.all([


### PR DESCRIPTION
Closes Issue #1729

# Summary
This PR fixes an audit data inconsistency when creating Secretariat organizations. The create path no longer mutates `authority` from `['SECRETARIAT']` to `'SECRETARIAT'` before writing audit history, so Audit records remain consistent with the stored BaseOrg schema.

# Important Changes
`src/repositories/baseOrgRepository.js`
- Removed the Secretariat-only mutation that converted `authority` from an array to a string.
- Keeps the explicit `SecretariatOrgModel` save path intact.

`test/integration-tests/audit/registryOrgCreatesAuditTest.js`
- Added an integration regression test that creates a Secretariat org through `/api/registry/org`.
- Verifies the audit entry stores `audit_object.authority` as `['SECRETARIAT']`.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Create a Secretariat org with `POST /api/registry/org`.
- [ ] 2) Fetch the audit record with `GET /api/audit/org/:uuid`.
- [ ] 3) Confirm `history[0].audit_object.authority` is `['SECRETARIAT']`.

Automated testing performed:
- `bash -i -c "npm run test:integration"`
- Result: `407 passing`
