### PR TITLE
Resolves issue #1829, Allows registry org partner active/inactive dates to be edited directly.

### DIFF
--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -12,7 +12,6 @@ const BaseOrg = require('../model/baseorg')
 const getConstants = require('../constants').getConstants
 const {
   handleShortNameUpdate,
-  automateProgramDataDates,
   processJointApprovalAndMerge,
   createAuditLogEntry,
   handleAuthorityModelChange
@@ -972,7 +971,6 @@ class BaseOrgRepository extends BaseRepository {
     }
 
     handleShortNameUpdate(incomingOrg, registryOrg, legacyOrg, registryObjectRaw, legacyObjectRaw)
-    automateProgramDataDates(registryObjectRaw, registryOrg)
 
     const requestingUser = requestingUserUUID ? await userRepo.findUserByUUID(requestingUserUUID, options) : null
     const requestingUsername = requestingUser ? requestingUser.username : null

--- a/src/repositories/baseOrgRepositoryHelpers.js
+++ b/src/repositories/baseOrgRepositoryHelpers.js
@@ -44,39 +44,6 @@ function handleShortNameUpdate (incomingOrg, registryOrg, legacyOrg, registryObj
 }
 
 /**
- * @function automateProgramDataDates
- * @description Automatically sets or removes `partner_active_date` and `partner_inactive_date` based on state transitions in the organization's program_data status.
- * @param {object} registryObjectRaw - The raw data payload mapped for the registry schema.
- * @param {object} registryOrg - The current registry organization Mongoose document.
- */
-function automateProgramDataDates (registryObjectRaw, registryOrg) {
-  if (registryObjectRaw.program_data && registryObjectRaw.program_data.status) {
-    const incomingStatus = registryObjectRaw.program_data.status
-    const currentStatus = registryOrg.program_data?.status || 'inactive'
-    if (incomingStatus !== currentStatus) {
-      if (incomingStatus === 'active') {
-        registryObjectRaw.program_data.partner_active_date = new Date().toISOString().split('T')[0]
-        if (registryObjectRaw.program_data.partner_inactive_date !== undefined) {
-          delete registryObjectRaw.program_data.partner_inactive_date
-        }
-      } else if (incomingStatus === 'inactive') {
-        registryObjectRaw.program_data.partner_inactive_date = new Date().toISOString().split('T')[0]
-        if (registryObjectRaw.program_data.partner_active_date !== undefined) {
-          delete registryObjectRaw.program_data.partner_active_date
-        }
-      }
-    } else {
-      if (registryOrg.program_data?.partner_active_date) {
-        registryObjectRaw.program_data.partner_active_date = registryOrg.program_data.partner_active_date
-      }
-      if (registryOrg.program_data?.partner_inactive_date) {
-        registryObjectRaw.program_data.partner_inactive_date = registryOrg.program_data.partner_inactive_date
-      }
-    }
-  }
-}
-
-/**
  * @function mergeAllowedFields
  * @description Deep merges new fields into a Mongoose document while strictly protecting explicitly defined system fields from being overwritten.
  * @param {object} targetDoc - The Mongoose document being updated.
@@ -273,7 +240,6 @@ async function handleAuthorityModelChange (updatedRegistryOrg, originalRoles, op
 module.exports = {
   skipNulls,
   handleShortNameUpdate,
-  automateProgramDataDates,
   mergeAllowedFields,
   manageReviewObject,
   processJointApprovalAndMerge,

--- a/test/integration-tests/registry-org/registryOrgCRUDTest.js
+++ b/test/integration-tests/registry-org/registryOrgCRUDTest.js
@@ -360,6 +360,7 @@ describe('Testing /registryOrg endpoints', () => {
           })
       })
       it('Allows Secretariat to update program_data', async () => {
+        const partnerActiveDate = '2024-01-15'
         await chai.request(app)
           .put('/api/registry/org/registry_org_test')
           .set(secretariatHeaders)
@@ -367,6 +368,7 @@ describe('Testing /registryOrg endpoints', () => {
             ...createdOrg,
             program_data: {
               status: 'active',
+              partner_active_date: partnerActiveDate,
               advisory_location_require_credentials: true,
               vulnerability_advisory_location_for_web_scraping: ['https://example.com/scraping']
             }
@@ -377,9 +379,105 @@ describe('Testing /registryOrg endpoints', () => {
             expect(res.body.updated).to.haveOwnProperty('program_data')
             expect(res.body.updated.program_data.status).to.equal('active')
             expect(res.body.updated.program_data).to.haveOwnProperty('partner_active_date')
-            expect(res.body.updated.program_data).to.not.haveOwnProperty('partner_inactive_date')
+            expect(res.body.updated.program_data.partner_active_date).to.equal(partnerActiveDate)
             expect(res.body.updated.program_data.advisory_location_require_credentials).to.be.true
             expect(res.body.updated.program_data.vulnerability_advisory_location_for_web_scraping).to.deep.equal(['https://example.com/scraping'])
+          })
+      })
+      it('Allows Secretariat to edit partner_active_date without changing status', async () => {
+        const partnerActiveDate = '2024-02-20'
+        await chai.request(app)
+          .put('/api/registry/org/registry_org_test')
+          .set(secretariatHeaders)
+          .send({
+            ...createdOrg,
+            program_data: {
+              status: 'active',
+              partner_active_date: partnerActiveDate
+            }
+          })
+          .then((res, err) => {
+            expect(err).to.be.undefined
+            expect(res).to.have.status(200)
+            expect(res.body.updated).to.haveOwnProperty('program_data')
+            expect(res.body.updated.program_data.status).to.equal('active')
+            expect(res.body.updated.program_data.partner_active_date).to.equal(partnerActiveDate)
+          })
+      })
+      it('Allows Secretariat to edit partner_inactive_date without changing status', async () => {
+        const inactiveDateOrg = {
+          ...testRegistryOrg,
+          short_name: 'registry_org_test_inactive_date',
+          long_name: 'Registry Org Test Inactive Date'
+        }
+        const partnerInactiveDate = '2024-03-25'
+
+        const createRes = await chai.request(app)
+          .post('/api/registry/org')
+          .set(secretariatHeaders)
+          .send(inactiveDateOrg)
+
+        expect(createRes).to.have.status(200)
+        const createdInactiveDateOrg = { ...createRes.body.created }
+        delete createdInactiveDateOrg.created
+        delete createdInactiveDateOrg.last_updated
+        delete createdInactiveDateOrg.users
+        delete createdInactiveDateOrg.admins
+
+        await chai.request(app)
+          .put(`/api/registry/org/${inactiveDateOrg.short_name}`)
+          .set(secretariatHeaders)
+          .send({
+            ...createdInactiveDateOrg,
+            program_data: {
+              status: 'inactive',
+              partner_inactive_date: partnerInactiveDate
+            }
+          })
+          .then((res, err) => {
+            expect(err).to.be.undefined
+            expect(res).to.have.status(200)
+            expect(res.body.updated).to.haveOwnProperty('program_data')
+            expect(res.body.updated.program_data.status).to.equal('inactive')
+            expect(res.body.updated.program_data.partner_inactive_date).to.equal(partnerInactiveDate)
+          })
+      })
+      it('Does not generate a partner_active_date when status changes without one provided', async () => {
+        const statusOnlyOrg = {
+          ...testRegistryOrg,
+          short_name: 'registry_org_test_status_only',
+          long_name: 'Registry Org Test Status Only'
+        }
+
+        const createRes = await chai.request(app)
+          .post('/api/registry/org')
+          .set(secretariatHeaders)
+          .send(statusOnlyOrg)
+
+        expect(createRes).to.have.status(200)
+        expect(createRes.body.created.program_data.status).to.equal('inactive')
+        expect(createRes.body.created.program_data).to.not.haveOwnProperty('partner_active_date')
+        const statusOnlyUpdateOrg = { ...createRes.body.created }
+        delete statusOnlyUpdateOrg.created
+        delete statusOnlyUpdateOrg.last_updated
+        delete statusOnlyUpdateOrg.users
+        delete statusOnlyUpdateOrg.admins
+
+        await chai.request(app)
+          .put(`/api/registry/org/${statusOnlyOrg.short_name}`)
+          .set(secretariatHeaders)
+          .send({
+            ...statusOnlyUpdateOrg,
+            program_data: {
+              status: 'active'
+            }
+          })
+          .then((res, err) => {
+            expect(err).to.be.undefined
+            expect(res).to.have.status(200)
+            expect(res.body.updated).to.haveOwnProperty('program_data')
+            expect(res.body.updated.program_data.status).to.equal('active')
+            expect(res.body.updated.program_data).to.not.haveOwnProperty('partner_active_date')
           })
       })
       it('Updates a registry organization\'s short name and role simultaneously to verify read-after-write audit logic', async () => {


### PR DESCRIPTION
Closes Issue #1829

# Summary
Removed update-time automation that overwrote `program_data.partner_active_date` and `program_data.partner_inactive_date`, so registry org updates now persist the values provided by the requester.

# Important Changes
`src/repositories/baseOrgRepository.js`
- Removed the update-time call that automatically recalculated partner status dates.

`src/repositories/baseOrgRepositoryHelpers.js`
- Removed the unused `automateProgramDataDates` helper.

`test/integration-tests/registry-org/registryOrgCRUDTest.js`
- Added regression coverage for editing `partner_active_date`.
- Added regression coverage for editing `partner_inactive_date`.
- Added coverage confirming status changes no longer generate a partner date when one is not provided.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Update a registry org with `program_data.status: "active"` and a custom `partner_active_date`; verify the response returns the provided date.
- [ ] 2) Update a registry org with `program_data.status: "inactive"` and a custom `partner_inactive_date`; verify the response returns the provided date.
- [ ] 3) Change `program_data.status` without passing a partner date; verify no partner date is auto-generated.

Automated testing performed:
- [] `bash -i -c "npm run test:integration"` passed with `409 passing`.

# Notes
- Create-time default date behavior was intentionally left unchanged.