### PR TITLE
Resolves issue #1830, move advisory scraping fields out of program_data and require joint approval.

### DIFF
--- a/schemas/registry-org/BaseOrg.json
+++ b/schemas/registry-org/BaseOrg.json
@@ -182,20 +182,20 @@
         },
         "status": {
           "type": "string"
-        },
-        "advisory_location_require_credentials": {
-          "type": "boolean"
-        },
-        "vulnerability_advisory_location_for_web_scraping": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         }
       },
       "additionalProperties": false
     },
     "advisory_locations": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "advisory_location_require_credentials": {
+      "type": "boolean"
+    },
+    "vulnerability_advisory_location_for_web_scraping": {
       "type": "array",
       "items": {
         "type": "string"

--- a/schemas/registry-org/CNAOrg.json
+++ b/schemas/registry-org/CNAOrg.json
@@ -123,6 +123,12 @@
     "advisory_locations": {
       "$ref": "/BaseOrg#/properties/advisory_locations"
     },
+    "advisory_location_require_credentials": {
+      "$ref": "/BaseOrg#/properties/advisory_location_require_credentials"
+    },
+    "vulnerability_advisory_location_for_web_scraping": {
+      "$ref": "/BaseOrg#/properties/vulnerability_advisory_location_for_web_scraping"
+    },
     "program_data": {
       "$ref": "/BaseOrg#/properties/program_data"
     },

--- a/schemas/registry-org/RootOrg.json
+++ b/schemas/registry-org/RootOrg.json
@@ -93,6 +93,12 @@
     "advisory_locations": {
       "$ref": "/BaseOrg#/properties/advisory_locations"
     },
+    "advisory_location_require_credentials": {
+      "$ref": "/BaseOrg#/properties/advisory_location_require_credentials"
+    },
+    "vulnerability_advisory_location_for_web_scraping": {
+      "$ref": "/BaseOrg#/properties/vulnerability_advisory_location_for_web_scraping"
+    },
     "program_data": {
       "$ref": "/BaseOrg#/properties/program_data"
     },

--- a/schemas/registry-org/create-registry-org-request.json
+++ b/schemas/registry-org/create-registry-org-request.json
@@ -114,6 +114,17 @@
       },
       "description": "Locations of vulnerability advisories"
     },
+    "advisory_location_require_credentials": {
+      "type": "boolean",
+      "description": "Indicates if advisory locations require credentials"
+    },
+    "vulnerability_advisory_location_for_web_scraping": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Advisory locations for web scraping"
+    },
     "industry": {
       "type": "string",
       "description": "Industry sector of the organization"
@@ -170,17 +181,6 @@
         },
         "status": {
           "type": "string"
-        },
-        "advisory_location_require_credentials": {
-          "type": "boolean",
-          "description": "Indicates if advisory locations require credentials"
-        },
-        "vulnerability_advisory_location_for_web_scraping": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Advisory locations for web scraping"
         }
       },
       "description": "Additional partner metadata (restricted)"

--- a/schemas/registry-org/get-registry-org-response.json
+++ b/schemas/registry-org/get-registry-org-response.json
@@ -144,17 +144,6 @@
         },
         "status": {
           "type": "string"
-        },
-        "advisory_location_require_credentials": {
-          "type": "boolean",
-          "description": "Indicates if advisory locations require credentials"
-        },
-        "vulnerability_advisory_location_for_web_scraping": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Advisory locations for web scraping"
         }
       },
       "description": "Additional partner metadata (restricted)"
@@ -165,6 +154,17 @@
         "type": "string"
       },
       "description": "Locations of vulnerability advisories"
+    },
+    "advisory_location_require_credentials": {
+      "type": "boolean",
+      "description": "Indicates if advisory locations require credentials"
+    },
+    "vulnerability_advisory_location_for_web_scraping": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Advisory locations for web scraping"
     },
     "industry": {
       "type": "string",

--- a/schemas/registry-org/list-registry-orgs-response.json
+++ b/schemas/registry-org/list-registry-orgs-response.json
@@ -173,17 +173,6 @@
               },
               "status": {
                 "type": "string"
-              },
-              "advisory_location_require_credentials": {
-                "type": "boolean",
-                "description": "Indicates if advisory locations require credentials"
-              },
-              "vulnerability_advisory_location_for_web_scraping": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "description": "Advisory locations for web scraping"
               }
             },
             "description": "Additional partner metadata (restricted)"
@@ -194,6 +183,17 @@
               "type": "string"
             },
             "description": "Locations of vulnerability advisories"
+          },
+          "advisory_location_require_credentials": {
+            "type": "boolean",
+            "description": "Indicates if advisory locations require credentials"
+          },
+          "vulnerability_advisory_location_for_web_scraping": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Advisory locations for web scraping"
           },
           "industry": {
             "type": "string",

--- a/schemas/registry-org/update-registry-org-request.json
+++ b/schemas/registry-org/update-registry-org-request.json
@@ -130,6 +130,17 @@
       },
       "description": "Locations of vulnerability advisories"
     },
+    "advisory_location_require_credentials": {
+      "type": "boolean",
+      "description": "Indicates if advisory locations require credentials"
+    },
+    "vulnerability_advisory_location_for_web_scraping": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Advisory locations for web scraping"
+    },
     "industry": {
       "type": "string",
       "description": "Industry sector of the organization"
@@ -186,17 +197,6 @@
         },
         "status": {
           "type": "string"
-        },
-        "advisory_location_require_credentials": {
-          "type": "boolean",
-          "description": "Indicates if advisory locations require credentials"
-        },
-        "vulnerability_advisory_location_for_web_scraping": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "Advisory locations for web scraping"
         }
       },
       "description": "Additional partner metadata (restricted)"

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -44,7 +44,7 @@ function getConstants () {
     USER_ROLES: [
       'ADMIN'
     ],
-    JOINT_APPROVAL_FIELDS: ['short_name', 'long_name', 'authority', 'aliases', 'oversees', 'top_level_root', 'charter_or_scope', 'product_list', 'disclosure_policy', 'partner_role_type', 'partner_number', 'program_data.cve_website_update_date', 'program_data.cve_website_update_needed', 'program_data.status', 'advisory_locations', 'tl_root_start_date', 'is_cna_discussion_list', 'hard_quota'],
+    JOINT_APPROVAL_FIELDS: ['short_name', 'long_name', 'authority', 'aliases', 'oversees', 'top_level_root', 'charter_or_scope', 'product_list', 'disclosure_policy', 'partner_role_type', 'partner_number', 'program_data.cve_website_update_date', 'program_data.cve_website_update_needed', 'program_data.status', 'advisory_locations', 'advisory_location_require_credentials', 'vulnerability_advisory_location_for_web_scraping', 'tl_root_start_date', 'is_cna_discussion_list', 'hard_quota'],
     JOINT_APPROVAL_FIELDS_LEGACY: ['short_name', 'name', 'authority.active_roles', 'policies.id_quota'],
     ORG_EXCLUDED_FIELDS: ['__t', '__v', '_id', 'inUse', 'in_use'],
     ORG_RESTRICTED_FIELDS: ['program_data'],
@@ -54,8 +54,6 @@ function getConstants () {
       'program_data.cve_website_update_date',
       'program_data.cve_website_update_needed',
       'program_data.status',
-      'program_data.advisory_location_require_credentials',
-      'program_data.vulnerability_advisory_location_for_web_scraping',
       'top_level_root',
       'oversees'
     ],

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -555,6 +555,8 @@ router.put('/registry/org/:shortname',
           <li>partner_role_type</li>
           <li>partner_country</li>
           <li>advisory_locations</li>
+          <li>advisory_location_require_credentials</li>
+          <li>vulnerability_advisory_location_for_web_scraping</li>
           <li>industry</li>
           <li>tl_root_start_date</li>
           <li>is_cna_discussion_list</li>

--- a/src/controller/org.controller/org.middleware.js
+++ b/src/controller/org.controller/org.middleware.js
@@ -51,10 +51,10 @@ function validateCreateOrgParameters () {
         body(['advisory_locations'])
           .default([])
           .custom(isFlatStringArray),
-        body(['program_data.advisory_location_require_credentials'])
+        body(['advisory_location_require_credentials'])
           .default(false)
           .isBoolean(),
-        body(['program_data.vulnerability_advisory_location_for_web_scraping'])
+        body(['vulnerability_advisory_location_for_web_scraping'])
           .default([])
           .custom(isFlatStringArray),
         body(['tl_root_start_date'])
@@ -153,8 +153,8 @@ function validateCreateOrgParameters () {
           'program_data.cve_website_update_needed',
           'program_data.status',
           'advisory_locations',
-          'program_data.advisory_location_require_credentials',
-          'program_data.vulnerability_advisory_location_for_web_scraping',
+          'advisory_location_require_credentials',
+          'vulnerability_advisory_location_for_web_scraping',
           'industry',
           'tl_root_start_date',
           'is_cna_discussion_list')
@@ -241,8 +241,8 @@ function validateUpdateOrgParameters () {
           'program_data.cve_website_update_date',
           'program_data.cve_website_update_needed',
           'program_data.status',
-          'program_data.advisory_location_require_credentials',
-          'program_data.vulnerability_advisory_location_for_web_scraping',
+          'advisory_location_require_credentials',
+          'vulnerability_advisory_location_for_web_scraping',
           'advisory_locations',
           'industry',
           'tl_root_start_date',
@@ -334,8 +334,8 @@ const QUERY_PARAMETERS = {
     'program_data.cve_website_update_date',
     'program_data.cve_website_update_needed',
     'program_data.status',
-    'program_data.advisory_location_require_credentials',
-    'program_data.vulnerability_advisory_location_for_web_scraping',
+    'advisory_location_require_credentials',
+    'vulnerability_advisory_location_for_web_scraping',
     'advisory_locations',
     'industry',
     'tl_root_start_date',

--- a/src/controller/registry-org.controller/registry-org.middleware.js
+++ b/src/controller/registry-org.controller/registry-org.middleware.js
@@ -23,8 +23,8 @@ function parsePostParams (req, res, next) {
     'program_data.cve_website_update_needed',
     'program_data.status',
     'advisory_locations',
-    'program_data.advisory_location_require_credentials',
-    'program_data.vulnerability_advisory_location_for_web_scraping',
+    'advisory_location_require_credentials',
+    'vulnerability_advisory_location_for_web_scraping',
     'industry',
     'tl_root_start_date',
     'is_cna_discussion_list'

--- a/src/model/baseorg.js
+++ b/src/model/baseorg.js
@@ -33,11 +33,11 @@ const schema = {
     cve_website_update_needed: Boolean,
     partner_active_date: String,
     partner_inactive_date: String,
-    status: String,
-    advisory_location_require_credentials: Boolean,
-    vulnerability_advisory_location_for_web_scraping: [String]
+    status: String
   },
   advisory_locations: [String],
+  advisory_location_require_credentials: Boolean,
+  vulnerability_advisory_location_for_web_scraping: { type: [String], default: undefined },
   industry: String,
   tl_root_start_date: Date,
   is_cna_discussion_list: Boolean,

--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -728,8 +728,8 @@ class BaseOrgRepository extends BaseRepository {
  * @param {string} [incomingParameters.cna_role_type] - (Registry only)
  * @param {string} [incomingParameters.cna_country] - (Registry only)
  * @param {string[]} [incomingParameters.advisory_locations] - (Registry only)
- * @param {boolean} [incomingParameters.program_data.advisory_location_require_credentials] - (Registry only)
- * @param {string[]} [incomingParameters.program_data.vulnerability_advisory_location_for_web_scraping] - (Registry only)
+ * @param {boolean} [incomingParameters.advisory_location_require_credentials] - (Registry only)
+ * @param {string[]} [incomingParameters.vulnerability_advisory_location_for_web_scraping] - (Registry only)
  * @param {string} [incomingParameters.industry] - (Registry only)
  * @param {string} [incomingParameters.tl_root_start_date] - (Registry only)
  * @param {boolean} [incomingParameters.is_cna_discussion_list] - (Registry only)
@@ -817,6 +817,8 @@ class BaseOrgRepository extends BaseRepository {
       'partner_number',
       'partner_country',
       'advisory_locations',
+      'advisory_location_require_credentials',
+      'vulnerability_advisory_location_for_web_scraping',
       'industry',
       'tl_root_start_date',
       'is_cna_discussion_list'

--- a/test/integration-tests/registry-org/registryOrgCRUDTest.js
+++ b/test/integration-tests/registry-org/registryOrgCRUDTest.js
@@ -83,10 +83,10 @@ describe('Testing /registryOrg endpoints', () => {
         const orgWithProgramData = {
           ...testRegistryOrg,
           short_name: 'registry_org_test_prog_data',
+          advisory_location_require_credentials: true,
+          vulnerability_advisory_location_for_web_scraping: ['https://example.com/scraping'],
           program_data: {
-            status: 'active',
-            advisory_location_require_credentials: true,
-            vulnerability_advisory_location_for_web_scraping: ['https://example.com/scraping']
+            status: 'active'
           }
         }
         await chai.request(app)
@@ -103,8 +103,10 @@ describe('Testing /registryOrg endpoints', () => {
             expect(res.body.created).to.haveOwnProperty('program_data')
             expect(res.body.created.program_data.status).to.equal('active')
             expect(res.body.created.program_data).to.haveOwnProperty('partner_active_date')
-            expect(res.body.created.program_data.advisory_location_require_credentials).to.be.true
-            expect(res.body.created.program_data.vulnerability_advisory_location_for_web_scraping).to.deep.equal(['https://example.com/scraping'])
+            expect(res.body.created.program_data).to.not.haveOwnProperty('advisory_location_require_credentials')
+            expect(res.body.created.program_data).to.not.haveOwnProperty('vulnerability_advisory_location_for_web_scraping')
+            expect(res.body.created.advisory_location_require_credentials).to.be.true
+            expect(res.body.created.vulnerability_advisory_location_for_web_scraping).to.deep.equal(['https://example.com/scraping'])
           })
       })
     })
@@ -366,11 +368,11 @@ describe('Testing /registryOrg endpoints', () => {
           .set(secretariatHeaders)
           .send({
             ...createdOrg,
+            advisory_location_require_credentials: true,
+            vulnerability_advisory_location_for_web_scraping: ['https://example.com/scraping'],
             program_data: {
               status: 'active',
-              partner_active_date: partnerActiveDate,
-              advisory_location_require_credentials: true,
-              vulnerability_advisory_location_for_web_scraping: ['https://example.com/scraping']
+              partner_active_date: partnerActiveDate
             }
           })
           .then((res, err) => {
@@ -380,8 +382,10 @@ describe('Testing /registryOrg endpoints', () => {
             expect(res.body.updated.program_data.status).to.equal('active')
             expect(res.body.updated.program_data).to.haveOwnProperty('partner_active_date')
             expect(res.body.updated.program_data.partner_active_date).to.equal(partnerActiveDate)
-            expect(res.body.updated.program_data.advisory_location_require_credentials).to.be.true
-            expect(res.body.updated.program_data.vulnerability_advisory_location_for_web_scraping).to.deep.equal(['https://example.com/scraping'])
+            expect(res.body.updated.program_data).to.not.haveOwnProperty('advisory_location_require_credentials')
+            expect(res.body.updated.program_data).to.not.haveOwnProperty('vulnerability_advisory_location_for_web_scraping')
+            expect(res.body.updated.advisory_location_require_credentials).to.be.true
+            expect(res.body.updated.vulnerability_advisory_location_for_web_scraping).to.deep.equal(['https://example.com/scraping'])
           })
       })
       it('Allows Secretariat to edit partner_active_date without changing status', async () => {

--- a/test/integration-tests/registry-org/registryOrgWithJointReviewTest.js
+++ b/test/integration-tests/registry-org/registryOrgWithJointReviewTest.js
@@ -22,6 +22,12 @@ const nonAdminHeaders2 = {
   'CVE-API-USER': 'drocca_admin_user_comments'
 }
 
+const nonAdminHeadersAdvisory = {
+  'CVE-API-ORG': 'non_advisory_review',
+  'content-type': 'application/json',
+  'CVE-API-USER': 'drocca_admin_user_advisory'
+}
+
 const testRegistryOrgForReview = {
   short_name: 'non_secretariat_org',
   long_name: 'Non Secretariat Org',
@@ -34,6 +40,14 @@ const testRegistryOrgForReviewWithComments = {
   long_name: 'Non Secretariat Org',
   authority: ['CNA'],
   hard_quota: 1000
+}
+
+const testRegistryOrgForAdvisoryReview = {
+  short_name: 'non_advisory_review',
+  long_name: 'Non Advisory Review Org',
+  authority: ['CNA'],
+  hard_quota: 1000,
+  advisory_locations: ['https://example.com/advisories']
 }
 
 const testRegistryOrgAdminUser = {
@@ -52,6 +66,20 @@ const testRegistryOrgAdminUser = {
 
 const testRegistryOrgAdminUserWithComments = {
   username: 'drocca_admin_user_comments',
+  active: 'true',
+  name: {
+    first: 'David',
+    last: 'Rocca',
+    middle: 'N',
+    suffix: 'I'
+  },
+  authority: {
+    active_roles: ['Admin']
+  }
+}
+
+const testRegistryOrgAdminUserAdvisory = {
+  username: 'drocca_admin_user_advisory',
   active: 'true',
   name: {
     first: 'David',
@@ -321,6 +349,79 @@ describe('Testing Joint approval', () => {
           expect(res).to.have.status(200)
           expect(res.body.short_name).to.equal('new_non_with_comments')
           expect(res.body.hard_quota).to.equal(1000)
+        })
+    })
+  })
+  describe('Admin user attempts to edit advisory scraping fields that require joint approval', () => {
+    let secret
+    let orgUUID
+    it('Create an org to use for advisory field review testing', async () => {
+      await chai.request(app)
+        .post('/api/registry/org')
+        .set(secretariatHeaders)
+        .send(testRegistryOrgForAdvisoryReview)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.created.short_name).to.equal(testRegistryOrgForAdvisoryReview.short_name)
+          expect(res.body.created).to.not.haveOwnProperty('advisory_location_require_credentials')
+          expect(res.body.created).to.not.haveOwnProperty('vulnerability_advisory_location_for_web_scraping')
+          orgUUID = res.body.created.UUID
+        })
+    })
+    it('Create an admin user for the advisory field review org', async () => {
+      await chai.request(app)
+        .post('/api/registry/org/non_advisory_review/user')
+        .set(constants.headers)
+        .send(testRegistryOrgAdminUserAdvisory)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.created.username).to.equal(testRegistryOrgAdminUserAdvisory.username)
+          secret = res.body.created.secret
+          nonAdminHeadersAdvisory['CVE-API-KEY'] = secret
+        })
+    })
+    it('Admin requests advisory scraping field changes for joint approval', async () => {
+      await chai.request(app)
+        .put('/api/registry/org/non_advisory_review')
+        .set(nonAdminHeadersAdvisory)
+        .send({
+          ...testRegistryOrgForAdvisoryReview,
+          advisory_location_require_credentials: true,
+          vulnerability_advisory_location_for_web_scraping: ['https://example.com/scraping']
+        })
+        .then((res) => {
+          expect(res).to.have.status(200)
+          expect(res.body.message).to.contain('organization was successfully updated, but joint approval is required for some fields.')
+          expect(res.body.updated).to.not.haveOwnProperty('advisory_location_require_credentials')
+          expect(res.body.updated).to.not.haveOwnProperty('vulnerability_advisory_location_for_web_scraping')
+        })
+    })
+    it('Check to see if the advisory scraping field review was created', async () => {
+      await chai.request(app)
+        .get(`/api/review/org/${orgUUID}`)
+        .set(secretariatHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body).to.have.property('status', 'pending')
+          expect(res.body.target_object_uuid).to.equal(orgUUID)
+          expect(res.body.new_review_data.advisory_location_require_credentials).to.be.true
+          expect(res.body.new_review_data.vulnerability_advisory_location_for_web_scraping).to.deep.equal(['https://example.com/scraping'])
+          expect(res.body.new_review_data.program_data).to.not.haveOwnProperty('advisory_location_require_credentials')
+          expect(res.body.new_review_data.program_data).to.not.haveOwnProperty('vulnerability_advisory_location_for_web_scraping')
+        })
+    })
+    it('Check to see if the org advisory scraping fields were not directly updated', async () => {
+      await chai.request(app)
+        .get('/api/registry/org/non_advisory_review')
+        .set(secretariatHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body).to.not.haveOwnProperty('advisory_location_require_credentials')
+          expect(res.body).to.not.haveOwnProperty('vulnerability_advisory_location_for_web_scraping')
         })
     })
   })

--- a/test/integration-tests/review-object/reviewObjectTest.js
+++ b/test/integration-tests/review-object/reviewObjectTest.js
@@ -32,6 +32,7 @@ describe('Review Object Controller Integration Tests', () => {
     it('Creates a review object for the organization', async () => {
       const reviewObject = { ...constants.testRegistryOrg2 }
       reviewObject.UUID = orgUUID
+      reviewObject.program_data = { status: 'active' }
       const res = await chai
         .request(app)
         .post('/api/review/org/')
@@ -99,6 +100,7 @@ describe('Review Object Controller Integration Tests', () => {
       const reviewObject = { ...constants.testRegistryOrg2 }
       reviewObject.UUID = orgUUID
       reviewObject.short_name = 'updated_org'
+      reviewObject.program_data = { status: 'active' }
       const res = await chai
         .request(app)
         .put(`/api/review/${reviewUUID}`)
@@ -368,17 +370,17 @@ describe('Review Object Controller Integration Tests', () => {
     it('Secretariat can see program_data in review history', async () => {
       const res = await chai
         .request(app)
-        .get(`/api/review/org/${constants.existingOrg.short_name}/reviews`)
+        .get(`/api/review/org/${constants.testRegistryOrg2.short_name}/reviews`)
         .set({ ...constants.headers })
       expect(res).to.have.status(200)
       expect(res.body).to.have.property('reviewObjects')
       expect(res.body.reviewObjects).to.be.an('array')
-      if (res.body.reviewObjects.length > 0) {
-        expect(res.body.reviewObjects[0].new_review_data).to.have.property('program_data')
-        expect(res.body.reviewObjects[0].new_review_data).to.not.have.property('inUse')
-        expect(res.body.reviewObjects[0].new_review_data).to.not.have.property('_id')
-        expect(res.body.reviewObjects[0].new_review_data).to.not.have.property('__v')
-      }
+      const reviewObject = res.body.reviewObjects.find(obj => obj.uuid === reviewUUID)
+      expect(reviewObject).to.exist
+      expect(reviewObject.new_review_data).to.have.property('program_data')
+      expect(reviewObject.new_review_data).to.not.have.property('inUse')
+      expect(reviewObject.new_review_data).to.not.have.property('_id')
+      expect(reviewObject.new_review_data).to.not.have.property('__v')
     })
 
     it('Admin cannot see program_data when getting review object by UUID', async () => {


### PR DESCRIPTION
Closes Issue #1830

# Summary
Moved `advisory_location_require_credentials` and `vulnerability_advisory_location_for_web_scraping` to root-level registry org fields and added them to the joint approval workflow for org admin updates.

# Important Changes
`src/model/baseorg.js`
- Moved advisory credential and web scraping advisory fields out of `program_data`.
- Prevented the web scraping locations array from appearing as an empty default value.

`schemas/registry-org/*.json`
- Updated registry org request/response/base/discriminator schemas to accept and return the two fields at root level.

`src/constants/index.js`
- Added the two root-level fields to `JOINT_APPROVAL_FIELDS`.
- Removed the old nested `program_data.*` entries from Secretariat-only fields.

`src/controller/*/middleware.js`
- Updated registry org parsing and validation to use the new root-level field paths.

`test/integration-tests/registry-org/registryOrgWithJointReviewTest.js`
- Added regression coverage for org admin updates requiring joint approval for the two fields.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Create or update a registry org as Secretariat with the two fields at root level.
- [ ] 2) Verify the fields are returned at root level and not inside `program_data`.
- [ ] 3) As an org admin, update those fields on the admin’s own org.
- [ ] 4) Verify the response says joint approval is required and the live org is not directly updated.
- [ ] 5) As Secretariat, verify the pending review object contains the requested root-level field values.

# Notes
- Ran `bash -i -c "npm run test:integration"` successfully.



