### PR TITLE
removing soft quota and renmaing hard quota to id_quota

### DIFF
--- a/api-docs/openapi.json
+++ b/api-docs/openapi.json
@@ -11,7 +11,7 @@
   },
   "servers": [
     {
-      "url": "https://cveawg-dev.mitre.org/api"
+      "url": "urlplaceholder"
     }
   ],
   "paths": {
@@ -2081,7 +2081,7 @@
               "example": {
                 "short_name": "fake_company",
                 "long_name": "Fake Company",
-                "hard_quota": 1000,
+                "id_quota": 1000,
                 "authority": [
                   "CNA"
                 ]
@@ -2208,14 +2208,14 @@
         }
       }
     },
-    "/registry/org/{shortname}/hard_quota": {
+    "/registry/org/{shortname}/id_quota": {
       "get": {
         "tags": [
           "Registry Organization"
         ],
         "summary": "Retrieves an organization's CVE ID quota (accessible to all registered users)",
         "description": "  <h2>Access Control</h2>  <p>All registered users can access this endpoint</p>  <h2>Expected Behavior</h2>  <p><b>Regular, CNA & Admin Users:</b> Retrieves the CVE ID quota for the user's organization</p>  <p><b>Secretariat:</b> Retrieves the CVE ID quota for any organization</p>",
-        "operationId": "orgHardQuota",
+        "operationId": "orgIdQuota",
         "parameters": [
           {
             "name": "shortname",
@@ -2616,7 +2616,7 @@
           "Registry Organization"
         ],
         "summary": "Updates information about the organization specified by short name (accessible Temporarily to Secretariat only)",
-        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role temporarily.</p>  <p>In the future, only the organization's admin will be able to request changes to its information.</p>  <p>With Joint Approval required for the following fields:</p>  <h2>Expected Behavior</h2>  <b>This endpoint expects a full organization object in the request body.</b>  <p><b>Secretariat:</b> Updates any organization's information</p>  <p><b>Organization Admin:</b> Requests changes to its organization's information</p>  <ul>  <li>short_name</li>  <li>long_name</li>  <li>authority</li>  <li>aliases</li>  <li>oversees</li>  <li>top_level_root</li>  <li>charter_or_scope</li>  <li>product_list</li>  <li>disclosure_policy</li>  <li>contact_info.websites</li>  <li>contact_info.emails</li>  <li>contact_info.phone</li>  <li>partner_role_type</li>  <li>partner_country</li>  <li>advisory_locations</li>  <li>industry</li>  <li>tl_root_start_date</li>  <li>is_cna_discussion_list</li>  </ul>",
+        "description": "  <h2>Access Control</h2>  <p>User must belong to an organization with the <b>Secretariat</b> role temporarily.</p>  <p>In the future, only the organization's admin will be able to request changes to its information.</p>  <p>With Joint Approval required for the following fields:</p>  <h2>Expected Behavior</h2>  <b>This endpoint expects a full organization object in the request body.</b>  <p><b>Secretariat:</b> Updates any organization's information</p>  <p><b>Organization Admin:</b> Requests changes to its organization's information</p>  <ul>  <li>short_name</li>  <li>long_name</li>  <li>authority</li>  <li>aliases</li>  <li>oversees</li>  <li>top_level_root</li>  <li>charter_or_scope</li>  <li>product_list</li>  <li>disclosure_policy</li>  <li>contact_info.websites</li>  <li>contact_info.emails</li>  <li>contact_info.phone</li>  <li>partner_role_type</li>  <li>partner_country</li>  <li>advisory_locations</li>  <li>advisory_location_require_credentials</li>  <li>vulnerability_advisory_location_for_web_scraping</li>  <li>industry</li>  <li>tl_root_start_date</li>  <li>is_cna_discussion_list</li>  </ul>",
         "operationId": "orgUpdateSingle",
         "parameters": [
           {
@@ -2710,7 +2710,7 @@
               "example": {
                 "short_name": "fake_company",
                 "long_name": "Fake Company",
-                "hard_quota": 1000,
+                "id_quota": 1000,
                 "authority": [
                   "CNA"
                 ]
@@ -3607,6 +3607,13 @@
               "type": "string"
             },
             "description": "The shortname of the organization"
+          },
+          {
+            "name": "registry",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "$ref": "#/components/parameters/id_quota"

--- a/schemas/registry-org/BaseOrg.json
+++ b/schemas/registry-org/BaseOrg.json
@@ -106,14 +106,8 @@
         "$ref": "#/definitions/uuidType"
       }
     },
-    "hard_quota": {
+    "id_quota": {
       "description": "The maximum number of CVE IDs this organization can reserve.",
-      "type": "integer",
-      "minimum": 0,
-      "maximum": 100000
-    },
-    "soft_quota": {
-      "description": "The threshold for notifying the organization about their remaining CVE ID count.",
       "type": "integer",
       "minimum": 0,
       "maximum": 100000

--- a/schemas/registry-org/CNAOrg.json
+++ b/schemas/registry-org/CNAOrg.json
@@ -84,12 +84,7 @@
         }
       }
     },
-    "hard_quota": {
-      "type": "integer",
-      "minimum": 0,
-      "maximum": 100000
-    },
-    "soft_quota": {
+    "id_quota": {
       "type": "integer",
       "minimum": 0,
       "maximum": 100000
@@ -147,6 +142,6 @@
   },
   "required": [
     "short_name",
-    "hard_quota"
+    "id_quota"
   ]
 }

--- a/schemas/registry-org/SecretariatOrg.json
+++ b/schemas/registry-org/SecretariatOrg.json
@@ -18,16 +18,12 @@
             "$ref": "/BaseOrg#/definitions/uuidType"
           }
         },
-        "hard_quota": {
-          "type": "integer",
-          "minimum": 0
-        },
-        "soft_quota": {
+        "id_quota": {
           "type": "integer",
           "minimum": 0
         }
       },
-      "required": ["hard_quota"]
+      "required": ["id_quota"]
     }
   ]
 }

--- a/schemas/registry-org/create-registry-org-response.json
+++ b/schemas/registry-org/create-registry-org-response.json
@@ -96,13 +96,9 @@
           "type": "string",
           "description": "List of products associated with the organization"
         },
-        "soft_quota": {
+        "id_quota": {
           "type": "integer",
-          "description": "Soft quota for CVE IDs"
-        },
-        "hard_quota": {
-          "type": "integer",
-          "description": "Hard quota for CVE IDs"
+          "description": "ID quota for CVE IDs"
         },
         "private_contacts": {
           "type": "array",

--- a/schemas/registry-org/get-registry-org-quota-response.json
+++ b/schemas/registry-org/get-registry-org-quota-response.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "hard_quota": {
+    "id_quota": {
       "type": "integer",
       "format": "int32",
       "description": "The number of CVE IDs the organization is allowed to have in the RESERVED state at one time."

--- a/schemas/registry-org/get-registry-org-response.json
+++ b/schemas/registry-org/get-registry-org-response.json
@@ -193,13 +193,9 @@
       "format": "date-time",
       "description": "Timestamp of the last update to the organization data"
     },
-    "hard_quota": {
+    "id_quota": {
       "type": "integer",
-      "description": "Hard quota for CVE IDs"
-    },
-    "soft_quota": {
-      "type": "integer",
-      "description": "Soft quota for CVE IDs"
+      "description": "ID quota for CVE IDs"
     },
     "charter_or_scope": {
       "type": "string",

--- a/schemas/registry-org/list-registry-orgs-response.json
+++ b/schemas/registry-org/list-registry-orgs-response.json
@@ -222,13 +222,9 @@
             "format": "date-time",
             "description": "Timestamp of the last update to the organization data"
           },
-          "hard_quota": {
+          "id_quota": {
             "type": "integer",
-            "description": "Hard quota for CVE IDs"
-          },
-          "soft_quota": {
-            "type": "integer",
-            "description": "Soft quota for CVE IDs"
+            "description": "ID quota for CVE IDs"
           },
           "charter_or_scope": {
             "type": "string",

--- a/schemas/registry-org/update-registry-org-response.json
+++ b/schemas/registry-org/update-registry-org-response.json
@@ -85,13 +85,9 @@
           "type": "string",
           "description": "List of products associated with the organization"
         },
-        "soft_quota": {
+        "id_quota": {
           "type": "integer",
-          "description": "Soft quota for CVE IDs"
-        },
-        "hard_quota": {
-          "type": "integer",
-          "description": "Hard quota for CVE IDs"
+          "description": "ID quota for CVE IDs"
         },
         "private_contacts": {
           "type": "array",

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -44,7 +44,7 @@ function getConstants () {
     USER_ROLES: [
       'ADMIN'
     ],
-    JOINT_APPROVAL_FIELDS: ['short_name', 'long_name', 'authority', 'aliases', 'oversees', 'top_level_root', 'charter_or_scope', 'product_list', 'disclosure_policy', 'partner_role_type', 'partner_number', 'program_data.cve_website_update_date', 'program_data.cve_website_update_needed', 'program_data.status', 'advisory_locations', 'advisory_location_require_credentials', 'vulnerability_advisory_location_for_web_scraping', 'tl_root_start_date', 'is_cna_discussion_list', 'hard_quota'],
+    JOINT_APPROVAL_FIELDS: ['short_name', 'long_name', 'authority', 'aliases', 'oversees', 'top_level_root', 'charter_or_scope', 'product_list', 'disclosure_policy', 'partner_role_type', 'partner_number', 'program_data.cve_website_update_date', 'program_data.cve_website_update_needed', 'program_data.status', 'advisory_locations', 'advisory_location_require_credentials', 'vulnerability_advisory_location_for_web_scraping', 'tl_root_start_date', 'is_cna_discussion_list', 'id_quota'],
     JOINT_APPROVAL_FIELDS_LEGACY: ['short_name', 'name', 'authority.active_roles', 'policies.id_quota'],
     ORG_EXCLUDED_FIELDS: ['__t', '__v', '_id', 'inUse', 'in_use'],
     ORG_RESTRICTED_FIELDS: ['program_data'],

--- a/src/controller/org.controller/index.js
+++ b/src/controller/org.controller/index.js
@@ -192,10 +192,10 @@ router.get('/registry/org/:shortname/users',
   parseGetParams,
   registryOrgController.USER_ALL)
 
-router.get('/registry/org/:shortname/hard_quota',
+router.get('/registry/org/:shortname/id_quota',
   /*
   #swagger.tags = ['Registry Organization']
-  #swagger.operationId = 'orgHardQuota'
+  #swagger.operationId = 'orgIdQuota'
   #swagger.summary = "Retrieves an organization's CVE ID quota (accessible to all registered users)"
   #swagger.description = "
         <h2>Access Control</h2>
@@ -459,7 +459,7 @@ router.post('/registry/org',
         example: {
           short_name: 'fake_company',
           long_name: 'Fake Company',
-          hard_quota: 1000,
+          id_quota: 1000,
           authority: ['CNA']
         }
       }
@@ -577,7 +577,7 @@ router.put('/registry/org/:shortname',
         example: {
           short_name: 'fake_company',
           long_name: 'Fake Company',
-          hard_quota: 1000,
+          id_quota: 1000,
           authority: ['CNA']
         }
       }

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -202,9 +202,9 @@ async function getUser (req, res, next) {
   }
 }
 
-/**
+ /**
  * Get details on ID quota for an org with the specified org shortname.
- * Called by GET /api/registry/org/{shortname}/hard_quota, GET /api/org/{shortname}/id_quota
+ * Called by GET /api/registry/org/{shortname}/id_quota, GET /api/org/{shortname}/id_quota
  *
  * @param {Object} req - The request object
  * @param {Object} res - The response object

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -202,7 +202,7 @@ async function getUser (req, res, next) {
   }
 }
 
- /**
+/**
  * Get details on ID quota for an org with the specified org shortname.
  * Called by GET /api/registry/org/{shortname}/id_quota, GET /api/org/{shortname}/id_quota
  *

--- a/src/controller/org.controller/org.middleware.js
+++ b/src/controller/org.controller/org.middleware.js
@@ -27,8 +27,6 @@ function validateCreateOrgParameters () {
     const useRegistry = req.query.registry === 'true'
     let validations = []
     if (useRegistry) {
-      // Optional
-      //  soft_quota,
       // Not allowed
       // users, , in_use, created, last_updated
       const orgOptions = ['CNA', 'Secretariat', 'Bulk Download', 'ADP']
@@ -96,7 +94,7 @@ function validateCreateOrgParameters () {
           .custom(isFlatStringArray)
           .customSanitizer(toUpperCaseArray)
           .custom(isOrgRole),
-        body(['hard_quota'])
+        body(['id_quota'])
           .default(CONSTANTS.DEFAULT_ID_QUOTA)
           .not()
           .isArray()
@@ -131,9 +129,8 @@ function validateCreateOrgParameters () {
           'in_use',
           'created',
           'top_level_root',
-          'soft_quota',
           'aliases',
-          'hard_quota',
+          'id_quota',
           'contact_info.phone',
           'contact_info.websites',
           'contact_info.emails',
@@ -313,7 +310,7 @@ const QUERY_PARAMETERS = {
     'active_roles',
     'active_roles.add',
     'active_roles.remove',
-    'id_quota' // For registry, maps to 'hard_quota' for CNAOrg
+    'id_quota'
   ],
   // Registry-only parameters
   registryOnly: [
@@ -339,8 +336,7 @@ const QUERY_PARAMETERS = {
     'advisory_locations',
     'industry',
     'tl_root_start_date',
-    'is_cna_discussion_list',
-    'hard_quota' // not directly used in query parameters
+    'is_cna_discussion_list'
   ],
   // User-related parameters
   userParams: [

--- a/src/controller/registry-org.controller/registry-org.middleware.js
+++ b/src/controller/registry-org.controller/registry-org.middleware.js
@@ -14,7 +14,7 @@ function parsePostParams (req, res, next) {
     'oversees',
     'top_level_root', 'users',
     'charter_or_scope', 'disclosure_policy', 'product_list',
-    'soft_quota', 'hard_quota',
+    'id_quota',
     'private_contacts', 'contact_info.websites', 'contact_info.emails', 'contact_info.phone',
     'partner_role_type',
     'partner_number',

--- a/src/model/adporg.js
+++ b/src/model/adporg.js
@@ -11,11 +11,10 @@ ajv.addSchema(BaseOrgSchema)
 
 const validate = ajv.compile(AdpOrgSchema)
 
-// Hard and soft quotas should be retained if something was a cna, then became an adp, then back to cna
+// ID quota should be retained if something was a cna, then became an adp, then back to cna
 // In general, this should never happen, but we have a test case for it, so I want to make sure it works as expected.
 const schema = {
-  hard_quota: Number,
-  soft_quota: Number
+  id_quota: Number
 }
 
 const options = { discriminatorKey: 'kind' }

--- a/src/model/cnaorg.js
+++ b/src/model/cnaorg.js
@@ -13,8 +13,7 @@ const validate = ajv.compile(CnaOrgSchema)
 
 const schema = {
   oversees: [String],
-  hard_quota: Number,
-  soft_quota: Number,
+  id_quota: Number,
   charter_or_scope: String,
   disclosure_policy: String,
   product_list: String

--- a/src/model/secretariatorg.js
+++ b/src/model/secretariatorg.js
@@ -13,8 +13,7 @@ const validate = ajv.compile(SecretariatOrgSchema)
 
 const schema = {
   oversees: [String],
-  hard_quota: Number,
-  soft_quota: Number
+  id_quota: Number
 }
 
 const options = { discriminatorKey: 'kind' }

--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -488,11 +488,11 @@ class BaseOrgRepository extends BaseRepository {
    * @description Calculates the ID quota and availability for an organization.
    * @param {object} org - The organization object.
    * @param {boolean} [useLegacy=false] - If true, uses legacy policies for calculation.
-   * @returns {Promise<object>} Object containing id_quota/hard_quota, total_reserved, and available.
+   * @returns {Promise<object>} Object containing id_quota, total_reserved, and available.
    */
   async getOrgIdQuota (org, useLegacy = false) {
     const returnPayload = {
-      ...(useLegacy ? { id_quota: org.policies.id_quota } : { hard_quota: org.hard_quota }),
+      id_quota: useLegacy ? org.policies.id_quota : org.id_quota,
       total_reserved: null,
       available: null
     }
@@ -503,11 +503,7 @@ class BaseOrgRepository extends BaseRepository {
     const cveIdRepo = new CveIdRepository()
     const docs = await cveIdRepo.countDocuments(query)
     returnPayload.total_reserved = docs
-    if (useLegacy) {
-      returnPayload.available = returnPayload.id_quota - returnPayload.total_reserved
-    } else {
-      returnPayload.available = returnPayload.hard_quota - returnPayload.total_reserved
-    }
+    returnPayload.available = returnPayload.id_quota - returnPayload.total_reserved
     return returnPayload
   }
 
@@ -608,9 +604,9 @@ class BaseOrgRepository extends BaseRepository {
       }
     } else if (registryObjectRaw.authority.includes('CNA')) {
       // A special case, we should make sure we have the default quota if it is not set
-      if (!registryObjectRaw.hard_quota) {
+      if (!registryObjectRaw.id_quota) {
       // set to default quota if none is specified
-        registryObjectRaw.hard_quota = CONSTANTS.DEFAULT_ID_QUOTA
+        registryObjectRaw.id_quota = CONSTANTS.DEFAULT_ID_QUOTA
       }
 
       // Write
@@ -621,7 +617,7 @@ class BaseOrgRepository extends BaseRepository {
         await reviewObjectRepo.createReviewOrgObject(registryObjectRaw, requestingUsername, options)
       }
     } else if (registryObjectRaw.authority.includes('ADP')) {
-      registryObjectRaw.hard_quota = 0
+      registryObjectRaw.id_quota = 0
       const adpObjectToSave = new ADPOrgModel(registryObjectRaw)
       if (isSecretariat) {
         registryObject = await adpObjectToSave.save(options)
@@ -629,7 +625,7 @@ class BaseOrgRepository extends BaseRepository {
         await reviewObjectRepo.createReviewOrgObject(registryObjectRaw, requestingUsername, options)
       }
     } else if (registryObjectRaw.authority.includes('BULK_DOWNLOAD')) {
-      registryObjectRaw.hard_quota = 0
+      registryObjectRaw.id_quota = 0
       const bulkDownloadObjectToSave = new BulkDownloadModel(registryObjectRaw)
       if (isSecretariat) {
         registryObject = await bulkDownloadObjectToSave.save(options)
@@ -841,7 +837,7 @@ class BaseOrgRepository extends BaseRepository {
     // Registry Only Stuff
     // Only a CNA object can have quota
     if (registryOrg.__t === 'CNAOrg' && incomingParameters?.id_quota !== undefined) {
-      registryOrg.hard_quota = incomingParameters.id_quota
+      registryOrg.id_quota = incomingParameters.id_quota
     }
 
     const legacyUpdates = {}
@@ -1175,7 +1171,7 @@ class BaseOrgRepository extends BaseRepository {
       short_name: legacyOrg?.short_name ?? null,
       UUID: legacyOrg?.UUID ?? null,
       authority: newRoles || ['CNA'],
-      hard_quota: legacyOrg?.policies?.id_quota ?? null,
+      id_quota: legacyOrg?.policies?.id_quota ?? null,
       created: legacyOrg?.time?.created ?? null,
       last_updated: legacyOrg?.time?.modified ?? null
     }
@@ -1196,7 +1192,7 @@ class BaseOrgRepository extends BaseRepository {
         active_roles: registryOrg?.authority || ['CNA']
       },
       policies: {
-        id_quota: registryOrg?.hard_quota ?? null
+        id_quota: registryOrg?.id_quota ?? null
       },
       time: {
         created: registryOrg?.created ?? null,

--- a/src/scripts/migrate.js
+++ b/src/scripts/migrate.js
@@ -106,8 +106,7 @@ async function addCVEBoard (db) {
       charter_or_scope: null,
       disclosure_policy: null,
       product_list: null,
-      soft_quota: null,
-      hard_quota: null,
+      id_quota: null,
       private_contacts: [],
       contact_info: {
         phone: null,
@@ -208,8 +207,7 @@ async function orgHelper (db) {
         charter_or_scope: charterScope,
         disclosure_policy: disclosure,
         product_list: null, // don't have now
-        soft_quota: null, // don't have now
-        hard_quota: doc.policies?.id_quota,
+        id_quota: doc.policies?.id_quota,
         admins: admins,
         private_contacts: [], // don't have now
         contact_info: {

--- a/test/integration-tests/audit/registryOrgCreatesAuditTest.js
+++ b/test/integration-tests/audit/registryOrgCreatesAuditTest.js
@@ -15,7 +15,7 @@ async function createTestOrg (customProps = {}) {
   const defaultProps = {
     short_name: shortName,
     long_name: `Test Org ${shortName}`,
-    hard_quota: 1000,
+    id_quota: 1000,
     authority: ['CNA']
   }
 
@@ -40,7 +40,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
   it('Should automatically create audit document when org is created', async () => {
     // Create org
     const org = await createTestOrg({
-      hard_quota: 1500,
+      id_quota: 1500,
       authority: ['CNA']
     })
 
@@ -69,7 +69,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
     const auditObject = initialEntry.audit_object
     expect(auditObject.short_name).to.equal(org.shortName)
     expect(auditObject.long_name).to.equal(org.longName)
-    expect(auditObject.hard_quota).to.equal(1500)
+    expect(auditObject.id_quota).to.equal(1500)
     expect(auditObject.UUID).to.equal(org.uuid)
   })
 
@@ -103,7 +103,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
 
   it('Should NOT add audit entry when updating with no actual changes', async () => {
     const org = await createTestOrg({
-      hard_quota: 1500,
+      id_quota: 1500,
       authority: ['CNA']
     })
 
@@ -113,7 +113,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
       .set(secretariatHeaders)
       .send({
         short_name: org.shortName,
-        hard_quota: 1500,
+        id_quota: 1500,
         authority: ['CNA'],
         long_name: org.longName
       })
@@ -130,7 +130,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
 
   it('Should add audit entry when single field is changed', async () => {
     const testOrg = await createTestOrg({
-      hard_quota: 1500,
+      id_quota: 1500,
       authority: ['CNA']
     })
 
@@ -142,7 +142,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
         long_name: testOrg.longName,
         short_name: testOrg.shortName,
         authority: ['CNA'],
-        hard_quota: 100
+        id_quota: 100
       })
 
     expect(updateRes).to.have.status(200)
@@ -155,15 +155,15 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
     expect(auditRes.body.history).to.have.lengthOf(2)
 
     // Original entry
-    expect(auditRes.body.history[0].audit_object.hard_quota).to.equal(1500)
+    expect(auditRes.body.history[0].audit_object.id_quota).to.equal(1500)
 
     // New entry
-    expect(auditRes.body.history[1].audit_object.hard_quota).to.equal(100)
+    expect(auditRes.body.history[1].audit_object.id_quota).to.equal(100)
   })
 
   it('Should maintain chronological order in audit history', async () => {
     const testOrg = await createTestOrg({
-      hard_quota: 1500,
+      id_quota: 1500,
       authority: ['CNA']
     })
     // Make sequential updates
@@ -174,7 +174,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
         short_name: testOrg.shortName,
         long_name: testOrg.longName,
         authority: ['CNA'],
-        hard_quota: 2000
+        id_quota: 2000
       })
     expect(updatedRes1).to.have.status(200)
 
@@ -185,7 +185,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
         short_name: testOrg.shortName,
         long_name: testOrg.longName,
         authority: ['CNA'],
-        hard_quota: 3000
+        id_quota: 3000
       })
     expect(updatedRes2).to.have.status(200)
 
@@ -196,7 +196,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
         short_name: testOrg.shortName,
         long_name: testOrg.longName,
         authority: ['CNA'],
-        hard_quota: 4000
+        id_quota: 4000
       })
     expect(updatedRes3).to.have.status(200)
     // Check audit history
@@ -207,7 +207,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
     expect(auditRes.body.history).to.have.lengthOf(4)
 
     // Verify chronological order
-    const quotas = auditRes.body.history.map(h => h.audit_object.hard_quota)
+    const quotas = auditRes.body.history.map(h => h.audit_object.id_quota)
     expect(quotas).to.deep.equal([1500, 2000, 3000, 4000])
 
     // Verify timestamps are in order
@@ -220,7 +220,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
 
   it('Should create an audit when updating an Org if it does not exist', async () => {
     const testOrg = await createTestOrg({
-      hard_quota: 1500,
+      id_quota: 1500,
       authority: ['CNA']
     })
     // Manually delete audit document
@@ -239,7 +239,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
         short_name: testOrg.shortName,
         long_name: testOrg.longName,
         authority: ['CNA'],
-        hard_quota: 2500
+        id_quota: 2500
       })
     expect(updateRes).to.have.status(200)
     // Check audit history
@@ -252,7 +252,7 @@ describe('Create and Update Audit Collection with Org Endpoints', () => {
 
   it('Should add audit entry when users or admins are modified via user endpoints', async () => {
     const testOrg = await createTestOrg({
-      hard_quota: 1500,
+      id_quota: 1500,
       authority: ['CNA']
     })
 

--- a/test/integration-tests/constants.js
+++ b/test/integration-tests/constants.js
@@ -391,7 +391,7 @@ const testRegistryOrg = {
     phone: '555-4321'
   }],
   authority: ['CNA'],
-  hard_quota: 100000
+  id_quota: 100000
 }
 
 const testRegistryOrg2 = {
@@ -403,7 +403,7 @@ const testRegistryOrg2 = {
     phone: '555-1234'
   },
   authority: ['CNA'],
-  hard_quota: 100000
+  id_quota: 100000
 }
 
 const existingOrg = {
@@ -429,7 +429,7 @@ const existingRegistryOrg = {
     phone: '555-1234'
   },
   authority: ['CNA'],
-  hard_quota: 100000
+  id_quota: 100000
 }
 
 module.exports = {

--- a/test/integration-tests/org/legacyAdminRoleRevokeTest.js
+++ b/test/integration-tests/org/legacyAdminRoleRevokeTest.js
@@ -32,7 +32,7 @@ describe('Legacy Admin Role Grant and Revoke Test', () => {
         short_name: orgShortName,
         long_name: orgShortName,
         authority: ['CNA'],
-        hard_quota: 1000
+        id_quota: 1000
       })
       .then((res) => {
         expect(res).to.have.status(200)

--- a/test/integration-tests/org/postOrgTest.js
+++ b/test/integration-tests/org/postOrgTest.js
@@ -68,8 +68,8 @@ describe('Testing Org post endpoint', () => {
           expect(res.body.created).to.haveOwnProperty('authority')
           expect(res.body.created.authority).to.deep.equal(['CNA'])
 
-          expect(res.body.created).to.haveOwnProperty('hard_quota')
-          expect(res.body.created.hard_quota).to.equal(constants.testRegistryOrg.hard_quota)
+          expect(res.body.created).to.haveOwnProperty('id_quota')
+          expect(res.body.created.id_quota).to.equal(constants.testRegistryOrg.id_quota)
         })
     })
   })

--- a/test/integration-tests/org/registryOrg.js
+++ b/test/integration-tests/org/registryOrg.js
@@ -21,7 +21,7 @@ const postNewOrg = async (shortName, name, quota = 1000) => {
       short_name: shortName,
       long_name: name,
       authority: ['CNA'],
-      hard_quota: quota
+      id_quota: quota
     })
 }
 
@@ -89,15 +89,15 @@ describe('Testing Secretariat functionality for Orgs', () => {
 
     it('The MITRE CNA has a valid ID quota', async () => {
       await chai.request(app)
-        .get('/api/registry/org/mitre/hard_quota')
+        .get('/api/registry/org/mitre/id_quota')
         .set(secretariatHeaders)
         .then((res) => {
           expect(res).to.have.status(200)
-          expect(res.body).to.have.property('hard_quota')
-          expect(res.body.hard_quota).to.be.a('number').and.to.be.at.least(0)
+          expect(res.body).to.have.property('id_quota')
+          expect(res.body.id_quota).to.be.a('number').and.to.be.at.least(0)
           expect(res.body.total_reserved).to.be.a('number').and.to.be.at.least(0)
           expect(res.body.available).to.be.a('number').and.to.be.at.least(0)
-          expect(res.body.hard_quota).to.equal(res.body.total_reserved + res.body.available)
+          expect(res.body.id_quota).to.equal(res.body.total_reserved + res.body.available)
         })
     })
 
@@ -108,7 +108,7 @@ describe('Testing Secretariat functionality for Orgs', () => {
         .send({
           short_name: 'test_registry_org_cna',
           long_name: 'Testing Registry Org CNA',
-          hard_quota: 123,
+          id_quota: 123,
           authority: ['CNA']
         }).then((res) => {
           expect(res).to.have.status(200)
@@ -119,12 +119,12 @@ describe('Testing Secretariat functionality for Orgs', () => {
         .send({
           short_name: 'test_registry_org_cna',
           long_name: 'Testing Registry Org CNA',
-          hard_quota: 100000,
+          id_quota: 100000,
           authority: ['CNA']
         })
         .then((res) => {
           expect(res).to.have.status(200)
-          expect(res.body.updated.hard_quota).to.equal(100000)
+          expect(res.body.updated.id_quota).to.equal(100000)
           expect(res.body.message).to.equal('test_registry_org_cna organization was successfully updated.')
         })
     })
@@ -362,7 +362,7 @@ describe('Testing Secretariat functionality for Orgs', () => {
       await chai.request(app)
         .post('/api/registry/org')
         .set(secretariatHeaders)
-        .send({ long_name: 'MITRE Corporation', authority: ['SECRETARIAT'], short_name: 'mitre', hard_quota: 1000 })
+        .send({ long_name: 'MITRE Corporation', authority: ['SECRETARIAT'], short_name: 'mitre', id_quota: 1000 })
         .then((res) => {
           expect(res).to.have.status(400)
           expect(res.body.message).to.equal('The \'mitre\' organization already exists.')
@@ -479,7 +479,7 @@ describe('Testing Secretariat functionality for Orgs', () => {
       await chai.request(app)
         .put(`/api/registry/org/${nonExistentOrg}`)
         .set(secretariatHeaders)
-        .send({ hard_quota: 100 })
+        .send({ id_quota: 100 })
         .then((res) => {
           expect(res).to.have.status(404)
           expect(res.body.error).to.equal('ORG_DNE_PARAM')

--- a/test/integration-tests/org/registryOrgAsOrgAdmin.js
+++ b/test/integration-tests/org/registryOrgAsOrgAdmin.js
@@ -225,13 +225,13 @@ describe('Testing Registry Org as org admin', () => {
     })
     it('Registry: services api allows org admins to get their own org quota', async () => {
       await chai.request(app)
-        .get(`/api/registry/org/${shortName}/hard_quota`)
+        .get(`/api/registry/org/${shortName}/id_quota`)
         .set(adminHeaders)
         .then((res, err) => {
           expect(err).to.be.undefined
           expect(res).to.have.status(200)
-          expect(res.body.hard_quota).to.be.lessThan(100000)
-          expect(res.body.hard_quota).to.be.greaterThan(0)
+          expect(res.body.id_quota).to.be.lessThan(100000)
+          expect(res.body.id_quota).to.be.greaterThan(0)
         })
     })
     it('Registry: allows admin users to update their own org without losing program_data', async () => {
@@ -244,7 +244,7 @@ describe('Testing Registry Org as org admin', () => {
           short_name: shortName,
           long_name: 'Test Org',
           authority: ['CNA'],
-          hard_quota: 1000,
+          id_quota: 1000,
           program_data: {
             status: 'active'
           }
@@ -263,7 +263,7 @@ describe('Testing Registry Org as org admin', () => {
           short_name: shortName,
           long_name: 'Test Org2',
           authority: ['CNA'],
-          hard_quota: 1000
+          id_quota: 1000
         })
         .then((res, err) => {
           expect(err).to.be.undefined
@@ -502,7 +502,7 @@ describe('Testing Registry Org as org admin', () => {
     })
     it('Registry: services api rejects requests for org quota by admin of another org', async () => {
       await chai.request(app)
-        .get('/api/registry/org/range_4/hard_quota')
+        .get('/api/registry/org/range_4/id_quota')
         .set(adminHeaders)
         .then((res, err) => {
           expect(err).to.be.undefined
@@ -512,7 +512,7 @@ describe('Testing Registry Org as org admin', () => {
     })
     it('Registry: services api rejects requests for secretariat quota by non-secretariat users', async () => {
       await chai.request(app)
-        .get('/api/registry/org/mitre/hard_quota')
+        .get('/api/registry/org/mitre/id_quota')
         .set(adminHeaders)
         .then((res, err) => {
           expect(err).to.be.undefined

--- a/test/integration-tests/org/regularUsersTestRegistry.js
+++ b/test/integration-tests/org/regularUsersTestRegistry.js
@@ -447,13 +447,13 @@ describe('Testing regular user permissions for /api/registry/org/ endpoints with
       it("regular users can see their organization's cve id quota", async () => {
         const org = constants.nonSecretariatUserHeaders['CVE-API-ORG']
         await chai.request(app)
-          .get(`/api/registry/org/${org}/hard_quota`)
+          .get(`/api/registry/org/${org}/id_quota`)
           .set(constants.nonSecretariatUserHeaders)
           .send({
           })
           .then((res) => {
             expect(res).to.have.status(200)
-            expect(res.body.hard_quota).to.be.greaterThan(0)
+            expect(res.body.id_quota).to.be.greaterThan(0)
             expect(res.body.total_reserved).to.be.greaterThan(0)
             expect(res.body.available).to.be.greaterThan(0)
           })
@@ -487,7 +487,7 @@ describe('Testing regular user permissions for /api/registry/org/ endpoints with
       it("regular users cannot see an organization's cve id quota they don't belong to", async () => {
         const org = constants.nonSecretariatUserHeaders3['CVE-API-ORG']
         await chai.request(app)
-          .get(`/api/registry/org/${org}/hard_quota`)
+          .get(`/api/registry/org/${org}/id_quota`)
           .set(constants.nonSecretariatUserHeaders)
           .send({
           })

--- a/test/integration-tests/registry-org/registryOrgCRUDTest.js
+++ b/test/integration-tests/registry-org/registryOrgCRUDTest.js
@@ -12,7 +12,7 @@ const testRegistryOrg = {
   short_name: 'registry_org_test',
   long_name: 'Registry Org Test',
   authority: ['CNA'],
-  hard_quota: 1000,
+  id_quota: 1000,
   partner_role_type: 'Vendor',
   partner_number: 'Initial Partner Number',
   partner_country: 'US',
@@ -49,8 +49,8 @@ describe('Testing /registryOrg endpoints', () => {
             expect(res.body.created).to.haveOwnProperty('authority')
             expect(res.body.created.authority).to.deep.equal(['CNA'])
 
-            expect(res.body.created).to.haveOwnProperty('hard_quota')
-            expect(res.body.created.hard_quota).to.equal(testRegistryOrg.hard_quota)
+            expect(res.body.created).to.haveOwnProperty('id_quota')
+            expect(res.body.created.id_quota).to.equal(testRegistryOrg.id_quota)
 
             expect(res.body.created).to.haveOwnProperty('partner_role_type')
             expect(res.body.created.partner_role_type).to.equal(testRegistryOrg.partner_role_type)
@@ -214,6 +214,22 @@ describe('Testing /registryOrg endpoints', () => {
             expect(res.body.message).to.equal('Parameters were invalid')
             expect(res.body.errors[0].message).to.equal('must NOT have additional properties')
             expect(res.body.errors[0].params.additionalProperty).to.equal('reports_to')
+          })
+      })
+      it('Fails to create a new registry organization with soft_quota provided', async () => {
+        await chai.request(app)
+          .post('/api/registry/org')
+          .set(secretariatHeaders)
+          .send({
+            ...testRegistryOrg,
+            short_name: 'test_create_soft_quota',
+            soft_quota: 100
+          })
+          .then((res) => {
+            expect(res).to.have.status(400)
+            expect(res.body.message).to.equal('Parameters were invalid')
+            expect(res.body.errors[0].message).to.equal('must NOT have additional properties')
+            expect(res.body.errors[0].params.additionalProperty).to.equal('soft_quota')
           })
       })
       it('Fails to create a new registry organization with an erroneous key not found in the schema', async () => {
@@ -396,8 +412,8 @@ describe('Testing /registryOrg endpoints', () => {
             expect(res.body.updated).to.haveOwnProperty('authority')
             expect(res.body.updated.authority).to.deep.equal(['CNA'])
 
-            expect(res.body.updated).to.haveOwnProperty('hard_quota')
-            expect(res.body.updated.hard_quota).to.equal(createdOrg.hard_quota)
+            expect(res.body.updated).to.haveOwnProperty('id_quota')
+            expect(res.body.updated.id_quota).to.equal(createdOrg.id_quota)
 
             expect(res.body.updated).to.haveOwnProperty('partner_role_type')
             expect(res.body.updated.partner_role_type).to.equal('Researcher')
@@ -544,7 +560,7 @@ describe('Testing /registryOrg endpoints', () => {
           short_name: 'temp_org_for_update',
           long_name: 'Temp Org',
           authority: ['CNA'],
-          hard_quota: 10
+          id_quota: 10
         }
         await chai.request(app)
           .post('/api/registry/org')
@@ -579,7 +595,7 @@ describe('Testing /registryOrg endpoints', () => {
           short_name: 'sub_org_test',
           long_name: 'Sub Org Test',
           authority: ['CNA'],
-          hard_quota: 100
+          id_quota: 100
         }
         let createdSubOrgUUID
         await chai.request(app)
@@ -640,7 +656,7 @@ describe('Testing /registryOrg endpoints', () => {
           short_name: 'temp_org_for_in_use_test',
           long_name: 'Temp Org In Use Test',
           authority: ['CNA'],
-          hard_quota: 10
+          id_quota: 10
         }
         await chai.request(app)
           .post('/api/registry/org')
@@ -794,7 +810,7 @@ describe('Testing /registryOrg endpoints', () => {
             short_name: win5Org.short_name,
             long_name: win5Org.long_name,
             authority: win5Org.authority,
-            hard_quota: win5Org.hard_quota,
+            id_quota: win5Org.id_quota,
             program_data: {
               status: 'active'
             }

--- a/test/integration-tests/registry-org/registryOrgDiscriminatorAuthorityTest.js
+++ b/test/integration-tests/registry-org/registryOrgDiscriminatorAuthorityTest.js
@@ -29,7 +29,7 @@ describe('Testing Registry Org Discriminator Authority inheritance', () => {
       short_name: 'test_cna_discriminator',
       long_name: 'Test CNA Discriminator',
       authority: ['CNA'],
-      hard_quota: 1000
+      id_quota: 1000
     }
     orgsToCleanup.push(cnaOrgData.short_name)
 
@@ -60,7 +60,7 @@ describe('Testing Registry Org Discriminator Authority inheritance', () => {
       short_name: 'test_sec_discriminator',
       long_name: 'Test Secretariat Discriminator',
       authority: ['SECRETARIAT'],
-      hard_quota: 0
+      id_quota: 0
     }
     orgsToCleanup.push(secretariatOrgData.short_name)
 

--- a/test/integration-tests/registry-org/registryOrgWithJointReviewTest.js
+++ b/test/integration-tests/registry-org/registryOrgWithJointReviewTest.js
@@ -32,21 +32,21 @@ const testRegistryOrgForReview = {
   short_name: 'non_secretariat_org',
   long_name: 'Non Secretariat Org',
   authority: ['CNA'],
-  hard_quota: 1000
+  id_quota: 1000
 }
 
 const testRegistryOrgForReviewWithComments = {
   short_name: 'non_with_comments',
   long_name: 'Non Secretariat Org',
   authority: ['CNA'],
-  hard_quota: 1000
+  id_quota: 1000
 }
 
 const testRegistryOrgForAdvisoryReview = {
   short_name: 'non_advisory_review',
   long_name: 'Non Advisory Review Org',
   authority: ['CNA'],
-  hard_quota: 1000,
+  id_quota: 1000,
   advisory_locations: ['https://example.com/advisories']
 }
 
@@ -122,8 +122,8 @@ describe('Testing Joint approval', () => {
           expect(res.body.created).to.haveOwnProperty('authority')
           expect(res.body.created.authority).to.deep.equal(['CNA'])
 
-          expect(res.body.created).to.haveOwnProperty('hard_quota')
-          expect(res.body.created.hard_quota).to.equal(testRegistryOrgForReview.hard_quota)
+          expect(res.body.created).to.haveOwnProperty('id_quota')
+          expect(res.body.created.id_quota).to.equal(testRegistryOrgForReview.id_quota)
         })
     })
     it('Create an User', async () => {
@@ -176,7 +176,7 @@ describe('Testing Joint approval', () => {
         })
     })
     it('Secretariat can approve the ORG review with body parameter', async function () {
-      const newBody = { short_name: 'final_non_secretariat_org', contact_info: { websites: ['https://final.example.com'] }, hard_quota: 1000, authority: ['CNA'], long_name: 'Final Non Secretariat Organization' }
+      const newBody = { short_name: 'final_non_secretariat_org', contact_info: { websites: ['https://final.example.com'] }, id_quota: 1000, authority: ['CNA'], long_name: 'Final Non Secretariat Organization' }
       await chai.request(app)
         .put(`/api/review/${reviewUUID}/approve`)
         .set(secretariatHeaders)
@@ -225,8 +225,8 @@ describe('Testing Joint approval', () => {
           expect(res.body.created).to.haveOwnProperty('authority')
           expect(res.body.created.authority).to.deep.equal(['CNA'])
 
-          expect(res.body.created).to.haveOwnProperty('hard_quota')
-          expect(res.body.created.hard_quota).to.equal(testRegistryOrgForReviewWithComments.hard_quota)
+          expect(res.body.created).to.haveOwnProperty('id_quota')
+          expect(res.body.created.id_quota).to.equal(testRegistryOrgForReviewWithComments.id_quota)
         })
     })
     it('Create an User', async () => {
@@ -348,7 +348,7 @@ describe('Testing Joint approval', () => {
           expect(err).to.be.undefined
           expect(res).to.have.status(200)
           expect(res.body.short_name).to.equal('new_non_with_comments')
-          expect(res.body.hard_quota).to.equal(1000)
+          expect(res.body.id_quota).to.equal(1000)
         })
     })
   })

--- a/test/integration-tests/registry-org/rootOrgTest.js
+++ b/test/integration-tests/registry-org/rootOrgTest.js
@@ -46,7 +46,7 @@ describe('Testing ROOT Organization Type', () => {
         .send({
           ...testRootOrg,
           short_name: 'root_org_fail',
-          hard_quota: 100
+          id_quota: 100
         })
         .then((res) => {
           expect(res).to.have.status(400)

--- a/test/integration-tests/registry-org/verifyDeepRemoveEmpty.js
+++ b/test/integration-tests/registry-org/verifyDeepRemoveEmpty.js
@@ -12,7 +12,7 @@ const testNullRemovalOrg = {
   short_name: 'test_null_removal',
   long_name: 'Test Null Removal Org',
   authority: ['CNA'],
-  hard_quota: 1000,
+  id_quota: 1000,
   contact_info: {
     phone: null // Should be removed
   }

--- a/test/integration-tests/review-object/reviewObjectTest.js
+++ b/test/integration-tests/review-object/reviewObjectTest.js
@@ -214,7 +214,7 @@ describe('Review Object Controller Integration Tests', () => {
       updateData.short_name = constants.existingOrg.short_name
       updateData.long_name = 'Approve Test Organization'
       updateData.authority = ['CNA']
-      updateData.hard_quota = 1000
+      updateData.id_quota = 1000
       updateData.contact_info = { websites: ['https://www.example.com'] }
       const res = await chai
         .request(app)
@@ -260,7 +260,7 @@ describe('Review Object Controller Integration Tests', () => {
       updateData.short_name = constants.existingOrg.short_name
       updateData.long_name = 'Original Pending Organization'
       updateData.authority = ['CNA']
-      updateData.hard_quota = 1000
+      updateData.id_quota = 1000
       const res = await chai
         .request(app)
         .put(`/api/registry/org/${constants.existingOrg.short_name}`)
@@ -284,7 +284,7 @@ describe('Review Object Controller Integration Tests', () => {
         short_name: constants.existingOrg.short_name,
         long_name: 'Modified Approved Organization',
         authority: ['CNA'],
-        hard_quota: 2000
+        id_quota: 2000
       }
       const res = await chai
         .request(app)
@@ -293,7 +293,7 @@ describe('Review Object Controller Integration Tests', () => {
         .send(modifiedData)
       expect(res).to.have.status(200)
       expect(res.body).to.have.property('long_name', 'Modified Approved Organization')
-      expect(res.body).to.have.property('hard_quota', 2000)
+      expect(res.body).to.have.property('id_quota', 2000)
     })
 
     it('Verifies the review object status is now approved and new_review_data reflects the modifications', async () => {
@@ -304,7 +304,7 @@ describe('Review Object Controller Integration Tests', () => {
       expect(res).to.have.status(200)
       expect(res.body).to.have.property('status', 'approved')
       expect(res.body).to.have.nested.property('new_review_data.long_name', 'Modified Approved Organization')
-      expect(res.body).to.have.nested.property('new_review_data.hard_quota', 2000)
+      expect(res.body).to.have.nested.property('new_review_data.id_quota', 2000)
     })
 
     it('Create new review object for rejection testing', async () => {
@@ -312,7 +312,7 @@ describe('Review Object Controller Integration Tests', () => {
       updateData.short_name = constants.existingOrg.short_name
       updateData.long_name = 'Reject Test Organization'
       updateData.authority = ['CNA']
-      updateData.hard_quota = 456
+      updateData.id_quota = 456
       const res = await chai
         .request(app)
         .put(`/api/registry/org/${constants.existingOrg.short_name}`)
@@ -401,7 +401,7 @@ describe('Review Object Controller Integration Tests', () => {
         short_name: constants.existingOrg.short_name,
         long_name: 'Auto Approve Test Org',
         authority: ['CNA'],
-        hard_quota: 789
+        id_quota: 789
       }
       const res = await chai
         .request(app)
@@ -418,7 +418,7 @@ describe('Review Object Controller Integration Tests', () => {
       expect(reviewRes.body).to.have.property('uuid')
       expect(reviewRes.body.status).to.equal('pending')
       expect(reviewRes.body).to.have.nested.property('new_review_data.long_name', 'Auto Approve Test Org')
-      expect(reviewRes.body).to.have.nested.property('new_review_data.hard_quota', 789)
+      expect(reviewRes.body).to.have.nested.property('new_review_data.id_quota', 789)
       autoApproveReviewUUID = reviewRes.body.uuid
     })
 
@@ -427,7 +427,7 @@ describe('Review Object Controller Integration Tests', () => {
         short_name: constants.existingOrg.short_name,
         long_name: 'Auto Approve Test Org',
         authority: ['CNA'],
-        hard_quota: 789
+        id_quota: 789
       }
       const res = await chai
         .request(app)
@@ -436,7 +436,7 @@ describe('Review Object Controller Integration Tests', () => {
         .send(updateData)
       expect(res).to.have.status(200)
       expect(res.body.updated.long_name).to.equal('Auto Approve Test Org')
-      expect(res.body.updated.hard_quota).to.equal(789)
+      expect(res.body.updated.id_quota).to.equal(789)
 
       const reviewRes = await chai
         .request(app)
@@ -452,7 +452,7 @@ describe('Review Object Controller Integration Tests', () => {
         short_name: constants.existingOrg.short_name,
         long_name: 'Auto Reject Pending Org',
         authority: ['CNA'],
-        hard_quota: 999
+        id_quota: 999
       }
       const res = await chai
         .request(app)
@@ -469,7 +469,7 @@ describe('Review Object Controller Integration Tests', () => {
       expect(reviewRes.body).to.have.property('uuid')
       expect(reviewRes.body.status).to.equal('pending')
       expect(reviewRes.body).to.have.nested.property('new_review_data.long_name', 'Auto Reject Pending Org')
-      expect(reviewRes.body).to.have.nested.property('new_review_data.hard_quota', 999)
+      expect(reviewRes.body).to.have.nested.property('new_review_data.id_quota', 999)
       autoRejectReviewUUID = reviewRes.body.uuid
     })
 
@@ -478,7 +478,7 @@ describe('Review Object Controller Integration Tests', () => {
         short_name: constants.existingOrg.short_name,
         long_name: 'Test Organization',
         authority: ['CNA'],
-        hard_quota: 111
+        id_quota: 111
       }
       const res = await chai
         .request(app)
@@ -487,7 +487,7 @@ describe('Review Object Controller Integration Tests', () => {
         .send(updateData)
       expect(res).to.have.status(200)
       expect(res.body.updated.long_name).to.equal('Test Organization')
-      expect(res.body.updated.hard_quota).to.equal(111)
+      expect(res.body.updated.id_quota).to.equal(111)
 
       const reviewRes = await chai
         .request(app)
@@ -503,7 +503,7 @@ describe('Review Object Controller Integration Tests', () => {
         short_name: constants.existingOrg.short_name,
         long_name: 'Admin Retrieval Test Org',
         authority: ['CNA'],
-        hard_quota: 1000
+        id_quota: 1000
       }
       const res = await chai
         .request(app)
@@ -627,7 +627,7 @@ describe('Review Object Controller Integration Tests', () => {
         .request(app)
         .put(`/api/review/org/${fakeUUID}`)
         .set({ ...constants.headers })
-        .send({ short_name: 'test', long_name: 'Test Org', hard_quota: 100 })
+        .send({ short_name: 'test', long_name: 'Test Org', id_quota: 100 })
       expect(res).to.have.status(404)
     })
 

--- a/test/integration-tests/user/updateUserTest.js
+++ b/test/integration-tests/user/updateUserTest.js
@@ -20,7 +20,7 @@ describe('Testing Edit user endpoint', () => {
           short_name: orgA,
           long_name: 'Migration Org A',
           authority: ['CNA'],
-          hard_quota: 1000
+          id_quota: 1000
         })
         .then(res => {
           expect(res.status).to.equal(200, JSON.stringify(res.body))
@@ -34,7 +34,7 @@ describe('Testing Edit user endpoint', () => {
           short_name: orgB,
           long_name: 'Migration Org B',
           authority: ['CNA'],
-          hard_quota: 1000
+          id_quota: 1000
         })
         .then(res => {
           expect(res.status).to.equal(200, JSON.stringify(res.body))

--- a/test/unit-tests/org/orgCreateTest.js
+++ b/test/unit-tests/org/orgCreateTest.js
@@ -79,7 +79,7 @@ describe('Testing the ORG_CREATE_SINGLE controller', () => {
       short_name: 'mitre',
       UUID: 'e388bfb5-77e3-4faa-a613-424b4af85fce',
       authority: 'SECRETARIAT',
-      hard_quota: 1000
+      id_quota: 1000
     }
 
     fakeBaseSavedObjectCisco = {
@@ -89,7 +89,7 @@ describe('Testing the ORG_CREATE_SINGLE controller', () => {
       authority: [
         'CNA'
       ],
-      hard_quota: 500
+      id_quota: 500
     }
 
     fakeLegacySavedObject = {


### PR DESCRIPTION
Remove soft quota and rename registry hard_quota to id_quota.

# Summary
Removes `soft_quota` from registry organization surfaces and renames registry `hard_quota` to `id_quota` across models, schemas, controllers, repositories, docs, migrations, and tests.

# Important Changes
`src/model/cnaorg.js`, `src/model/adporg.js`, `src/model/secretariatorg.js`
- Removed `soft_quota`.
- Renamed registry quota storage from `hard_quota` to `id_quota`.

`src/repositories/baseOrgRepository.js`
- Updated registry/legacy org quota conversion to use registry `id_quota`.
- Updated create, update, and quota response logic to return `id_quota`.

`src/controller/org.controller/index.js`
- Renamed registry quota endpoint from `/registry/org/:shortname/hard_quota` to `/registry/org/:shortname/id_quota`.

`schemas/registry-org/*.json`, `api-docs/openapi.json`
- Updated registry org schemas and OpenAPI docs to use `id_quota`.
- Removed `soft_quota` from registry org schema responses.

`src/scripts/migrate.js`
- Updated migration output to write `id_quota`.

`test/integration-tests/**`, `test/unit-tests/org/orgCreateTest.js`
- Updated quota assertions and request payloads to use `id_quota`.
- Added coverage that rejects `soft_quota` in registry org creation.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Create a registry CNA org with `id_quota` and verify the response includes `id_quota`.
- [ ] 2) Get `/api/registry/org/{shortname}/id_quota` and verify the response includes `id_quota`, `total_reserved`, and `available`.
- [ ] 3) Attempt to create a registry org with `soft_quota` and verify the API returns 400.
- [ ] 4) Run `bash -i -c "npm run test:integration"`.
