### PR TITLE
Resolves Issue #1856 and #1857: Return authority validation errors for invalid registry org roles

### DIFF
--- a/src/repositories/baseOrgRepository.js
+++ b/src/repositories/baseOrgRepository.js
@@ -1042,8 +1042,23 @@ class BaseOrgRepository extends BaseRepository {
       return { isValid: false, errors: [{ instancePath: '/authority', message: 'authority is required' }] }
     }
 
+    const validAuthorityRoles = getConstants().ORG_ROLES
+    const authorityRoleError = instancePath => ({
+      isValid: false,
+      errors: [{
+        instancePath,
+        message: 'must be equal to one of the allowed values',
+        params: { allowedValues: validAuthorityRoles }
+      }]
+    })
+
     let validateObject = {}
     if (Array.isArray(org.authority)) {
+      const invalidAuthorityIndex = org.authority.findIndex(role => !validAuthorityRoles.includes(role))
+      if (invalidAuthorityIndex !== -1) {
+        return authorityRoleError(`/authority/${invalidAuthorityIndex}`)
+      }
+
       // User passed in an array, we need to decide how we handle this.
       if (org.authority.includes('SECRETARIAT')) {
         org.authority = ['SECRETARIAT']
@@ -1068,6 +1083,10 @@ class BaseOrgRepository extends BaseRepository {
         }
       }
     } else {
+      if (!validAuthorityRoles.includes(org.authority)) {
+        return authorityRoleError('/authority')
+      }
+
       if (org.authority === 'ADP') {
         validateObject = ADPOrgModel.validateOrg(org)
       }

--- a/test/integration-tests/registry-org/registryOrgCRUDTest.js
+++ b/test/integration-tests/registry-org/registryOrgCRUDTest.js
@@ -748,6 +748,23 @@ describe('Testing /registryOrg endpoints', () => {
             expect(res.body.message).to.equal('Parameters were invalid')
           })
       })
+      it('Fails to update a registry organization with lowercase authority and returns authority errors', async () => {
+        await chai.request(app)
+          .put('/api/registry/org/registry_org_test')
+          .set(secretariatHeaders)
+          .send({
+            ...createdOrg,
+            authority: ['cna']
+          })
+          .then((res) => {
+            expect(res).to.have.status(400)
+            expect(res.body.message).to.equal('Parameters were invalid')
+            expect(res.body.errors).to.be.an('array')
+            expect(res.body.errors[0].instancePath).to.equal('/authority/0')
+            expect(res.body.errors[0].message).to.equal('must be equal to one of the allowed values')
+            expect(res.body.errors[0].params.allowedValues).to.include('CNA')
+          })
+      })
       it('Fails to update a registry organization providing an invalid partner_role_type enum value', async () => {
         await chai.request(app)
           .put('/api/registry/org/registry_org_test')


### PR DESCRIPTION
Closes Issue #1856 and #1857

# Summary
This MR fixes registry organization validation so invalid `authority` values return structured errors instead of producing an uninformative `Parameters were invalid` response. It also prevents mixed authority arrays from reaching the joint-approval review-object flow with invalid `BaseOrg` data.

# Important Changes
`src/repositories/baseOrgRepository.js`
- Adds explicit validation for every `authority` array item before discriminator-specific validation mutates the authority value.
- Returns structured errors with `instancePath`, message, and allowed values.
- Prevents invalid authority arrays such as `['cna']` or `['CNA', {}, null, 1234, true]` from reaching `updateOrgFull()` and review-object creation.

`test/integration-tests/registry-org/registryOrgCRUDTest.js`
- Adds regression coverage for `PUT /api/registry/org/:shortname` with lowercase `authority: ['cna']`.
- Verifies the response includes `/authority/0` and an allowed-values validation message.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run `bash -i -c "npm run test:integration"`.