### PR TITLE
Resolves Issue #1827, Adding generate and reset_keys test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,8 @@
         "populate-cve:stage": "NODE_ENV=staging node src/scripts/populate-cve.js",
         "populate-cve:int": "NODE_ENV=integration node src/scripts/populate-cve.js",
         "populate-cve:prd": "NODE_ENV=production node src/scripts/populate-cve.js",
+        "generate": "NODE_ENV=test node src/scripts/test_data/generate.js",
+        "reset-keys": "NODE_ENV=test node src/scripts/test_data/reset_keys.js",
         "start:dev": "node src/swagger.js && TZ=utc NODE_ENV=development node src/scripts/updateOpenapiHost.js && TZ=utc NODE_ENV=development node-dev src/index.js",
         "dev": "node src/swagger.js && TZ=utc NODE_ENV=development node src/scripts/updateOpenapiHost.js && TZ=utc NODE_ENV=development node-dev src/index.js",
         "start:stage": "node src/swagger.js && NODE_ENV=staging node src/scripts/updateOpenapiHost.js && NODE_ENV=staging node src/index.js",

--- a/src/scripts/test_data/generate.js
+++ b/src/scripts/test_data/generate.js
@@ -40,7 +40,7 @@ function log (ok, status, label, body) {
 }
 
 // ─── Steps ────────────────────────────────────────────────────────────────────
-async function seedOrgs() {
+async function seedOrgs () {
   console.log(`\n── Seeding ${orgs.length} orgs ─────────────────────────────`)
   const failed = []
 
@@ -56,7 +56,7 @@ async function seedOrgs() {
 
 async function seedUsers () {
   console.log(
-    `\n── Seeding users ────────────────────────────────────────────`,
+    '\n── Seeding users ────────────────────────────────────────────'
   )
   const failed = []
 
@@ -65,8 +65,9 @@ async function seedUsers () {
     for (const user of orgUsers) {
       const { status, ok, body } = await post(`/org/${short_name}/user`, user)
       log(ok, status, user.username, body)
-      if (!ok)
+      if (!ok) {
         failed.push({ short_name, username: user.username, status, body })
+      }
     }
   }
 
@@ -75,7 +76,7 @@ async function seedUsers () {
 
 async function grantAdmins () {
   console.log(
-    `\n── Granting admin roles ─────────────────────────────────────`,
+    '\n── Granting admin roles ─────────────────────────────────────'
   )
   const failed = []
 
@@ -84,11 +85,12 @@ async function grantAdmins () {
     for (const admin of admins) {
       const { status, ok, body } = await post(
         `/org/${short_name}/user/${encodeURIComponent(admin.username)}/grant-role`,
-        { role: 'ADMIN' },
+        { role: 'ADMIN' }
       )
       log(ok, status, `${short_name} / ${admin.username}`, body)
-      if (!ok)
+      if (!ok) {
         failed.push({ short_name, username: admin.username, status, body })
+      }
     }
   }
 

--- a/src/scripts/test_data/generate.js
+++ b/src/scripts/test_data/generate.js
@@ -2,122 +2,122 @@
  * Script to generate and seed test data for CVE Services
  */
 
-const { users, orgs } = require("./testData.js");
-require("dotenv").config();
+const { users, orgs } = require('./testData.js')
+require('dotenv').config()
 
 // ─── Headers ──────────────────────────────────────────────────────────────────
 const HEADERS = {
-  "Content-Type": "application/json",
-  "CVE-API-USER": process.env.VITE_TEST_API_USER,
-  "CVE-API-ORG": process.env.VITE_TEST_API_ORG,
-  "CVE-API-KEY": process.env.VITE_TEST_API_KEY,
-};
-
-const API_URL = `${process.env.VITE_CVE_SERVICES_URL}/api/registry`;
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-async function post(path, body) {
-  const res = await fetch(`${API_URL}${path}`, {
-    method: "POST",
-    headers: HEADERS,
-    body: JSON.stringify(body),
-  });
-
-  const text = await res.text();
-  let parsed;
-  try {
-    parsed = JSON.parse(text);
-  } catch {
-    parsed = text;
-  }
-
-  return { status: res.status, ok: res.ok, body: parsed };
+  'Content-Type': 'application/json',
+  'CVE-API-USER': process.env.VITE_TEST_API_USER,
+  'CVE-API-ORG': process.env.VITE_TEST_API_ORG,
+  'CVE-API-KEY': process.env.VITE_TEST_API_KEY
 }
 
-function log(ok, status, label, body) {
-  if (ok) console.log(`  ✓ [${status}] ${label}`);
-  else console.error(`  ✗ [${status}] ${label}`, JSON.stringify(body, null, 2));
+const API_URL = `${process.env.VITE_CVE_SERVICES_URL}/api/registry`
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+async function post (path, body) {
+  const res = await fetch(`${API_URL}${path}`, {
+    method: 'POST',
+    headers: HEADERS,
+    body: JSON.stringify(body)
+  })
+
+  const text = await res.text()
+  let parsed
+  try {
+    parsed = JSON.parse(text)
+  } catch {
+    parsed = text
+  }
+
+  return { status: res.status, ok: res.ok, body: parsed }
+}
+
+function log (ok, status, label, body) {
+  if (ok) console.log(`  ✓ [${status}] ${label}`)
+  else console.error(`  ✗ [${status}] ${label}`, JSON.stringify(body, null, 2))
 }
 
 // ─── Steps ────────────────────────────────────────────────────────────────────
 async function seedOrgs() {
-  console.log(`\n── Seeding ${orgs.length} orgs ─────────────────────────────`);
-  const failed = [];
+  console.log(`\n── Seeding ${orgs.length} orgs ─────────────────────────────`)
+  const failed = []
 
   for (const org of orgs) {
-    org.long_name = org.long_name + " (fake)";
-    const { status, ok, body } = await post("/org", org);
-    log(ok, status, org.short_name, body);
-    if (!ok) failed.push({ name: org.short_name, status, body });
+    org.long_name = org.long_name + ' (fake)'
+    const { status, ok, body } = await post('/org', org)
+    log(ok, status, org.short_name, body)
+    if (!ok) failed.push({ name: org.short_name, status, body })
   }
 
-  return failed;
+  return failed
 }
 
-async function seedUsers() {
+async function seedUsers () {
   console.log(
     `\n── Seeding users ────────────────────────────────────────────`,
-  );
-  const failed = [];
+  )
+  const failed = []
 
   for (const { short_name, users: orgUsers } of users) {
-    console.log(`  ${short_name}`);
+    console.log(`  ${short_name}`)
     for (const user of orgUsers) {
-      const { status, ok, body } = await post(`/org/${short_name}/user`, user);
-      log(ok, status, user.username, body);
+      const { status, ok, body } = await post(`/org/${short_name}/user`, user)
+      log(ok, status, user.username, body)
       if (!ok)
-        failed.push({ short_name, username: user.username, status, body });
+        failed.push({ short_name, username: user.username, status, body })
     }
   }
 
-  return failed;
+  return failed
 }
 
-async function grantAdmins() {
+async function grantAdmins () {
   console.log(
     `\n── Granting admin roles ─────────────────────────────────────`,
-  );
-  const failed = [];
+  )
+  const failed = []
 
   for (const { short_name, users: orgUsers } of users) {
-    const admins = orgUsers.filter((u) => u.username.includes("_admin@"));
+    const admins = orgUsers.filter((u) => u.username.includes('_admin@'))
     for (const admin of admins) {
       const { status, ok, body } = await post(
         `/org/${short_name}/user/${encodeURIComponent(admin.username)}/grant-role`,
-        { role: "ADMIN" },
-      );
-      log(ok, status, `${short_name} / ${admin.username}`, body);
+        { role: 'ADMIN' },
+      )
+      log(ok, status, `${short_name} / ${admin.username}`, body)
       if (!ok)
-        failed.push({ short_name, username: admin.username, status, body });
+        failed.push({ short_name, username: admin.username, status, body })
     }
   }
 
-  return failed;
+  return failed
 }
 
-function summary(label, failed) {
+function summary (label, failed) {
   if (failed.length) {
-    console.log(`\n  Failed ${label}:`);
-    failed.forEach((f) => console.log(`    • ${f.name ?? f.username}`));
+    console.log(`\n  Failed ${label}:`)
+    failed.forEach((f) => console.log(`    • ${f.name ?? f.username}`))
   }
 }
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
-async function main() {
-  const orgFailed = await seedOrgs();
-  const userFailed = await seedUsers();
-  const adminFailed = await grantAdmins();
+async function main () {
+  const orgFailed = await seedOrgs()
+  const userFailed = await seedUsers()
+  const adminFailed = await grantAdmins()
 
-  console.log(`\n─── Done ───────────────────────────────────────────────────`);
+  console.log(`\n─── Done ───────────────────────────────────────────────────`)
   console.log(
     `  Orgs    : ${orgs.length - orgFailed.length}/${orgs.length} succeeded`,
-  );
-  console.log(`  Users   : failed ${userFailed.length}`);
-  console.log(`  Admins  : failed ${adminFailed.length}`);
+  )
+  console.log(`  Users   : failed ${userFailed.length}`)
+  console.log(`  Admins  : failed ${adminFailed.length}`)
 
-  summary("orgs", orgFailed);
-  summary("users", userFailed);
-  summary("admins", adminFailed);
+  summary('orgs', orgFailed)
+  summary('users', userFailed)
+  summary('admins', adminFailed)
 }
 
-main();
+main()

--- a/src/scripts/test_data/generate.js
+++ b/src/scripts/test_data/generate.js
@@ -1,0 +1,123 @@
+/*
+ * Script to generate and seed test data for CVE Services
+ */
+
+const { users, orgs } = require("./testData.js");
+require("dotenv").config();
+
+// ─── Headers ──────────────────────────────────────────────────────────────────
+const HEADERS = {
+  "Content-Type": "application/json",
+  "CVE-API-USER": process.env.VITE_TEST_API_USER,
+  "CVE-API-ORG": process.env.VITE_TEST_API_ORG,
+  "CVE-API-KEY": process.env.VITE_TEST_API_KEY,
+};
+
+const API_URL = `${process.env.VITE_CVE_SERVICES_URL}/api/registry`;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+async function post(path, body) {
+  const res = await fetch(`${API_URL}${path}`, {
+    method: "POST",
+    headers: HEADERS,
+    body: JSON.stringify(body),
+  });
+
+  const text = await res.text();
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    parsed = text;
+  }
+
+  return { status: res.status, ok: res.ok, body: parsed };
+}
+
+function log(ok, status, label, body) {
+  if (ok) console.log(`  ✓ [${status}] ${label}`);
+  else console.error(`  ✗ [${status}] ${label}`, JSON.stringify(body, null, 2));
+}
+
+// ─── Steps ────────────────────────────────────────────────────────────────────
+async function seedOrgs() {
+  console.log(`\n── Seeding ${orgs.length} orgs ─────────────────────────────`);
+  const failed = [];
+
+  for (const org of orgs) {
+    org.long_name = org.long_name + " (fake)";
+    const { status, ok, body } = await post("/org", org);
+    log(ok, status, org.short_name, body);
+    if (!ok) failed.push({ name: org.short_name, status, body });
+  }
+
+  return failed;
+}
+
+async function seedUsers() {
+  console.log(
+    `\n── Seeding users ────────────────────────────────────────────`,
+  );
+  const failed = [];
+
+  for (const { short_name, users: orgUsers } of users) {
+    console.log(`  ${short_name}`);
+    for (const user of orgUsers) {
+      const { status, ok, body } = await post(`/org/${short_name}/user`, user);
+      log(ok, status, user.username, body);
+      if (!ok)
+        failed.push({ short_name, username: user.username, status, body });
+    }
+  }
+
+  return failed;
+}
+
+async function grantAdmins() {
+  console.log(
+    `\n── Granting admin roles ─────────────────────────────────────`,
+  );
+  const failed = [];
+
+  for (const { short_name, users: orgUsers } of users) {
+    const admins = orgUsers.filter((u) => u.username.includes("_admin@"));
+    for (const admin of admins) {
+      const { status, ok, body } = await post(
+        `/org/${short_name}/user/${encodeURIComponent(admin.username)}/grant-role`,
+        { role: "ADMIN" },
+      );
+      log(ok, status, `${short_name} / ${admin.username}`, body);
+      if (!ok)
+        failed.push({ short_name, username: admin.username, status, body });
+    }
+  }
+
+  return failed;
+}
+
+function summary(label, failed) {
+  if (failed.length) {
+    console.log(`\n  Failed ${label}:`);
+    failed.forEach((f) => console.log(`    • ${f.name ?? f.username}`));
+  }
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+async function main() {
+  const orgFailed = await seedOrgs();
+  const userFailed = await seedUsers();
+  const adminFailed = await grantAdmins();
+
+  console.log(`\n─── Done ───────────────────────────────────────────────────`);
+  console.log(
+    `  Orgs    : ${orgs.length - orgFailed.length}/${orgs.length} succeeded`,
+  );
+  console.log(`  Users   : failed ${userFailed.length}`);
+  console.log(`  Admins  : failed ${adminFailed.length}`);
+
+  summary("orgs", orgFailed);
+  summary("users", userFailed);
+  summary("admins", adminFailed);
+}
+
+main();

--- a/src/scripts/test_data/generate.js
+++ b/src/scripts/test_data/generate.js
@@ -1,3 +1,5 @@
+/* eslint-disable camelcase */
+
 /*
  * Script to generate and seed test data for CVE Services
  */
@@ -110,9 +112,9 @@ async function main () {
   const userFailed = await seedUsers()
   const adminFailed = await grantAdmins()
 
-  console.log(`\n─── Done ───────────────────────────────────────────────────`)
+  console.log('\n─── Done ───────────────────────────────────────────────────')
   console.log(
-    `  Orgs    : ${orgs.length - orgFailed.length}/${orgs.length} succeeded`,
+    `  Orgs    : ${orgs.length - orgFailed.length}/${orgs.length} succeeded`
   )
   console.log(`  Users   : failed ${userFailed.length}`)
   console.log(`  Admins  : failed ${adminFailed.length}`)

--- a/src/scripts/test_data/reset_keys.js
+++ b/src/scripts/test_data/reset_keys.js
@@ -1,67 +1,67 @@
-const { MongoClient } = require("mongodb");
-const { users } = require("./testData.js");
-require("dotenv").config();
+const { MongoClient } = require('mongodb')
+const { users } = require('./testData.js')
+require('dotenv').config()
 
-async function clearBaseUserSecrets() {
-  const secret = process.env.TEST_DATA_USER_SECRET_HASH;
+async function clearBaseUserSecrets () {
+  const secret = process.env.TEST_DATA_USER_SECRET_HASH
   if (!secret) {
-    throw new Error("TEST_DATA_USER_SECRET_HASH must be set.");
+    throw new Error('TEST_DATA_USER_SECRET_HASH must be set.')
   }
 
   const usernames = [
-    ...new Set(users.flatMap((org) => org.users.map((user) => user.username))),
-  ];
+    ...new Set(users.flatMap((org) => org.users.map((user) => user.username)))
+  ]
   if (!usernames.length) {
-    throw new Error("No test users found in testData.js.");
+    throw new Error('No test users found in testData.js.')
   }
 
-  const url = process.env.TEST_DATA_MONGO_URL ?? "mongodb://localhost:27017";
-  const client = new MongoClient(url);
+  const url = process.env.TEST_DATA_MONGO_URL ?? 'mongodb://localhost:27017'
+  const client = new MongoClient(url)
 
-  const dbName = process.env.TEST_DATA_MONGO_DB ?? "cve_dev";
-  const collectionName = process.env.TEST_DATA_USER_COLLECTION ?? "BaseUser";
+  const dbName = process.env.TEST_DATA_MONGO_DB ?? 'cve_dev'
+  const collectionName = process.env.TEST_DATA_USER_COLLECTION ?? 'BaseUser'
 
   try {
-    await client.connect();
-    console.log("Successfully connected to MongoDB");
+    await client.connect()
+    console.log('Successfully connected to MongoDB')
 
-    const db = client.db(dbName);
-    const collection = db.collection(collectionName);
-    const userFilter = { username: { $in: usernames } };
+    const db = client.db(dbName)
+    const collection = db.collection(collectionName)
+    const userFilter = { username: { $in: usernames } }
 
     const foundUsers = await collection
       .find(userFilter, { projection: { username: 1 } })
-      .toArray();
+      .toArray()
 
     if (foundUsers.length !== usernames.length) {
-      const foundUsernames = new Set(foundUsers.map((user) => user.username));
+      const foundUsernames = new Set(foundUsers.map((user) => user.username))
       const missing = usernames.filter(
-        (username) => !foundUsernames.has(username),
-      );
+        (username) => !foundUsernames.has(username)
+      )
       throw new Error(
-        `Expected ${usernames.length} test users but found ${foundUsers.length}. Missing: ${missing.join(", ") || "none"}`,
-      );
+        `Expected ${usernames.length} test users but found ${foundUsers.length}. Missing: ${missing.join(', ') || 'none'}`
+      )
     }
 
     const result = await collection.updateMany(
       userFilter,
       {
         $set: {
-          secret,
-        },
-      },
-    );
+          secret
+        }
+      }
+    )
 
-    console.log(`Targeted ${usernames.length} test users.`);
-    console.log(`Matched ${result.matchedCount} documents.`);
-    console.log(`Updated ${result.modifiedCount} documents.`);
+    console.log(`Targeted ${usernames.length} test users.`)
+    console.log(`Matched ${result.matchedCount} documents.`)
+    console.log(`Updated ${result.modifiedCount} documents.`)
   } catch (error) {
-    console.error("An error occurred:", error);
-    process.exitCode = 1;
+    console.error('An error occurred:', error)
+    process.exitCode = 1
   } finally {
-    await client.close();
-    console.log("Connection closed.");
+    await client.close()
+    console.log('Connection closed.')
   }
 }
 
-clearBaseUserSecrets();
+clearBaseUserSecrets()

--- a/src/scripts/test_data/reset_keys.js
+++ b/src/scripts/test_data/reset_keys.js
@@ -1,0 +1,67 @@
+const { MongoClient } = require("mongodb");
+const { users } = require("./testData.js");
+require("dotenv").config();
+
+async function clearBaseUserSecrets() {
+  const secret = process.env.TEST_DATA_USER_SECRET_HASH;
+  if (!secret) {
+    throw new Error("TEST_DATA_USER_SECRET_HASH must be set.");
+  }
+
+  const usernames = [
+    ...new Set(users.flatMap((org) => org.users.map((user) => user.username))),
+  ];
+  if (!usernames.length) {
+    throw new Error("No test users found in testData.js.");
+  }
+
+  const url = process.env.TEST_DATA_MONGO_URL ?? "mongodb://localhost:27017";
+  const client = new MongoClient(url);
+
+  const dbName = process.env.TEST_DATA_MONGO_DB ?? "cve_dev";
+  const collectionName = process.env.TEST_DATA_USER_COLLECTION ?? "BaseUser";
+
+  try {
+    await client.connect();
+    console.log("Successfully connected to MongoDB");
+
+    const db = client.db(dbName);
+    const collection = db.collection(collectionName);
+    const userFilter = { username: { $in: usernames } };
+
+    const foundUsers = await collection
+      .find(userFilter, { projection: { username: 1 } })
+      .toArray();
+
+    if (foundUsers.length !== usernames.length) {
+      const foundUsernames = new Set(foundUsers.map((user) => user.username));
+      const missing = usernames.filter(
+        (username) => !foundUsernames.has(username),
+      );
+      throw new Error(
+        `Expected ${usernames.length} test users but found ${foundUsers.length}. Missing: ${missing.join(", ") || "none"}`,
+      );
+    }
+
+    const result = await collection.updateMany(
+      userFilter,
+      {
+        $set: {
+          secret,
+        },
+      },
+    );
+
+    console.log(`Targeted ${usernames.length} test users.`);
+    console.log(`Matched ${result.matchedCount} documents.`);
+    console.log(`Updated ${result.modifiedCount} documents.`);
+  } catch (error) {
+    console.error("An error occurred:", error);
+    process.exitCode = 1;
+  } finally {
+    await client.close();
+    console.log("Connection closed.");
+  }
+}
+
+clearBaseUserSecrets();

--- a/src/scripts/test_data/testData.js
+++ b/src/scripts/test_data/testData.js
@@ -363,7 +363,7 @@ export const users = [
         username: 'vcastro@acra.example.co'
       }
     ]
-  },
+  }
 ]
 
 export const orgs = [
@@ -407,7 +407,7 @@ export const orgs = [
     },
     charter_or_scope: 'https://acmesecurity.example.com/charter',
     disclosure_policy: 'https://acmesecurity.example.com/disclosure',
-    product_list: 'https://acmesecurity.example.com/products',
+    product_list: 'https://acmesecurity.example.com/products'
   },
   {
     authority: ['CNA'],
@@ -444,7 +444,7 @@ export const orgs = [
       vulnerability_advisory_location_for_web_scraping: [
         'https://cetil.example.de/advisories'
       ],
-      advisory_location_require_credentials: true,
+      advisory_location_require_credentials: true
     },
     charter_or_scope: 'https://cetil.example.de/scope',
     disclosure_policy: 'https://cetil.example.de/disclosure'
@@ -581,8 +581,8 @@ export const orgs = [
       cve_website_update_needed: false,
       advisory_location_require_credentials: true,
       vulnerability_advisory_location_for_web_scraping: [
-        'https://fncap.example.fr/advisories',
-      ],
+        'https://fncap.example.fr/advisories'
+      ]
     }
   },
   {
@@ -641,7 +641,7 @@ export const orgs = [
       vulnerability_advisory_location_for_web_scraping: [
         'https://ukhssl.example.co.uk/security'
       ],
-      advisory_location_require_credentials: true,
+      advisory_location_require_credentials: true
     },
     charter_or_scope: 'https://ukhssl.example.co.uk/scope',
     disclosure_policy: 'https://ukhssl.example.co.uk/disclosure',
@@ -709,7 +709,7 @@ export const orgs = [
       partner_active_date: '2019-11-05',
       cve_website_update_needed: false,
       advisory_location_require_credentials: false
-    },
+    }
   },
   {
     authority: ['SECRETARIAT'],
@@ -845,7 +845,7 @@ export const orgs = [
       partner_active_date: '2021-01-10',
       cve_website_update_needed: false,
       advisory_location_require_credentials: false
-    },
+    }
   },
   {
     authority: ['CNA'],
@@ -984,5 +984,5 @@ export const orgs = [
     },
     charter_or_scope: 'https://acra.example.co/charter',
     disclosure_policy: 'https://acra.example.co/disclosure'
-  },
+  }
 ]

--- a/src/scripts/test_data/testData.js
+++ b/src/scripts/test_data/testData.js
@@ -1,988 +1,988 @@
 export const users = [
   {
-    short_name: "ASRG_FAKE",
+    short_name: 'ASRG_FAKE',
     users: [
       {
-        name: { first: "Jane", last: "Holloway" },
-        status: "active",
-        username: "jholloway_admin@acmesecurity.example.com",
+        name: { first: 'Jane', last: 'Holloway' },
+        status: 'active',
+        username: 'jholloway_admin@acmesecurity.example.com'
       },
       {
-        name: { first: "Brian", last: "Stokes" },
-        status: "active",
-        username: "bstokes@acmesecurity.example.com",
+        name: { first: 'Brian', last: 'Stokes' },
+        status: 'active',
+        username: 'bstokes@acmesecurity.example.com'
       },
       {
-        name: { first: "Rachel", last: "Torres", middle: "A" },
-        status: "active",
-        username: "rtorres@acmesecurity.example.com",
-      },
-    ],
+        name: { first: 'Rachel', last: 'Torres', middle: 'A' },
+        status: 'active',
+        username: 'rtorres@acmesecurity.example.com'
+      }
+    ]
   },
   {
-    short_name: "CETIL_FAKE",
+    short_name: 'CETIL_FAKE',
     users: [
       {
-        name: { first: "Klaus", last: "Bauer" },
-        status: "active",
-        username: "kbauer_admin@cetil.example.de",
+        name: { first: 'Klaus', last: 'Bauer' },
+        status: 'active',
+        username: 'kbauer_admin@cetil.example.de'
       },
       {
-        name: { first: "Heike", last: "Vogel" },
-        status: "active",
-        username: "hvogel@cetil.example.de",
+        name: { first: 'Heike', last: 'Vogel' },
+        status: 'active',
+        username: 'hvogel@cetil.example.de'
       },
       {
-        name: { first: "Marcus", last: "Schreiber", middle: "J" },
-        status: "active",
-        username: "mschreiber@cetil.example.de",
-      },
-    ],
+        name: { first: 'Marcus', last: 'Schreiber', middle: 'J' },
+        status: 'active',
+        username: 'mschreiber@cetil.example.de'
+      }
+    ]
   },
   {
-    short_name: "KVIC_FAKE",
+    short_name: 'KVIC_FAKE',
     users: [
       {
-        name: { first: "Ji-ho", last: "Park" },
-        status: "active",
-        username: "jhpark_admin@kvic.example.kr",
+        name: { first: 'Ji-ho', last: 'Park' },
+        status: 'active',
+        username: 'jhpark_admin@kvic.example.kr'
       },
       {
-        name: { first: "Soo-yeon", last: "Kim" },
-        status: "active",
-        username: "sykim@kvic.example.kr",
-      },
-    ],
+        name: { first: 'Soo-yeon', last: 'Kim' },
+        status: 'active',
+        username: 'sykim@kvic.example.kr'
+      }
+    ]
   },
   {
-    short_name: "NAVE_FAKE",
+    short_name: 'NAVE_FAKE',
     users: [
       {
-        name: { first: "Priya", last: "Mehta" },
-        status: "active",
-        username: "pmehta_admin@nave.example.ca",
+        name: { first: 'Priya', last: 'Mehta' },
+        status: 'active',
+        username: 'pmehta_admin@nave.example.ca'
       },
       {
-        name: { first: "Daniel", last: "Okafor" },
-        status: "active",
-        username: "dokafor@nave.example.ca",
+        name: { first: 'Daniel', last: 'Okafor' },
+        status: 'active',
+        username: 'dokafor@nave.example.ca'
       },
       {
-        name: { first: "Samantha", last: "Cho", suffix: "Jr" },
-        status: "active",
-        username: "scho@nave.example.ca",
-      },
-    ],
+        name: { first: 'Samantha', last: 'Cho', suffix: 'Jr' },
+        status: 'active',
+        username: 'scho@nave.example.ca'
+      }
+    ]
   },
   {
-    short_name: "SPSG_FAKE",
+    short_name: 'SPSG_FAKE',
     users: [
       {
-        name: { first: "Hans", last: "Müller" },
-        status: "active",
-        username: "hmuller_admin@spsg.example.ch",
+        name: { first: 'Hans', last: 'Müller' },
+        status: 'active',
+        username: 'hmuller_admin@spsg.example.ch'
       },
       {
-        name: { first: "Ursula", last: "Frei" },
-        status: "active",
-        username: "ufrei@spsg.example.ch",
+        name: { first: 'Ursula', last: 'Frei' },
+        status: 'active',
+        username: 'ufrei@spsg.example.ch'
       },
       {
-        name: { first: "Thomas", last: "Keller", middle: "R" },
-        status: "active",
-        username: "tkeller@spsg.example.ch",
-      },
-    ],
+        name: { first: 'Thomas', last: 'Keller', middle: 'R' },
+        status: 'active',
+        username: 'tkeller@spsg.example.ch'
+      }
+    ]
   },
   {
-    short_name: "FNCAP_FAKE",
+    short_name: 'FNCAP_FAKE',
     users: [
       {
-        name: { first: "Sophie", last: "Leclerc" },
-        status: "active",
-        username: "sleclerc_admin@fncap.example.fr",
+        name: { first: 'Sophie', last: 'Leclerc' },
+        status: 'active',
+        username: 'sleclerc_admin@fncap.example.fr'
       },
       {
-        name: { first: "Pierre", last: "Dubois" },
-        status: "active",
-        username: "pdubois@fncap.example.fr",
-      },
-    ],
+        name: { first: 'Pierre', last: 'Dubois' },
+        status: 'active',
+        username: 'pdubois@fncap.example.fr'
+      }
+    ]
   },
   {
-    short_name: "IVCC_FAKE",
+    short_name: 'IVCC_FAKE',
     users: [
       {
-        name: { first: "Carmen", last: "Delgado" },
-        status: "active",
-        username: "cdelgado_admin@ivcc.example.es",
+        name: { first: 'Carmen', last: 'Delgado' },
+        status: 'active',
+        username: 'cdelgado_admin@ivcc.example.es'
       },
       {
-        name: { first: "Rafael", last: "Montoya", middle: "E" },
-        status: "active",
-        username: "rmontoya@ivcc.example.es",
+        name: { first: 'Rafael', last: 'Montoya', middle: 'E' },
+        status: 'active',
+        username: 'rmontoya@ivcc.example.es'
       },
       {
-        name: { first: "Lucia", last: "Vega" },
-        status: "active",
-        username: "lvega@ivcc.example.es",
-      },
-    ],
+        name: { first: 'Lucia', last: 'Vega' },
+        status: 'active',
+        username: 'lvega@ivcc.example.es'
+      }
+    ]
   },
   {
-    short_name: "UKHSSL_FAKE",
+    short_name: 'UKHSSL_FAKE',
     users: [
       {
-        name: { first: "James", last: "Whitfield" },
-        status: "active",
-        username: "jwhitfield_admin@ukhssl.example.co.uk",
+        name: { first: 'James', last: 'Whitfield' },
+        status: 'active',
+        username: 'jwhitfield_admin@ukhssl.example.co.uk'
       },
       {
-        name: { first: "Emily", last: "Harrison", suffix: "OBE" },
-        status: "active",
-        username: "eharrison@ukhssl.example.co.uk",
+        name: { first: 'Emily', last: 'Harrison', suffix: 'OBE' },
+        status: 'active',
+        username: 'eharrison@ukhssl.example.co.uk'
       },
       {
-        name: { first: "Nigel", last: "Forsythe", middle: "P" },
-        status: "active",
-        username: "nforsythe@ukhssl.example.co.uk",
-      },
-    ],
+        name: { first: 'Nigel', last: 'Forsythe', middle: 'P' },
+        status: 'active',
+        username: 'nforsythe@ukhssl.example.co.uk'
+      }
+    ]
   },
   {
-    short_name: "EEBBN_FAKE",
+    short_name: 'EEBBN_FAKE',
     users: [
       {
-        name: { first: "Tomasz", last: "Wieczorek" },
-        status: "active",
-        username: "twieczorek_admin@eebbn.example.pl",
+        name: { first: 'Tomasz', last: 'Wieczorek' },
+        status: 'active',
+        username: 'twieczorek_admin@eebbn.example.pl'
       },
       {
-        name: { first: "Agnieszka", last: "Kowalska" },
-        status: "active",
-        username: "akowalska@eebbn.example.pl",
-      },
-    ],
+        name: { first: 'Agnieszka', last: 'Kowalska' },
+        status: 'active',
+        username: 'akowalska@eebbn.example.pl'
+      }
+    ]
   },
   {
-    short_name: "BCOC_FAKE",
+    short_name: 'BCOC_FAKE',
     users: [
       {
-        name: { first: "Lucas", last: "Ferreira" },
-        status: "active",
-        username: "lferreira_admin@bcoc.example.br",
+        name: { first: 'Lucas', last: 'Ferreira' },
+        status: 'active',
+        username: 'lferreira_admin@bcoc.example.br'
       },
       {
-        name: { first: "Ana", last: "Souza", middle: "M" },
-        status: "active",
-        username: "asouza@bcoc.example.br",
+        name: { first: 'Ana', last: 'Souza', middle: 'M' },
+        status: 'active',
+        username: 'asouza@bcoc.example.br'
       },
       {
-        name: { first: "Carlos", last: "Mendes" },
-        status: "active",
-        username: "cmendes@bcoc.example.br",
-      },
-    ],
+        name: { first: 'Carlos', last: 'Mendes' },
+        status: 'active',
+        username: 'cmendes@bcoc.example.br'
+      }
+    ]
   },
   {
-    short_name: "GVSA_FAKE",
+    short_name: 'GVSA_FAKE',
     users: [
       {
-        name: { first: "Margaret", last: "Collins" },
-        status: "active",
-        username: "mcollins_admin@gvsa.example.org",
+        name: { first: 'Margaret', last: 'Collins' },
+        status: 'active',
+        username: 'mcollins_admin@gvsa.example.org'
       },
       {
-        name: { first: "Robert", last: "Haines", suffix: "III" },
-        status: "active",
-        username: "rhaines@gvsa.example.org",
+        name: { first: 'Robert', last: 'Haines', suffix: 'III' },
+        status: 'active',
+        username: 'rhaines@gvsa.example.org'
       },
       {
-        name: { first: "Diana", last: "Patel", middle: "L" },
-        status: "active",
-        username: "dpatel@gvsa.example.org",
-      },
-    ],
+        name: { first: 'Diana', last: 'Patel', middle: 'L' },
+        status: 'active',
+        username: 'dpatel@gvsa.example.org'
+      }
+    ]
   },
   {
-    short_name: "NCDI_FAKE",
+    short_name: 'NCDI_FAKE',
     users: [
       {
-        name: { first: "Erik", last: "Lindgren" },
-        status: "active",
-        username: "elindgren_admin@ncdi.example.no",
+        name: { first: 'Erik', last: 'Lindgren' },
+        status: 'active',
+        username: 'elindgren_admin@ncdi.example.no'
       },
       {
-        name: { first: "Astrid", last: "Haugen" },
-        status: "active",
-        username: "ahaugen@ncdi.example.no",
+        name: { first: 'Astrid', last: 'Haugen' },
+        status: 'active',
+        username: 'ahaugen@ncdi.example.no'
       },
       {
-        name: { first: "Bjorn", last: "Stavanger", middle: "K" },
-        status: "active",
-        username: "bstavanger@ncdi.example.no",
-      },
-    ],
+        name: { first: 'Bjorn', last: 'Stavanger', middle: 'K' },
+        status: 'active',
+        username: 'bstavanger@ncdi.example.no'
+      }
+    ]
   },
   {
-    short_name: "SCDA_FAKE",
+    short_name: 'SCDA_FAKE',
     users: [
       {
-        name: { first: "Olivia", last: "Chen" },
-        status: "active",
-        username: "ochen_admin@scda.example.au",
+        name: { first: 'Olivia', last: 'Chen' },
+        status: 'active',
+        username: 'ochen_admin@scda.example.au'
       },
       {
-        name: { first: "Liam", last: "Nguyen" },
-        status: "active",
-        username: "lnguyen@scda.example.au",
-      },
-    ],
+        name: { first: 'Liam', last: 'Nguyen' },
+        status: 'active',
+        username: 'lnguyen@scda.example.au'
+      }
+    ]
   },
   {
-    short_name: "ISCRU_FAKE",
+    short_name: 'ISCRU_FAKE',
     users: [
       {
-        name: { first: "Ravi", last: "Krishnamurthy" },
-        status: "active",
-        username: "rkrishnamurthy_admin@iscru.example.in",
+        name: { first: 'Ravi', last: 'Krishnamurthy' },
+        status: 'active',
+        username: 'rkrishnamurthy_admin@iscru.example.in'
       },
       {
-        name: { first: "Deepa", last: "Nair" },
-        status: "active",
-        username: "dnair@iscru.example.in",
+        name: { first: 'Deepa', last: 'Nair' },
+        status: 'active',
+        username: 'dnair@iscru.example.in'
       },
       {
-        name: { first: "Arjun", last: "Sharma", middle: "V" },
-        status: "active",
-        username: "asharma@iscru.example.in",
-      },
-    ],
+        name: { first: 'Arjun', last: 'Sharma', middle: 'V' },
+        status: 'active',
+        username: 'asharma@iscru.example.in'
+      }
+    ]
   },
   {
-    short_name: "PROSC_FAKE",
+    short_name: 'PROSC_FAKE',
     users: [
       {
-        name: { first: "Haruki", last: "Yamamoto" },
-        status: "active",
-        username: "hyamamoto_admin@prosc.example.jp",
+        name: { first: 'Haruki', last: 'Yamamoto' },
+        status: 'active',
+        username: 'hyamamoto_admin@prosc.example.jp'
       },
       {
-        name: { first: "Yuki", last: "Tanaka" },
-        status: "active",
-        username: "ytanaka@prosc.example.jp",
-      },
-    ],
+        name: { first: 'Yuki', last: 'Tanaka' },
+        status: 'active',
+        username: 'ytanaka@prosc.example.jp'
+      }
+    ]
   },
   {
-    short_name: "SACA_FAKE",
+    short_name: 'SACA_FAKE',
     users: [
       {
-        name: { first: "Wei Liang", last: "Tan" },
-        status: "active",
-        username: "wltan_admin@saca.example.sg",
+        name: { first: 'Wei Liang', last: 'Tan' },
+        status: 'active',
+        username: 'wltan_admin@saca.example.sg'
       },
       {
-        name: { first: "Mei Lin", last: "Chua" },
-        status: "active",
-        username: "mlchua@saca.example.sg",
+        name: { first: 'Mei Lin', last: 'Chua' },
+        status: 'active',
+        username: 'mlchua@saca.example.sg'
       },
       {
-        name: { first: "Jun Wei", last: "Lim", middle: "H" },
-        status: "active",
-        username: "jwlim@saca.example.sg",
-      },
-    ],
+        name: { first: 'Jun Wei', last: 'Lim', middle: 'H' },
+        status: 'active',
+        username: 'jwlim@saca.example.sg'
+      }
+    ]
   },
   {
-    short_name: "MEVRC_FAKE",
+    short_name: 'MEVRC_FAKE',
     users: [
       {
-        name: { first: "Yael", last: "Shapiro" },
-        status: "active",
-        username: "yshapiro_admin@mevrc.example.il",
+        name: { first: 'Yael', last: 'Shapiro' },
+        status: 'active',
+        username: 'yshapiro_admin@mevrc.example.il'
       },
       {
-        name: { first: "Avi", last: "Cohen" },
-        status: "active",
-        username: "acohen@mevrc.example.il",
-      },
-    ],
+        name: { first: 'Avi', last: 'Cohen' },
+        status: 'active',
+        username: 'acohen@mevrc.example.il'
+      }
+    ]
   },
   {
-    short_name: "OVDI_FAKE",
+    short_name: 'OVDI_FAKE',
     users: [
       {
-        name: { first: "Dirk", last: "van der Berg" },
-        status: "active",
-        username: "dvandenberg_admin@ovdi.example.nl",
+        name: { first: 'Dirk', last: 'van der Berg' },
+        status: 'active',
+        username: 'dvandenberg_admin@ovdi.example.nl'
       },
       {
-        name: { first: "Femke", last: "de Vries" },
-        status: "active",
-        username: "fdevries@ovdi.example.nl",
+        name: { first: 'Femke', last: 'de Vries' },
+        status: 'active',
+        username: 'fdevries@ovdi.example.nl'
       },
       {
-        name: { first: "Pieter", last: "Janssen", middle: "C" },
-        status: "active",
-        username: "pjanssen@ovdi.example.nl",
-      },
-    ],
+        name: { first: 'Pieter', last: 'Janssen', middle: 'C' },
+        status: 'active',
+        username: 'pjanssen@ovdi.example.nl'
+      }
+    ]
   },
   {
-    short_name: "ACTE_FAKE",
+    short_name: 'ACTE_FAKE',
     users: [
       {
-        name: { first: "Amara", last: "Diallo" },
-        status: "active",
-        username: "adiallo_admin@acte.example.za",
+        name: { first: 'Amara', last: 'Diallo' },
+        status: 'active',
+        username: 'adiallo_admin@acte.example.za'
       },
       {
-        name: { first: "Kwame", last: "Mensah" },
-        status: "active",
-        username: "kmensah@acte.example.za",
-      },
-    ],
+        name: { first: 'Kwame', last: 'Mensah' },
+        status: 'active',
+        username: 'kmensah@acte.example.za'
+      }
+    ]
   },
   {
-    short_name: "ACRA_FAKE",
+    short_name: 'ACRA_FAKE',
     users: [
       {
-        name: { first: "Isabella", last: "Moreno" },
-        status: "active",
-        username: "imoreno_admin@acra.example.co",
+        name: { first: 'Isabella', last: 'Moreno' },
+        status: 'active',
+        username: 'imoreno_admin@acra.example.co'
       },
       {
-        name: { first: "Carlos", last: "Ruiz", middle: "A" },
-        status: "active",
-        username: "cruiz@acra.example.co",
+        name: { first: 'Carlos', last: 'Ruiz', middle: 'A' },
+        status: 'active',
+        username: 'cruiz@acra.example.co'
       },
       {
-        name: { first: "Valentina", last: "Castro" },
-        status: "active",
-        username: "vcastro@acra.example.co",
-      },
-    ],
+        name: { first: 'Valentina', last: 'Castro' },
+        status: 'active',
+        username: 'vcastro@acra.example.co'
+      }
+    ]
   },
-];
+]
 
 export const orgs = [
   {
-    authority: ["CNA"],
-    long_name: "Acme Security Research Group",
-    short_name: "ASRG_FAKE",
-    partner_number: "CNA-2015-0001",
-    top_level_root: "MITRE TLR",
-    aliases: ["Acme Research", "ASRG Security"],
-    partner_role_type: "Vendor",
-    partner_country: "United States",
-    industry: "Information Technology",
+    authority: ['CNA'],
+    long_name: 'Acme Security Research Group',
+    short_name: 'ASRG_FAKE',
+    partner_number: 'CNA-2015-0001',
+    top_level_root: 'MITRE TLR',
+    aliases: ['Acme Research', 'ASRG Security'],
+    partner_role_type: 'Vendor',
+    partner_country: 'United States',
+    industry: 'Information Technology',
     hard_quota: 500,
     soft_quota: 400,
-    advisory_locations: ["https://acmesecurity.example.com/advisories"],
+    advisory_locations: ['https://acmesecurity.example.com/advisories'],
     is_cna_discussion_list: true,
     contact_info: {
-      phone: "+1-555-210-3344",
+      phone: '+1-555-210-3344',
       emails: [
-        "jholloway@acmesecurity.example.com",
-        "security@acmesecurity.example.com",
+        'jholloway@acmesecurity.example.com',
+        'security@acmesecurity.example.com'
       ],
-      websites: ["https://acmesecurity.example.com"],
+      websites: ['https://acmesecurity.example.com']
     },
     private_contacts: [
       {
-        phone: "+1-555-210-3345",
-        poc_email: "bstokes@acmesecurity.example.com",
-      },
+        phone: '+1-555-210-3345',
+        poc_email: 'bstokes@acmesecurity.example.com'
+      }
     ],
     program_data: {
-      status: "Active",
-      partner_active_date: "2015-03-15",
+      status: 'Active',
+      partner_active_date: '2015-03-15',
       cve_website_update_needed: false,
-      cve_website_update_date: "2024-11-01T10:00:00Z",
+      cve_website_update_date: '2024-11-01T10:00:00Z',
       vulnerability_advisory_location_for_web_scraping: [
-        "https://acmesecurity.example.com/advisories",
+        'https://acmesecurity.example.com/advisories'
       ],
-      advisory_location_require_credentials: false,
+      advisory_location_require_credentials: false
     },
-    charter_or_scope: "https://acmesecurity.example.com/charter",
-    disclosure_policy: "https://acmesecurity.example.com/disclosure",
-    product_list: "https://acmesecurity.example.com/products",
+    charter_or_scope: 'https://acmesecurity.example.com/charter',
+    disclosure_policy: 'https://acmesecurity.example.com/disclosure',
+    product_list: 'https://acmesecurity.example.com/products',
   },
   {
-    authority: ["CNA"],
-    long_name: "Central European Threat Intelligence Lab",
-    short_name: "CETIL_FAKE",
-    partner_number: "CNA-2015-0002",
-    top_level_root: "CISA TLR",
-    aliases: ["CETIL Labs"],
-    partner_role_type: "Researcher",
-    partner_country: "Germany",
+    authority: ['CNA'],
+    long_name: 'Central European Threat Intelligence Lab',
+    short_name: 'CETIL_FAKE',
+    partner_number: 'CNA-2015-0002',
+    top_level_root: 'CISA TLR',
+    aliases: ['CETIL Labs'],
+    partner_role_type: 'Researcher',
+    partner_country: 'Germany',
     hard_quota: 400,
     soft_quota: 350,
-    advisory_locations: ["https://cetil.example.de/advisories"],
+    advisory_locations: ['https://cetil.example.de/advisories'],
     is_cna_discussion_list: false,
     contact_info: {
-      phone: "+49-30-555-2211",
-      emails: ["kbauer@cetil.example.de"],
-      websites: ["https://cetil.example.de"],
+      phone: '+49-30-555-2211',
+      emails: ['kbauer@cetil.example.de'],
+      websites: ['https://cetil.example.de']
     },
     private_contacts: [
       {
-        phone: "+49-30-555-2212",
-        poc_email: "hvogel@cetil.example.de",
+        phone: '+49-30-555-2212',
+        poc_email: 'hvogel@cetil.example.de'
       },
       {
-        poc_email: "security@cetil.example.de",
-      },
+        poc_email: 'security@cetil.example.de'
+      }
     ],
     program_data: {
-      status: "Active",
-      partner_active_date: "2015-05-12",
+      status: 'Active',
+      partner_active_date: '2015-05-12',
       cve_website_update_needed: true,
-      cve_website_update_date: "2025-01-15T08:30:00Z",
+      cve_website_update_date: '2025-01-15T08:30:00Z',
       vulnerability_advisory_location_for_web_scraping: [
-        "https://cetil.example.de/advisories",
+        'https://cetil.example.de/advisories'
       ],
       advisory_location_require_credentials: true,
     },
-    charter_or_scope: "https://cetil.example.de/scope",
-    disclosure_policy: "https://cetil.example.de/disclosure",
+    charter_or_scope: 'https://cetil.example.de/scope',
+    disclosure_policy: 'https://cetil.example.de/disclosure'
   },
   {
-    authority: ["CNA"],
-    long_name: "Korean Vulnerability Intelligence Center",
-    short_name: "KVIC_FAKE",
-    partner_number: "CNA-2016-0001",
-    top_level_root: "MITRE TLR",
-    partner_role_type: "Vendor",
-    partner_country: "South Korea",
+    authority: ['CNA'],
+    long_name: 'Korean Vulnerability Intelligence Center',
+    short_name: 'KVIC_FAKE',
+    partner_number: 'CNA-2016-0001',
+    top_level_root: 'MITRE TLR',
+    partner_role_type: 'Vendor',
+    partner_country: 'South Korea',
     hard_quota: 380,
     soft_quota: 320,
-    advisory_locations: ["https://kvic.example.kr/advisories"],
+    advisory_locations: ['https://kvic.example.kr/advisories'],
     is_cna_discussion_list: false,
     contact_info: {
-      phone: "+82-2-5555-1122",
-      emails: ["jhpark@kvic.example.kr"],
-      websites: ["https://kvic.example.kr"],
+      phone: '+82-2-5555-1122',
+      emails: ['jhpark@kvic.example.kr'],
+      websites: ['https://kvic.example.kr']
     },
     private_contacts: [
       {
-        phone: "+82-2-5555-1123",
-        poc_email: "sykim@kvic.example.kr",
+        phone: '+82-2-5555-1123',
+        poc_email: 'sykim@kvic.example.kr'
       },
       {
-        phone: "+82-2-5555-1124",
-      },
+        phone: '+82-2-5555-1124'
+      }
     ],
     program_data: {
-      status: "Active",
-      partner_active_date: "2016-03-20",
+      status: 'Active',
+      partner_active_date: '2016-03-20',
       cve_website_update_needed: false,
-      cve_website_update_date: "2024-10-15T12:00:00Z",
+      cve_website_update_date: '2024-10-15T12:00:00Z',
       advisory_location_require_credentials: false,
       vulnerability_advisory_location_for_web_scraping: [
-        "https://kvic.example.kr/advisories",
-      ],
+        'https://kvic.example.kr/advisories'
+      ]
     },
-    charter_or_scope: "https://kvic.example.kr/charter",
-    disclosure_policy: "https://kvic.example.kr/disclosure",
-    product_list: "https://kvic.example.kr/products",
+    charter_or_scope: 'https://kvic.example.kr/charter',
+    disclosure_policy: 'https://kvic.example.kr/disclosure',
+    product_list: 'https://kvic.example.kr/products'
   },
   {
-    authority: ["CNA"],
-    long_name: "North American Vulnerability Exchange",
-    short_name: "NAVE_FAKE",
-    partner_number: "CNA-2016-0002",
-    top_level_root: "CISA TLR",
-    partner_role_type: "Consortium",
-    partner_country: "Canada",
-    industry: "Financials",
+    authority: ['CNA'],
+    long_name: 'North American Vulnerability Exchange',
+    short_name: 'NAVE_FAKE',
+    partner_number: 'CNA-2016-0002',
+    top_level_root: 'CISA TLR',
+    partner_role_type: 'Consortium',
+    partner_country: 'Canada',
+    industry: 'Financials',
     hard_quota: 600,
     soft_quota: 500,
     is_cna_discussion_list: true,
     contact_info: {
-      emails: ["pmehta@nave.example.ca"],
-      websites: ["https://nave.example.ca"],
+      emails: ['pmehta@nave.example.ca'],
+      websites: ['https://nave.example.ca']
     },
     private_contacts: [],
     program_data: {
-      status: "Active",
-      partner_active_date: "2016-11-30",
+      status: 'Active',
+      partner_active_date: '2016-11-30',
       cve_website_update_needed: false,
-      advisory_location_require_credentials: false,
+      advisory_location_require_credentials: false
     },
-    charter_or_scope: "https://nave.example.ca/charter",
-    product_list: "https://nave.example.ca/products",
+    charter_or_scope: 'https://nave.example.ca/charter',
+    product_list: 'https://nave.example.ca/products'
   },
   {
-    authority: ["CNA"],
-    long_name: "Swiss Precision Security Group",
-    short_name: "SPSG_FAKE",
-    partner_number: "CNA-2016-0003",
-    top_level_root: "CISA TLR",
-    partner_role_type: "Vendor",
-    partner_country: "Switzerland",
-    industry: "Financials",
+    authority: ['CNA'],
+    long_name: 'Swiss Precision Security Group',
+    short_name: 'SPSG_FAKE',
+    partner_number: 'CNA-2016-0003',
+    top_level_root: 'CISA TLR',
+    partner_role_type: 'Vendor',
+    partner_country: 'Switzerland',
+    industry: 'Financials',
     hard_quota: 420,
     soft_quota: 380,
-    advisory_locations: ["https://spsg.example.ch/advisories"],
+    advisory_locations: ['https://spsg.example.ch/advisories'],
     is_cna_discussion_list: true,
     contact_info: {
-      phone: "+41-44-555-7766",
-      emails: ["hmuller@spsg.example.ch"],
-      websites: ["https://spsg.example.ch"],
+      phone: '+41-44-555-7766',
+      emails: ['hmuller@spsg.example.ch'],
+      websites: ['https://spsg.example.ch']
     },
     private_contacts: [
       {
-        phone: "+41-44-555-7767",
-        poc_email: "ufrei@spsg.example.ch",
-      },
+        phone: '+41-44-555-7767',
+        poc_email: 'ufrei@spsg.example.ch'
+      }
     ],
     program_data: {
-      status: "Active",
-      partner_active_date: "2016-09-30",
+      status: 'Active',
+      partner_active_date: '2016-09-30',
       cve_website_update_needed: true,
-      cve_website_update_date: "2025-02-01T08:00:00Z",
+      cve_website_update_date: '2025-02-01T08:00:00Z',
       advisory_location_require_credentials: true,
       vulnerability_advisory_location_for_web_scraping: [
-        "https://spsg.example.ch/advisories",
-      ],
+        'https://spsg.example.ch/advisories'
+      ]
     },
-    charter_or_scope: "https://spsg.example.ch/charter",
-    disclosure_policy: "https://spsg.example.ch/disclosure",
+    charter_or_scope: 'https://spsg.example.ch/charter',
+    disclosure_policy: 'https://spsg.example.ch/disclosure'
   },
   {
-    authority: ["ADP"],
-    long_name: "French National Cybersecurity Agency Partners",
-    short_name: "FNCAP_FAKE",
-    partner_number: "CNA-2018-0001",
-    top_level_root: "CISA TLR",
-    partner_role_type: "CERT",
-    partner_country: "France",
+    authority: ['ADP'],
+    long_name: 'French National Cybersecurity Agency Partners',
+    short_name: 'FNCAP_FAKE',
+    partner_number: 'CNA-2018-0001',
+    top_level_root: 'CISA TLR',
+    partner_role_type: 'CERT',
+    partner_country: 'France',
     hard_quota: 325,
     soft_quota: 275,
-    advisory_locations: ["https://fncap.example.fr/advisories"],
+    advisory_locations: ['https://fncap.example.fr/advisories'],
     is_cna_discussion_list: true,
     contact_info: {
-      phone: "+33-1-5555-9988",
-      emails: ["sleclerc@fncap.example.fr"],
-      websites: ["https://fncap.example.fr"],
+      phone: '+33-1-5555-9988',
+      emails: ['sleclerc@fncap.example.fr'],
+      websites: ['https://fncap.example.fr']
     },
     private_contacts: [
       {
-        phone: "+33-1-5555-9989",
-        poc_email: "pdubois@fncap.example.fr",
-      },
+        phone: '+33-1-5555-9989',
+        poc_email: 'pdubois@fncap.example.fr'
+      }
     ],
     program_data: {
-      status: "Active",
-      partner_active_date: "2018-07-14",
+      status: 'Active',
+      partner_active_date: '2018-07-14',
       cve_website_update_needed: false,
       advisory_location_require_credentials: true,
       vulnerability_advisory_location_for_web_scraping: [
-        "https://fncap.example.fr/advisories",
+        'https://fncap.example.fr/advisories',
       ],
-    },
+    }
   },
   {
-    authority: ["CNA"],
-    long_name: "Iberian Vulnerability Coordination Center",
-    short_name: "IVCC_FAKE",
-    partner_number: "CNA-2018-0002",
-    aliases: ["IVCC Spain"],
-    partner_role_type: "CERT",
-    partner_country: "Spain",
+    authority: ['CNA'],
+    long_name: 'Iberian Vulnerability Coordination Center',
+    short_name: 'IVCC_FAKE',
+    partner_number: 'CNA-2018-0002',
+    aliases: ['IVCC Spain'],
+    partner_role_type: 'CERT',
+    partner_country: 'Spain',
     hard_quota: 250,
     is_cna_discussion_list: true,
     contact_info: {
-      phone: "+34-91-555-9900",
-      emails: ["cdelgado@ivcc.example.es"],
-      websites: ["https://ivcc.example.es"],
+      phone: '+34-91-555-9900',
+      emails: ['cdelgado@ivcc.example.es'],
+      websites: ['https://ivcc.example.es']
     },
     private_contacts: [],
     program_data: {
-      status: "Active",
-      partner_active_date: "2018-09-20",
-      cve_website_update_needed: false,
+      status: 'Active',
+      partner_active_date: '2018-09-20',
+      cve_website_update_needed: false
     },
-    charter_or_scope: "https://ivcc.example.es/charter",
-    disclosure_policy: "https://ivcc.example.es/disclosure",
-    product_list: "https://ivcc.example.es/products",
+    charter_or_scope: 'https://ivcc.example.es/charter',
+    disclosure_policy: 'https://ivcc.example.es/disclosure',
+    product_list: 'https://ivcc.example.es/products'
   },
   {
-    authority: ["CNA"],
-    long_name: "United Kingdom Hosted Security Services Ltd",
-    short_name: "UKHSSL_FAKE",
-    partner_number: "CNA-2018-0003",
-    top_level_root: "MITRE TLR",
-    partner_role_type: "Hosted Service",
-    partner_country: "United Kingdom",
-    industry: "Information Technology",
+    authority: ['CNA'],
+    long_name: 'United Kingdom Hosted Security Services Ltd',
+    short_name: 'UKHSSL_FAKE',
+    partner_number: 'CNA-2018-0003',
+    top_level_root: 'MITRE TLR',
+    partner_role_type: 'Hosted Service',
+    partner_country: 'United Kingdom',
+    industry: 'Information Technology',
     hard_quota: 450,
     soft_quota: 400,
-    advisory_locations: ["https://ukhssl.example.co.uk/security"],
+    advisory_locations: ['https://ukhssl.example.co.uk/security'],
     is_cna_discussion_list: false,
     contact_info: {
-      phone: "+44-20-5555-1234",
-      emails: ["jwhitfield@ukhssl.example.co.uk"],
-      websites: ["https://ukhssl.example.co.uk"],
+      phone: '+44-20-5555-1234',
+      emails: ['jwhitfield@ukhssl.example.co.uk'],
+      websites: ['https://ukhssl.example.co.uk']
     },
     private_contacts: [
       {
-        poc_email: "security@ukhssl.example.co.uk",
-      },
+        poc_email: 'security@ukhssl.example.co.uk'
+      }
     ],
     program_data: {
-      status: "Active",
-      partner_active_date: "2018-04-17",
+      status: 'Active',
+      partner_active_date: '2018-04-17',
       cve_website_update_needed: true,
-      cve_website_update_date: "2024-12-01T09:00:00Z",
+      cve_website_update_date: '2024-12-01T09:00:00Z',
       vulnerability_advisory_location_for_web_scraping: [
-        "https://ukhssl.example.co.uk/security",
+        'https://ukhssl.example.co.uk/security'
       ],
       advisory_location_require_credentials: true,
     },
-    charter_or_scope: "https://ukhssl.example.co.uk/scope",
-    disclosure_policy: "https://ukhssl.example.co.uk/disclosure",
-    product_list: "https://ukhssl.example.co.uk/products",
+    charter_or_scope: 'https://ukhssl.example.co.uk/scope',
+    disclosure_policy: 'https://ukhssl.example.co.uk/disclosure',
+    product_list: 'https://ukhssl.example.co.uk/products'
   },
   {
-    authority: ["CNA"],
-    long_name: "Eastern European Bug Bounty Network",
-    short_name: "EEBBN_FAKE",
-    partner_number: "CNA-2019-0001",
-    top_level_root: "MITRE TLR",
-    aliases: ["EE Bug Bounty"],
-    partner_role_type: "Bug Bounty Provider",
-    partner_country: "Poland",
+    authority: ['CNA'],
+    long_name: 'Eastern European Bug Bounty Network',
+    short_name: 'EEBBN_FAKE',
+    partner_number: 'CNA-2019-0001',
+    top_level_root: 'MITRE TLR',
+    aliases: ['EE Bug Bounty'],
+    partner_role_type: 'Bug Bounty Provider',
+    partner_country: 'Poland',
     hard_quota: 175,
     soft_quota: 150,
-    advisory_locations: ["https://eebbn.example.pl/advisories"],
+    advisory_locations: ['https://eebbn.example.pl/advisories'],
     is_cna_discussion_list: false,
     contact_info: {
-      phone: "+48-22-555-4321",
-      emails: ["twieczorek@eebbn.example.pl"],
-      websites: ["https://eebbn.example.pl"],
+      phone: '+48-22-555-4321',
+      emails: ['twieczorek@eebbn.example.pl'],
+      websites: ['https://eebbn.example.pl']
     },
     private_contacts: [
       {
-        poc_email: "triage@eebbn.example.pl",
-      },
+        poc_email: 'triage@eebbn.example.pl'
+      }
     ],
     program_data: {
-      status: "Active",
-      partner_active_date: "2019-03-22",
+      status: 'Active',
+      partner_active_date: '2019-03-22',
       cve_website_update_needed: false,
-      advisory_location_require_credentials: false,
+      advisory_location_require_credentials: false
     },
-    charter_or_scope: "https://eebbn.example.pl/charter",
-    disclosure_policy: "https://eebbn.example.pl/disclosure",
-    product_list: "https://eebbn.example.pl/products",
+    charter_or_scope: 'https://eebbn.example.pl/charter',
+    disclosure_policy: 'https://eebbn.example.pl/disclosure',
+    product_list: 'https://eebbn.example.pl/products'
   },
   {
-    authority: ["ADP"],
-    long_name: "Brazilian Cybersecurity Operations Center",
-    short_name: "BCOC_FAKE",
-    partner_number: "CNA-2019-0002",
-    partner_role_type: "CERT",
-    partner_country: "Brazil",
+    authority: ['ADP'],
+    long_name: 'Brazilian Cybersecurity Operations Center',
+    short_name: 'BCOC_FAKE',
+    partner_number: 'CNA-2019-0002',
+    partner_role_type: 'CERT',
+    partner_country: 'Brazil',
     hard_quota: 350,
     soft_quota: 300,
     is_cna_discussion_list: true,
     contact_info: {
-      phone: "+55-11-5555-3344",
-      emails: ["lferreira@bcoc.example.br"],
-      websites: ["https://bcoc.example.br"],
+      phone: '+55-11-5555-3344',
+      emails: ['lferreira@bcoc.example.br'],
+      websites: ['https://bcoc.example.br']
     },
     private_contacts: [
       {
-        phone: "+55-11-5555-3345",
-        poc_email: "asouza@bcoc.example.br",
+        phone: '+55-11-5555-3345',
+        poc_email: 'asouza@bcoc.example.br'
       },
       {
-        phone: "+55-11-5555-3346",
-      },
+        phone: '+55-11-5555-3346'
+      }
     ],
     program_data: {
-      status: "Active",
-      partner_active_date: "2019-11-05",
+      status: 'Active',
+      partner_active_date: '2019-11-05',
       cve_website_update_needed: false,
-      advisory_location_require_credentials: false,
+      advisory_location_require_credentials: false
     },
   },
   {
-    authority: ["SECRETARIAT"],
-    long_name: "Global Vulnerability Standards Authority",
-    short_name: "GVSA_FAKE",
-    partner_number: "CNA-2010-0001",
-    top_level_root: "MITRE TLR",
-    partner_role_type: "N/A",
-    partner_country: "United States",
-    industry: "Information Technology",
+    authority: ['SECRETARIAT'],
+    long_name: 'Global Vulnerability Standards Authority',
+    short_name: 'GVSA_FAKE',
+    partner_number: 'CNA-2010-0001',
+    top_level_root: 'MITRE TLR',
+    partner_role_type: 'N/A',
+    partner_country: 'United States',
+    industry: 'Information Technology',
     hard_quota: 9999,
     soft_quota: 9000,
-    advisory_locations: ["https://gvsa.example.org/advisories"],
+    advisory_locations: ['https://gvsa.example.org/advisories'],
     is_cna_discussion_list: true,
     contact_info: {
-      phone: "+1-202-555-0100",
-      emails: ["mcollins@gvsa.example.org"],
-      websites: ["https://gvsa.example.org"],
+      phone: '+1-202-555-0100',
+      emails: ['mcollins@gvsa.example.org'],
+      websites: ['https://gvsa.example.org']
     },
     private_contacts: [
       {
-        phone: "+1-202-555-0101",
-        poc_email: "ops@gvsa.example.org",
+        phone: '+1-202-555-0101',
+        poc_email: 'ops@gvsa.example.org'
       },
       {
-        phone: "+1-202-555-0102",
-      },
+        phone: '+1-202-555-0102'
+      }
     ],
     program_data: {
-      status: "Active",
-      partner_active_date: "2010-01-01",
+      status: 'Active',
+      partner_active_date: '2010-01-01',
       cve_website_update_needed: false,
-      cve_website_update_date: "2025-03-01T00:00:00Z",
-      advisory_location_require_credentials: false,
-    },
+      cve_website_update_date: '2025-03-01T00:00:00Z',
+      advisory_location_require_credentials: false
+    }
   },
   {
-    authority: ["CNA"],
-    long_name: "Nordic Cyber Defense Institute",
-    short_name: "NCDI_FAKE",
-    partner_number: "CNA-2020-0001",
-    top_level_root: "MITRE TLR",
-    partner_role_type: "CERT",
-    partner_country: "Norway",
+    authority: ['CNA'],
+    long_name: 'Nordic Cyber Defense Institute',
+    short_name: 'NCDI_FAKE',
+    partner_number: 'CNA-2020-0001',
+    top_level_root: 'MITRE TLR',
+    partner_role_type: 'CERT',
+    partner_country: 'Norway',
     hard_quota: 300,
-    advisory_locations: ["https://ncdi.example.no/advisories"],
+    advisory_locations: ['https://ncdi.example.no/advisories'],
     is_cna_discussion_list: false,
     contact_info: {
-      phone: "+47-21-555-678",
-      emails: ["elindgren@ncdi.example.no"],
-      websites: ["https://ncdi.example.no"],
+      phone: '+47-21-555-678',
+      emails: ['elindgren@ncdi.example.no'],
+      websites: ['https://ncdi.example.no']
     },
     private_contacts: [
       {
-        phone: "+47-21-555-679",
-        poc_email: "ahaugen@ncdi.example.no",
-      },
+        phone: '+47-21-555-679',
+        poc_email: 'ahaugen@ncdi.example.no'
+      }
     ],
     program_data: {
-      status: "Active",
-      partner_active_date: "2020-06-01",
+      status: 'Active',
+      partner_active_date: '2020-06-01',
       cve_website_update_needed: true,
-      advisory_location_require_credentials: false,
+      advisory_location_require_credentials: false
     },
-    charter_or_scope: "https://ncdi.example.no/scope",
-    disclosure_policy: "https://ncdi.example.no/disclosure",
+    charter_or_scope: 'https://ncdi.example.no/scope',
+    disclosure_policy: 'https://ncdi.example.no/disclosure'
   },
   {
-    authority: ["ADP"],
-    long_name: "Southern Cross Data Analytics",
-    short_name: "SCDA_FAKE",
-    partner_number: "CNA-2020-0002",
-    partner_country: "Australia",
+    authority: ['ADP'],
+    long_name: 'Southern Cross Data Analytics',
+    short_name: 'SCDA_FAKE',
+    partner_number: 'CNA-2020-0002',
+    partner_country: 'Australia',
     hard_quota: 150,
     contact_info: {
-      emails: ["ochen@scda.example.au"],
-      websites: ["https://scda.example.au"],
+      emails: ['ochen@scda.example.au'],
+      websites: ['https://scda.example.au']
     },
     private_contacts: [],
     program_data: {
-      status: "Inactive",
-      partner_active_date: "2020-03-10",
-      partner_inactive_date: "2023-07-01",
+      status: 'Inactive',
+      partner_active_date: '2020-03-10',
+      partner_inactive_date: '2023-07-01',
       cve_website_update_needed: false,
-      advisory_location_require_credentials: false,
-    },
+      advisory_location_require_credentials: false
+    }
   },
   {
-    authority: ["CNA"],
-    long_name: "Indian Subcontinent Cyber Response Unit",
-    short_name: "ISCRU_FAKE",
-    partner_number: "CNA-2020-0003",
-    partner_role_type: "CERT",
-    partner_country: "India",
+    authority: ['CNA'],
+    long_name: 'Indian Subcontinent Cyber Response Unit',
+    short_name: 'ISCRU_FAKE',
+    partner_number: 'CNA-2020-0003',
+    partner_role_type: 'CERT',
+    partner_country: 'India',
     hard_quota: 275,
     is_cna_discussion_list: false,
     contact_info: {
-      phone: "+91-11-5555-2233",
-      emails: ["rkrishnamurthy@iscru.example.in"],
-      websites: ["https://iscru.example.in"],
+      phone: '+91-11-5555-2233',
+      emails: ['rkrishnamurthy@iscru.example.in'],
+      websites: ['https://iscru.example.in']
     },
     private_contacts: [
       {
-        phone: "+91-11-5555-2234",
-        poc_email: "dnair@iscru.example.in",
-      },
+        phone: '+91-11-5555-2234',
+        poc_email: 'dnair@iscru.example.in'
+      }
     ],
     program_data: {
-      status: "Active",
-      partner_active_date: "2020-09-01",
+      status: 'Active',
+      partner_active_date: '2020-09-01',
       cve_website_update_needed: true,
-      advisory_location_require_credentials: false,
+      advisory_location_require_credentials: false
     },
-    charter_or_scope: "https://iscru.example.in/charter",
-    disclosure_policy: "https://iscru.example.in/disclosure",
+    charter_or_scope: 'https://iscru.example.in/charter',
+    disclosure_policy: 'https://iscru.example.in/disclosure'
   },
   {
-    authority: ["BULK_DOWNLOAD"],
-    long_name: "Pacific Rim Open Source Consortium",
-    short_name: "PROSC_FAKE",
-    partner_number: "CNA-2021-0001 {BULK_DOWNLOAD}",
-    partner_role_type: "Open Source",
-    partner_country: "Japan",
+    authority: ['BULK_DOWNLOAD'],
+    long_name: 'Pacific Rim Open Source Consortium',
+    short_name: 'PROSC_FAKE',
+    partner_number: 'CNA-2021-0001 {BULK_DOWNLOAD}',
+    partner_role_type: 'Open Source',
+    partner_country: 'Japan',
     hard_quota: 1000,
     soft_quota: 800,
     contact_info: {
-      emails: ["hyamamoto@prosc.example.jp"],
-      websites: ["https://prosc.example.jp"],
+      emails: ['hyamamoto@prosc.example.jp'],
+      websites: ['https://prosc.example.jp']
     },
     private_contacts: [],
     program_data: {
-      status: "Active",
-      partner_active_date: "2021-01-10",
+      status: 'Active',
+      partner_active_date: '2021-01-10',
       cve_website_update_needed: false,
-      advisory_location_require_credentials: false,
+      advisory_location_require_credentials: false
     },
   },
   {
-    authority: ["CNA"],
-    long_name: "Southeast Asia Cybersecurity Alliance",
-    short_name: "SACA_FAKE",
-    partner_number: "CNA-2021-0002",
-    aliases: ["SEA Cyber Alliance"],
-    partner_role_type: "CERT",
-    partner_country: "Singapore",
+    authority: ['CNA'],
+    long_name: 'Southeast Asia Cybersecurity Alliance',
+    short_name: 'SACA_FAKE',
+    partner_number: 'CNA-2021-0002',
+    aliases: ['SEA Cyber Alliance'],
+    partner_role_type: 'CERT',
+    partner_country: 'Singapore',
     hard_quota: 200,
     is_cna_discussion_list: false,
     contact_info: {
-      phone: "+65-6555-8877",
-      emails: ["wltan@saca.example.sg"],
-      websites: ["https://saca.example.sg"],
+      phone: '+65-6555-8877',
+      emails: ['wltan@saca.example.sg'],
+      websites: ['https://saca.example.sg']
     },
     private_contacts: [
       {
-        phone: "+65-6555-8878",
-        poc_email: "mlchua@saca.example.sg",
-      },
+        phone: '+65-6555-8878',
+        poc_email: 'mlchua@saca.example.sg'
+      }
     ],
     program_data: {
-      status: "Active",
-      partner_active_date: "2021-08-01",
-      cve_website_update_needed: false,
+      status: 'Active',
+      partner_active_date: '2021-08-01',
+      cve_website_update_needed: false
     },
-    charter_or_scope: "https://saca.example.sg/scope",
-    disclosure_policy: "https://saca.example.sg/disclosure",
+    charter_or_scope: 'https://saca.example.sg/scope',
+    disclosure_policy: 'https://saca.example.sg/disclosure'
   },
   {
-    authority: ["CNA"],
-    long_name: "Middle East Vulnerability Research Collective",
-    short_name: "MEVRC_FAKE",
-    partner_number: "CNA-2022-0001",
-    top_level_root: "MITRE TLR",
-    partner_role_type: "Researcher",
-    partner_country: "Israel",
+    authority: ['CNA'],
+    long_name: 'Middle East Vulnerability Research Collective',
+    short_name: 'MEVRC_FAKE',
+    partner_number: 'CNA-2022-0001',
+    top_level_root: 'MITRE TLR',
+    partner_role_type: 'Researcher',
+    partner_country: 'Israel',
     hard_quota: 300,
     soft_quota: 250,
-    advisory_locations: ["https://mevrc.example.il/advisories"],
+    advisory_locations: ['https://mevrc.example.il/advisories'],
     is_cna_discussion_list: false,
     contact_info: {
-      phone: "+972-3-555-7890",
-      emails: ["yshapiro@mevrc.example.il"],
-      websites: ["https://mevrc.example.il"],
+      phone: '+972-3-555-7890',
+      emails: ['yshapiro@mevrc.example.il'],
+      websites: ['https://mevrc.example.il']
     },
     private_contacts: [
       {
-        phone: "+972-3-555-7891",
-        poc_email: "acohen@mevrc.example.il",
-      },
+        phone: '+972-3-555-7891',
+        poc_email: 'acohen@mevrc.example.il'
+      }
     ],
     program_data: {
-      status: "Active",
-      partner_active_date: "2022-02-10",
+      status: 'Active',
+      partner_active_date: '2022-02-10',
       cve_website_update_needed: false,
-      advisory_location_require_credentials: false,
+      advisory_location_require_credentials: false
     },
-    charter_or_scope: "https://mevrc.example.il/charter",
-    disclosure_policy: "https://mevrc.example.il/disclosure",
+    charter_or_scope: 'https://mevrc.example.il/charter',
+    disclosure_policy: 'https://mevrc.example.il/disclosure'
   },
   {
-    authority: ["BULK_DOWNLOAD"],
-    long_name: "Open Vulnerability Data Initiative",
-    short_name: "OVDI_FAKE",
-    partner_number: "CNA-2022-0002 {BULK_DOWNLOAD}",
-    partner_role_type: "Open Source",
-    partner_country: "Netherlands",
+    authority: ['BULK_DOWNLOAD'],
+    long_name: 'Open Vulnerability Data Initiative',
+    short_name: 'OVDI_FAKE',
+    partner_number: 'CNA-2022-0002 {BULK_DOWNLOAD}',
+    partner_role_type: 'Open Source',
+    partner_country: 'Netherlands',
     hard_quota: 2000,
     soft_quota: 1800,
     contact_info: {
-      emails: ["dvandenberg@ovdi.example.nl"],
-      websites: ["https://ovdi.example.nl"],
+      emails: ['dvandenberg@ovdi.example.nl'],
+      websites: ['https://ovdi.example.nl']
     },
     private_contacts: [],
     program_data: {
-      status: "Active",
-      partner_active_date: "2022-06-15",
+      status: 'Active',
+      partner_active_date: '2022-06-15',
       cve_website_update_needed: false,
-      advisory_location_require_credentials: false,
-    },
+      advisory_location_require_credentials: false
+    }
   },
   {
-    authority: ["CNA"],
-    long_name: "African Cyber Threat Exchange",
-    short_name: "ACTE_FAKE",
-    partner_number: "CNA-2023-0001",
-    partner_role_type: "Consortium",
-    partner_country: "South Africa",
+    authority: ['CNA'],
+    long_name: 'African Cyber Threat Exchange',
+    short_name: 'ACTE_FAKE',
+    partner_number: 'CNA-2023-0001',
+    partner_role_type: 'Consortium',
+    partner_country: 'South Africa',
     hard_quota: 200,
     is_cna_discussion_list: false,
     contact_info: {
-      phone: "+27-11-555-6677",
-      emails: ["adiallo@acte.example.za"],
-      websites: ["https://acte.example.za"],
+      phone: '+27-11-555-6677',
+      emails: ['adiallo@acte.example.za'],
+      websites: ['https://acte.example.za']
     },
     private_contacts: [],
     program_data: {
-      status: "Active",
-      partner_active_date: "2023-01-15",
+      status: 'Active',
+      partner_active_date: '2023-01-15',
       cve_website_update_needed: false,
-      advisory_location_require_credentials: false,
+      advisory_location_require_credentials: false
     },
-    charter_or_scope: "https://acte.example.za/charter",
-    disclosure_policy: "https://acte.example.za/disclosure",
+    charter_or_scope: 'https://acte.example.za/charter',
+    disclosure_policy: 'https://acte.example.za/disclosure'
   },
   {
-    authority: ["CNA"],
-    long_name: "Andean Cybersecurity Research Alliance",
-    short_name: "ACRA_FAKE",
-    aliases: ["ACRA Labs"],
-    partner_number: "CNA-2023-0002",
-    partner_role_type: "Researcher",
-    partner_country: "Colombia",
-    top_level_root: "MITRE TLR",
+    authority: ['CNA'],
+    long_name: 'Andean Cybersecurity Research Alliance',
+    short_name: 'ACRA_FAKE',
+    aliases: ['ACRA Labs'],
+    partner_number: 'CNA-2023-0002',
+    partner_role_type: 'Researcher',
+    partner_country: 'Colombia',
+    top_level_root: 'MITRE TLR',
     hard_quota: 150,
-    industry: "Technology Hardware & Equipment (4520)",
+    industry: 'Technology Hardware & Equipment (4520)',
     is_cna_discussion_list: false,
     contact_info: {
-      phone: "+57-1-555-4422",
-      emails: ["imoreno@acra.example.co"],
-      websites: ["https://acra.example.co"],
+      phone: '+57-1-555-4422',
+      emails: ['imoreno@acra.example.co'],
+      websites: ['https://acra.example.co']
     },
     private_contacts: [
       {
-        phone: "+57-1-555-4423",
-        poc_email: "cruiz@acra.example.co",
-      },
+        phone: '+57-1-555-4423',
+        poc_email: 'cruiz@acra.example.co'
+      }
     ],
     program_data: {
-      status: "Active",
-      partner_active_date: "2023-05-20",
+      status: 'Active',
+      partner_active_date: '2023-05-20',
       cve_website_update_needed: false,
-      advisory_location_require_credentials: false,
+      advisory_location_require_credentials: false
     },
-    charter_or_scope: "https://acra.example.co/charter",
-    disclosure_policy: "https://acra.example.co/disclosure",
+    charter_or_scope: 'https://acra.example.co/charter',
+    disclosure_policy: 'https://acra.example.co/disclosure'
   },
-];
+]

--- a/src/scripts/test_data/testData.js
+++ b/src/scripts/test_data/testData.js
@@ -1,0 +1,988 @@
+export const users = [
+  {
+    short_name: "ASRG_FAKE",
+    users: [
+      {
+        name: { first: "Jane", last: "Holloway" },
+        status: "active",
+        username: "jholloway_admin@acmesecurity.example.com",
+      },
+      {
+        name: { first: "Brian", last: "Stokes" },
+        status: "active",
+        username: "bstokes@acmesecurity.example.com",
+      },
+      {
+        name: { first: "Rachel", last: "Torres", middle: "A" },
+        status: "active",
+        username: "rtorres@acmesecurity.example.com",
+      },
+    ],
+  },
+  {
+    short_name: "CETIL_FAKE",
+    users: [
+      {
+        name: { first: "Klaus", last: "Bauer" },
+        status: "active",
+        username: "kbauer_admin@cetil.example.de",
+      },
+      {
+        name: { first: "Heike", last: "Vogel" },
+        status: "active",
+        username: "hvogel@cetil.example.de",
+      },
+      {
+        name: { first: "Marcus", last: "Schreiber", middle: "J" },
+        status: "active",
+        username: "mschreiber@cetil.example.de",
+      },
+    ],
+  },
+  {
+    short_name: "KVIC_FAKE",
+    users: [
+      {
+        name: { first: "Ji-ho", last: "Park" },
+        status: "active",
+        username: "jhpark_admin@kvic.example.kr",
+      },
+      {
+        name: { first: "Soo-yeon", last: "Kim" },
+        status: "active",
+        username: "sykim@kvic.example.kr",
+      },
+    ],
+  },
+  {
+    short_name: "NAVE_FAKE",
+    users: [
+      {
+        name: { first: "Priya", last: "Mehta" },
+        status: "active",
+        username: "pmehta_admin@nave.example.ca",
+      },
+      {
+        name: { first: "Daniel", last: "Okafor" },
+        status: "active",
+        username: "dokafor@nave.example.ca",
+      },
+      {
+        name: { first: "Samantha", last: "Cho", suffix: "Jr" },
+        status: "active",
+        username: "scho@nave.example.ca",
+      },
+    ],
+  },
+  {
+    short_name: "SPSG_FAKE",
+    users: [
+      {
+        name: { first: "Hans", last: "Müller" },
+        status: "active",
+        username: "hmuller_admin@spsg.example.ch",
+      },
+      {
+        name: { first: "Ursula", last: "Frei" },
+        status: "active",
+        username: "ufrei@spsg.example.ch",
+      },
+      {
+        name: { first: "Thomas", last: "Keller", middle: "R" },
+        status: "active",
+        username: "tkeller@spsg.example.ch",
+      },
+    ],
+  },
+  {
+    short_name: "FNCAP_FAKE",
+    users: [
+      {
+        name: { first: "Sophie", last: "Leclerc" },
+        status: "active",
+        username: "sleclerc_admin@fncap.example.fr",
+      },
+      {
+        name: { first: "Pierre", last: "Dubois" },
+        status: "active",
+        username: "pdubois@fncap.example.fr",
+      },
+    ],
+  },
+  {
+    short_name: "IVCC_FAKE",
+    users: [
+      {
+        name: { first: "Carmen", last: "Delgado" },
+        status: "active",
+        username: "cdelgado_admin@ivcc.example.es",
+      },
+      {
+        name: { first: "Rafael", last: "Montoya", middle: "E" },
+        status: "active",
+        username: "rmontoya@ivcc.example.es",
+      },
+      {
+        name: { first: "Lucia", last: "Vega" },
+        status: "active",
+        username: "lvega@ivcc.example.es",
+      },
+    ],
+  },
+  {
+    short_name: "UKHSSL_FAKE",
+    users: [
+      {
+        name: { first: "James", last: "Whitfield" },
+        status: "active",
+        username: "jwhitfield_admin@ukhssl.example.co.uk",
+      },
+      {
+        name: { first: "Emily", last: "Harrison", suffix: "OBE" },
+        status: "active",
+        username: "eharrison@ukhssl.example.co.uk",
+      },
+      {
+        name: { first: "Nigel", last: "Forsythe", middle: "P" },
+        status: "active",
+        username: "nforsythe@ukhssl.example.co.uk",
+      },
+    ],
+  },
+  {
+    short_name: "EEBBN_FAKE",
+    users: [
+      {
+        name: { first: "Tomasz", last: "Wieczorek" },
+        status: "active",
+        username: "twieczorek_admin@eebbn.example.pl",
+      },
+      {
+        name: { first: "Agnieszka", last: "Kowalska" },
+        status: "active",
+        username: "akowalska@eebbn.example.pl",
+      },
+    ],
+  },
+  {
+    short_name: "BCOC_FAKE",
+    users: [
+      {
+        name: { first: "Lucas", last: "Ferreira" },
+        status: "active",
+        username: "lferreira_admin@bcoc.example.br",
+      },
+      {
+        name: { first: "Ana", last: "Souza", middle: "M" },
+        status: "active",
+        username: "asouza@bcoc.example.br",
+      },
+      {
+        name: { first: "Carlos", last: "Mendes" },
+        status: "active",
+        username: "cmendes@bcoc.example.br",
+      },
+    ],
+  },
+  {
+    short_name: "GVSA_FAKE",
+    users: [
+      {
+        name: { first: "Margaret", last: "Collins" },
+        status: "active",
+        username: "mcollins_admin@gvsa.example.org",
+      },
+      {
+        name: { first: "Robert", last: "Haines", suffix: "III" },
+        status: "active",
+        username: "rhaines@gvsa.example.org",
+      },
+      {
+        name: { first: "Diana", last: "Patel", middle: "L" },
+        status: "active",
+        username: "dpatel@gvsa.example.org",
+      },
+    ],
+  },
+  {
+    short_name: "NCDI_FAKE",
+    users: [
+      {
+        name: { first: "Erik", last: "Lindgren" },
+        status: "active",
+        username: "elindgren_admin@ncdi.example.no",
+      },
+      {
+        name: { first: "Astrid", last: "Haugen" },
+        status: "active",
+        username: "ahaugen@ncdi.example.no",
+      },
+      {
+        name: { first: "Bjorn", last: "Stavanger", middle: "K" },
+        status: "active",
+        username: "bstavanger@ncdi.example.no",
+      },
+    ],
+  },
+  {
+    short_name: "SCDA_FAKE",
+    users: [
+      {
+        name: { first: "Olivia", last: "Chen" },
+        status: "active",
+        username: "ochen_admin@scda.example.au",
+      },
+      {
+        name: { first: "Liam", last: "Nguyen" },
+        status: "active",
+        username: "lnguyen@scda.example.au",
+      },
+    ],
+  },
+  {
+    short_name: "ISCRU_FAKE",
+    users: [
+      {
+        name: { first: "Ravi", last: "Krishnamurthy" },
+        status: "active",
+        username: "rkrishnamurthy_admin@iscru.example.in",
+      },
+      {
+        name: { first: "Deepa", last: "Nair" },
+        status: "active",
+        username: "dnair@iscru.example.in",
+      },
+      {
+        name: { first: "Arjun", last: "Sharma", middle: "V" },
+        status: "active",
+        username: "asharma@iscru.example.in",
+      },
+    ],
+  },
+  {
+    short_name: "PROSC_FAKE",
+    users: [
+      {
+        name: { first: "Haruki", last: "Yamamoto" },
+        status: "active",
+        username: "hyamamoto_admin@prosc.example.jp",
+      },
+      {
+        name: { first: "Yuki", last: "Tanaka" },
+        status: "active",
+        username: "ytanaka@prosc.example.jp",
+      },
+    ],
+  },
+  {
+    short_name: "SACA_FAKE",
+    users: [
+      {
+        name: { first: "Wei Liang", last: "Tan" },
+        status: "active",
+        username: "wltan_admin@saca.example.sg",
+      },
+      {
+        name: { first: "Mei Lin", last: "Chua" },
+        status: "active",
+        username: "mlchua@saca.example.sg",
+      },
+      {
+        name: { first: "Jun Wei", last: "Lim", middle: "H" },
+        status: "active",
+        username: "jwlim@saca.example.sg",
+      },
+    ],
+  },
+  {
+    short_name: "MEVRC_FAKE",
+    users: [
+      {
+        name: { first: "Yael", last: "Shapiro" },
+        status: "active",
+        username: "yshapiro_admin@mevrc.example.il",
+      },
+      {
+        name: { first: "Avi", last: "Cohen" },
+        status: "active",
+        username: "acohen@mevrc.example.il",
+      },
+    ],
+  },
+  {
+    short_name: "OVDI_FAKE",
+    users: [
+      {
+        name: { first: "Dirk", last: "van der Berg" },
+        status: "active",
+        username: "dvandenberg_admin@ovdi.example.nl",
+      },
+      {
+        name: { first: "Femke", last: "de Vries" },
+        status: "active",
+        username: "fdevries@ovdi.example.nl",
+      },
+      {
+        name: { first: "Pieter", last: "Janssen", middle: "C" },
+        status: "active",
+        username: "pjanssen@ovdi.example.nl",
+      },
+    ],
+  },
+  {
+    short_name: "ACTE_FAKE",
+    users: [
+      {
+        name: { first: "Amara", last: "Diallo" },
+        status: "active",
+        username: "adiallo_admin@acte.example.za",
+      },
+      {
+        name: { first: "Kwame", last: "Mensah" },
+        status: "active",
+        username: "kmensah@acte.example.za",
+      },
+    ],
+  },
+  {
+    short_name: "ACRA_FAKE",
+    users: [
+      {
+        name: { first: "Isabella", last: "Moreno" },
+        status: "active",
+        username: "imoreno_admin@acra.example.co",
+      },
+      {
+        name: { first: "Carlos", last: "Ruiz", middle: "A" },
+        status: "active",
+        username: "cruiz@acra.example.co",
+      },
+      {
+        name: { first: "Valentina", last: "Castro" },
+        status: "active",
+        username: "vcastro@acra.example.co",
+      },
+    ],
+  },
+];
+
+export const orgs = [
+  {
+    authority: ["CNA"],
+    long_name: "Acme Security Research Group",
+    short_name: "ASRG_FAKE",
+    partner_number: "CNA-2015-0001",
+    top_level_root: "MITRE TLR",
+    aliases: ["Acme Research", "ASRG Security"],
+    partner_role_type: "Vendor",
+    partner_country: "United States",
+    industry: "Information Technology",
+    hard_quota: 500,
+    soft_quota: 400,
+    advisory_locations: ["https://acmesecurity.example.com/advisories"],
+    is_cna_discussion_list: true,
+    contact_info: {
+      phone: "+1-555-210-3344",
+      emails: [
+        "jholloway@acmesecurity.example.com",
+        "security@acmesecurity.example.com",
+      ],
+      websites: ["https://acmesecurity.example.com"],
+    },
+    private_contacts: [
+      {
+        phone: "+1-555-210-3345",
+        poc_email: "bstokes@acmesecurity.example.com",
+      },
+    ],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2015-03-15",
+      cve_website_update_needed: false,
+      cve_website_update_date: "2024-11-01T10:00:00Z",
+      vulnerability_advisory_location_for_web_scraping: [
+        "https://acmesecurity.example.com/advisories",
+      ],
+      advisory_location_require_credentials: false,
+    },
+    charter_or_scope: "https://acmesecurity.example.com/charter",
+    disclosure_policy: "https://acmesecurity.example.com/disclosure",
+    product_list: "https://acmesecurity.example.com/products",
+  },
+  {
+    authority: ["CNA"],
+    long_name: "Central European Threat Intelligence Lab",
+    short_name: "CETIL_FAKE",
+    partner_number: "CNA-2015-0002",
+    top_level_root: "CISA TLR",
+    aliases: ["CETIL Labs"],
+    partner_role_type: "Researcher",
+    partner_country: "Germany",
+    hard_quota: 400,
+    soft_quota: 350,
+    advisory_locations: ["https://cetil.example.de/advisories"],
+    is_cna_discussion_list: false,
+    contact_info: {
+      phone: "+49-30-555-2211",
+      emails: ["kbauer@cetil.example.de"],
+      websites: ["https://cetil.example.de"],
+    },
+    private_contacts: [
+      {
+        phone: "+49-30-555-2212",
+        poc_email: "hvogel@cetil.example.de",
+      },
+      {
+        poc_email: "security@cetil.example.de",
+      },
+    ],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2015-05-12",
+      cve_website_update_needed: true,
+      cve_website_update_date: "2025-01-15T08:30:00Z",
+      vulnerability_advisory_location_for_web_scraping: [
+        "https://cetil.example.de/advisories",
+      ],
+      advisory_location_require_credentials: true,
+    },
+    charter_or_scope: "https://cetil.example.de/scope",
+    disclosure_policy: "https://cetil.example.de/disclosure",
+  },
+  {
+    authority: ["CNA"],
+    long_name: "Korean Vulnerability Intelligence Center",
+    short_name: "KVIC_FAKE",
+    partner_number: "CNA-2016-0001",
+    top_level_root: "MITRE TLR",
+    partner_role_type: "Vendor",
+    partner_country: "South Korea",
+    hard_quota: 380,
+    soft_quota: 320,
+    advisory_locations: ["https://kvic.example.kr/advisories"],
+    is_cna_discussion_list: false,
+    contact_info: {
+      phone: "+82-2-5555-1122",
+      emails: ["jhpark@kvic.example.kr"],
+      websites: ["https://kvic.example.kr"],
+    },
+    private_contacts: [
+      {
+        phone: "+82-2-5555-1123",
+        poc_email: "sykim@kvic.example.kr",
+      },
+      {
+        phone: "+82-2-5555-1124",
+      },
+    ],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2016-03-20",
+      cve_website_update_needed: false,
+      cve_website_update_date: "2024-10-15T12:00:00Z",
+      advisory_location_require_credentials: false,
+      vulnerability_advisory_location_for_web_scraping: [
+        "https://kvic.example.kr/advisories",
+      ],
+    },
+    charter_or_scope: "https://kvic.example.kr/charter",
+    disclosure_policy: "https://kvic.example.kr/disclosure",
+    product_list: "https://kvic.example.kr/products",
+  },
+  {
+    authority: ["CNA"],
+    long_name: "North American Vulnerability Exchange",
+    short_name: "NAVE_FAKE",
+    partner_number: "CNA-2016-0002",
+    top_level_root: "CISA TLR",
+    partner_role_type: "Consortium",
+    partner_country: "Canada",
+    industry: "Financials",
+    hard_quota: 600,
+    soft_quota: 500,
+    is_cna_discussion_list: true,
+    contact_info: {
+      emails: ["pmehta@nave.example.ca"],
+      websites: ["https://nave.example.ca"],
+    },
+    private_contacts: [],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2016-11-30",
+      cve_website_update_needed: false,
+      advisory_location_require_credentials: false,
+    },
+    charter_or_scope: "https://nave.example.ca/charter",
+    product_list: "https://nave.example.ca/products",
+  },
+  {
+    authority: ["CNA"],
+    long_name: "Swiss Precision Security Group",
+    short_name: "SPSG_FAKE",
+    partner_number: "CNA-2016-0003",
+    top_level_root: "CISA TLR",
+    partner_role_type: "Vendor",
+    partner_country: "Switzerland",
+    industry: "Financials",
+    hard_quota: 420,
+    soft_quota: 380,
+    advisory_locations: ["https://spsg.example.ch/advisories"],
+    is_cna_discussion_list: true,
+    contact_info: {
+      phone: "+41-44-555-7766",
+      emails: ["hmuller@spsg.example.ch"],
+      websites: ["https://spsg.example.ch"],
+    },
+    private_contacts: [
+      {
+        phone: "+41-44-555-7767",
+        poc_email: "ufrei@spsg.example.ch",
+      },
+    ],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2016-09-30",
+      cve_website_update_needed: true,
+      cve_website_update_date: "2025-02-01T08:00:00Z",
+      advisory_location_require_credentials: true,
+      vulnerability_advisory_location_for_web_scraping: [
+        "https://spsg.example.ch/advisories",
+      ],
+    },
+    charter_or_scope: "https://spsg.example.ch/charter",
+    disclosure_policy: "https://spsg.example.ch/disclosure",
+  },
+  {
+    authority: ["ADP"],
+    long_name: "French National Cybersecurity Agency Partners",
+    short_name: "FNCAP_FAKE",
+    partner_number: "CNA-2018-0001",
+    top_level_root: "CISA TLR",
+    partner_role_type: "CERT",
+    partner_country: "France",
+    hard_quota: 325,
+    soft_quota: 275,
+    advisory_locations: ["https://fncap.example.fr/advisories"],
+    is_cna_discussion_list: true,
+    contact_info: {
+      phone: "+33-1-5555-9988",
+      emails: ["sleclerc@fncap.example.fr"],
+      websites: ["https://fncap.example.fr"],
+    },
+    private_contacts: [
+      {
+        phone: "+33-1-5555-9989",
+        poc_email: "pdubois@fncap.example.fr",
+      },
+    ],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2018-07-14",
+      cve_website_update_needed: false,
+      advisory_location_require_credentials: true,
+      vulnerability_advisory_location_for_web_scraping: [
+        "https://fncap.example.fr/advisories",
+      ],
+    },
+  },
+  {
+    authority: ["CNA"],
+    long_name: "Iberian Vulnerability Coordination Center",
+    short_name: "IVCC_FAKE",
+    partner_number: "CNA-2018-0002",
+    aliases: ["IVCC Spain"],
+    partner_role_type: "CERT",
+    partner_country: "Spain",
+    hard_quota: 250,
+    is_cna_discussion_list: true,
+    contact_info: {
+      phone: "+34-91-555-9900",
+      emails: ["cdelgado@ivcc.example.es"],
+      websites: ["https://ivcc.example.es"],
+    },
+    private_contacts: [],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2018-09-20",
+      cve_website_update_needed: false,
+    },
+    charter_or_scope: "https://ivcc.example.es/charter",
+    disclosure_policy: "https://ivcc.example.es/disclosure",
+    product_list: "https://ivcc.example.es/products",
+  },
+  {
+    authority: ["CNA"],
+    long_name: "United Kingdom Hosted Security Services Ltd",
+    short_name: "UKHSSL_FAKE",
+    partner_number: "CNA-2018-0003",
+    top_level_root: "MITRE TLR",
+    partner_role_type: "Hosted Service",
+    partner_country: "United Kingdom",
+    industry: "Information Technology",
+    hard_quota: 450,
+    soft_quota: 400,
+    advisory_locations: ["https://ukhssl.example.co.uk/security"],
+    is_cna_discussion_list: false,
+    contact_info: {
+      phone: "+44-20-5555-1234",
+      emails: ["jwhitfield@ukhssl.example.co.uk"],
+      websites: ["https://ukhssl.example.co.uk"],
+    },
+    private_contacts: [
+      {
+        poc_email: "security@ukhssl.example.co.uk",
+      },
+    ],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2018-04-17",
+      cve_website_update_needed: true,
+      cve_website_update_date: "2024-12-01T09:00:00Z",
+      vulnerability_advisory_location_for_web_scraping: [
+        "https://ukhssl.example.co.uk/security",
+      ],
+      advisory_location_require_credentials: true,
+    },
+    charter_or_scope: "https://ukhssl.example.co.uk/scope",
+    disclosure_policy: "https://ukhssl.example.co.uk/disclosure",
+    product_list: "https://ukhssl.example.co.uk/products",
+  },
+  {
+    authority: ["CNA"],
+    long_name: "Eastern European Bug Bounty Network",
+    short_name: "EEBBN_FAKE",
+    partner_number: "CNA-2019-0001",
+    top_level_root: "MITRE TLR",
+    aliases: ["EE Bug Bounty"],
+    partner_role_type: "Bug Bounty Provider",
+    partner_country: "Poland",
+    hard_quota: 175,
+    soft_quota: 150,
+    advisory_locations: ["https://eebbn.example.pl/advisories"],
+    is_cna_discussion_list: false,
+    contact_info: {
+      phone: "+48-22-555-4321",
+      emails: ["twieczorek@eebbn.example.pl"],
+      websites: ["https://eebbn.example.pl"],
+    },
+    private_contacts: [
+      {
+        poc_email: "triage@eebbn.example.pl",
+      },
+    ],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2019-03-22",
+      cve_website_update_needed: false,
+      advisory_location_require_credentials: false,
+    },
+    charter_or_scope: "https://eebbn.example.pl/charter",
+    disclosure_policy: "https://eebbn.example.pl/disclosure",
+    product_list: "https://eebbn.example.pl/products",
+  },
+  {
+    authority: ["ADP"],
+    long_name: "Brazilian Cybersecurity Operations Center",
+    short_name: "BCOC_FAKE",
+    partner_number: "CNA-2019-0002",
+    partner_role_type: "CERT",
+    partner_country: "Brazil",
+    hard_quota: 350,
+    soft_quota: 300,
+    is_cna_discussion_list: true,
+    contact_info: {
+      phone: "+55-11-5555-3344",
+      emails: ["lferreira@bcoc.example.br"],
+      websites: ["https://bcoc.example.br"],
+    },
+    private_contacts: [
+      {
+        phone: "+55-11-5555-3345",
+        poc_email: "asouza@bcoc.example.br",
+      },
+      {
+        phone: "+55-11-5555-3346",
+      },
+    ],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2019-11-05",
+      cve_website_update_needed: false,
+      advisory_location_require_credentials: false,
+    },
+  },
+  {
+    authority: ["SECRETARIAT"],
+    long_name: "Global Vulnerability Standards Authority",
+    short_name: "GVSA_FAKE",
+    partner_number: "CNA-2010-0001",
+    top_level_root: "MITRE TLR",
+    partner_role_type: "N/A",
+    partner_country: "United States",
+    industry: "Information Technology",
+    hard_quota: 9999,
+    soft_quota: 9000,
+    advisory_locations: ["https://gvsa.example.org/advisories"],
+    is_cna_discussion_list: true,
+    contact_info: {
+      phone: "+1-202-555-0100",
+      emails: ["mcollins@gvsa.example.org"],
+      websites: ["https://gvsa.example.org"],
+    },
+    private_contacts: [
+      {
+        phone: "+1-202-555-0101",
+        poc_email: "ops@gvsa.example.org",
+      },
+      {
+        phone: "+1-202-555-0102",
+      },
+    ],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2010-01-01",
+      cve_website_update_needed: false,
+      cve_website_update_date: "2025-03-01T00:00:00Z",
+      advisory_location_require_credentials: false,
+    },
+  },
+  {
+    authority: ["CNA"],
+    long_name: "Nordic Cyber Defense Institute",
+    short_name: "NCDI_FAKE",
+    partner_number: "CNA-2020-0001",
+    top_level_root: "MITRE TLR",
+    partner_role_type: "CERT",
+    partner_country: "Norway",
+    hard_quota: 300,
+    advisory_locations: ["https://ncdi.example.no/advisories"],
+    is_cna_discussion_list: false,
+    contact_info: {
+      phone: "+47-21-555-678",
+      emails: ["elindgren@ncdi.example.no"],
+      websites: ["https://ncdi.example.no"],
+    },
+    private_contacts: [
+      {
+        phone: "+47-21-555-679",
+        poc_email: "ahaugen@ncdi.example.no",
+      },
+    ],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2020-06-01",
+      cve_website_update_needed: true,
+      advisory_location_require_credentials: false,
+    },
+    charter_or_scope: "https://ncdi.example.no/scope",
+    disclosure_policy: "https://ncdi.example.no/disclosure",
+  },
+  {
+    authority: ["ADP"],
+    long_name: "Southern Cross Data Analytics",
+    short_name: "SCDA_FAKE",
+    partner_number: "CNA-2020-0002",
+    partner_country: "Australia",
+    hard_quota: 150,
+    contact_info: {
+      emails: ["ochen@scda.example.au"],
+      websites: ["https://scda.example.au"],
+    },
+    private_contacts: [],
+    program_data: {
+      status: "Inactive",
+      partner_active_date: "2020-03-10",
+      partner_inactive_date: "2023-07-01",
+      cve_website_update_needed: false,
+      advisory_location_require_credentials: false,
+    },
+  },
+  {
+    authority: ["CNA"],
+    long_name: "Indian Subcontinent Cyber Response Unit",
+    short_name: "ISCRU_FAKE",
+    partner_number: "CNA-2020-0003",
+    partner_role_type: "CERT",
+    partner_country: "India",
+    hard_quota: 275,
+    is_cna_discussion_list: false,
+    contact_info: {
+      phone: "+91-11-5555-2233",
+      emails: ["rkrishnamurthy@iscru.example.in"],
+      websites: ["https://iscru.example.in"],
+    },
+    private_contacts: [
+      {
+        phone: "+91-11-5555-2234",
+        poc_email: "dnair@iscru.example.in",
+      },
+    ],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2020-09-01",
+      cve_website_update_needed: true,
+      advisory_location_require_credentials: false,
+    },
+    charter_or_scope: "https://iscru.example.in/charter",
+    disclosure_policy: "https://iscru.example.in/disclosure",
+  },
+  {
+    authority: ["BULK_DOWNLOAD"],
+    long_name: "Pacific Rim Open Source Consortium",
+    short_name: "PROSC_FAKE",
+    partner_number: "CNA-2021-0001 {BULK_DOWNLOAD}",
+    partner_role_type: "Open Source",
+    partner_country: "Japan",
+    hard_quota: 1000,
+    soft_quota: 800,
+    contact_info: {
+      emails: ["hyamamoto@prosc.example.jp"],
+      websites: ["https://prosc.example.jp"],
+    },
+    private_contacts: [],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2021-01-10",
+      cve_website_update_needed: false,
+      advisory_location_require_credentials: false,
+    },
+  },
+  {
+    authority: ["CNA"],
+    long_name: "Southeast Asia Cybersecurity Alliance",
+    short_name: "SACA_FAKE",
+    partner_number: "CNA-2021-0002",
+    aliases: ["SEA Cyber Alliance"],
+    partner_role_type: "CERT",
+    partner_country: "Singapore",
+    hard_quota: 200,
+    is_cna_discussion_list: false,
+    contact_info: {
+      phone: "+65-6555-8877",
+      emails: ["wltan@saca.example.sg"],
+      websites: ["https://saca.example.sg"],
+    },
+    private_contacts: [
+      {
+        phone: "+65-6555-8878",
+        poc_email: "mlchua@saca.example.sg",
+      },
+    ],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2021-08-01",
+      cve_website_update_needed: false,
+    },
+    charter_or_scope: "https://saca.example.sg/scope",
+    disclosure_policy: "https://saca.example.sg/disclosure",
+  },
+  {
+    authority: ["CNA"],
+    long_name: "Middle East Vulnerability Research Collective",
+    short_name: "MEVRC_FAKE",
+    partner_number: "CNA-2022-0001",
+    top_level_root: "MITRE TLR",
+    partner_role_type: "Researcher",
+    partner_country: "Israel",
+    hard_quota: 300,
+    soft_quota: 250,
+    advisory_locations: ["https://mevrc.example.il/advisories"],
+    is_cna_discussion_list: false,
+    contact_info: {
+      phone: "+972-3-555-7890",
+      emails: ["yshapiro@mevrc.example.il"],
+      websites: ["https://mevrc.example.il"],
+    },
+    private_contacts: [
+      {
+        phone: "+972-3-555-7891",
+        poc_email: "acohen@mevrc.example.il",
+      },
+    ],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2022-02-10",
+      cve_website_update_needed: false,
+      advisory_location_require_credentials: false,
+    },
+    charter_or_scope: "https://mevrc.example.il/charter",
+    disclosure_policy: "https://mevrc.example.il/disclosure",
+  },
+  {
+    authority: ["BULK_DOWNLOAD"],
+    long_name: "Open Vulnerability Data Initiative",
+    short_name: "OVDI_FAKE",
+    partner_number: "CNA-2022-0002 {BULK_DOWNLOAD}",
+    partner_role_type: "Open Source",
+    partner_country: "Netherlands",
+    hard_quota: 2000,
+    soft_quota: 1800,
+    contact_info: {
+      emails: ["dvandenberg@ovdi.example.nl"],
+      websites: ["https://ovdi.example.nl"],
+    },
+    private_contacts: [],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2022-06-15",
+      cve_website_update_needed: false,
+      advisory_location_require_credentials: false,
+    },
+  },
+  {
+    authority: ["CNA"],
+    long_name: "African Cyber Threat Exchange",
+    short_name: "ACTE_FAKE",
+    partner_number: "CNA-2023-0001",
+    partner_role_type: "Consortium",
+    partner_country: "South Africa",
+    hard_quota: 200,
+    is_cna_discussion_list: false,
+    contact_info: {
+      phone: "+27-11-555-6677",
+      emails: ["adiallo@acte.example.za"],
+      websites: ["https://acte.example.za"],
+    },
+    private_contacts: [],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2023-01-15",
+      cve_website_update_needed: false,
+      advisory_location_require_credentials: false,
+    },
+    charter_or_scope: "https://acte.example.za/charter",
+    disclosure_policy: "https://acte.example.za/disclosure",
+  },
+  {
+    authority: ["CNA"],
+    long_name: "Andean Cybersecurity Research Alliance",
+    short_name: "ACRA_FAKE",
+    aliases: ["ACRA Labs"],
+    partner_number: "CNA-2023-0002",
+    partner_role_type: "Researcher",
+    partner_country: "Colombia",
+    top_level_root: "MITRE TLR",
+    hard_quota: 150,
+    industry: "Technology Hardware & Equipment (4520)",
+    is_cna_discussion_list: false,
+    contact_info: {
+      phone: "+57-1-555-4422",
+      emails: ["imoreno@acra.example.co"],
+      websites: ["https://acra.example.co"],
+    },
+    private_contacts: [
+      {
+        phone: "+57-1-555-4423",
+        poc_email: "cruiz@acra.example.co",
+      },
+    ],
+    program_data: {
+      status: "Active",
+      partner_active_date: "2023-05-20",
+      cve_website_update_needed: false,
+      advisory_location_require_credentials: false,
+    },
+    charter_or_scope: "https://acra.example.co/charter",
+    disclosure_policy: "https://acra.example.co/disclosure",
+  },
+];


### PR DESCRIPTION
Closes Issue #1827 

# Summary
The test code to reset keys and generate a database with realistic looking users, was originally located in the DR Client repository. This code has been migrated over to services where it actually belongs.

`generate` requires that the following .env vars are set
- VITE_CVE_SERVICES_URL
- VITE_TEST_API_USER
- VITE_TEST_API_ORG
- VITE_TEST_API_KEY

`reset_keys` requires that the following .env vars are set
- TEST_DATA_USER_SECRET_HASH

# Important Changes
`scripts/test_data/generate.js`
- Contains the logic to generate realistic users
`scripts/test_data/reset_keys.js`
- Contains the logic to test resetting keys
`scripts/test_data/testData.js`
- Contains the data for the realistic users added by the `generate` script

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) `npm run populate:dev`
- [ ] 2) `npm run migrate:dev`
- [ ] 3) `npm run generate` which should succeed in adding 20 test orgs
- [ ] 4) Find the secret key from any of the users added by `generate`, set it to the TEST_DATA_USER_SECRET_HASH in your .env
- [ ] 5) `npm run reset_keys` which should succeed in updating keys of all test users found