### PR TITLE
Fixing partner_role_type to be an array during migration

### DIFF
--- a/src/scripts/MondayHelpers.js
+++ b/src/scripts/MondayHelpers.js
@@ -15,6 +15,17 @@ const pocEmailColumnNumbers = Array.from(
   { length: 10 },
   (_, index) => index + 1
 )
+const partnerRoleTypeValues = new Set([
+  '',
+  'Bug Bounty Provider',
+  'CERT',
+  'Consortium',
+  'Hosted Service',
+  'N/A',
+  'Open Source',
+  'Researcher',
+  'Vendor'
+])
 
 const countryNames = new Set(countryList.map((country) => country.name))
 const countryAliases = new Map([
@@ -101,7 +112,7 @@ function buildAsOrgRows (rawRows) {
     vulnerability_advisory_location_for_web_scraping: toOptionalSingleItemArray(
       row.vulnerability_advisory_location_s_for_web_scraping
     ),
-    partner_role_type: row.cna_role_type,
+    partner_role_type: formatPartnerRoleType(row.cna_role_type),
     partner_number: formatPartnerNumber(row),
     partner_country: normalizePartnerCountry(row, unknownCountries),
     primary_poc_name: formatPocName(row.primary_poc_name),
@@ -165,6 +176,15 @@ function formatPartnerNumber (mondayOrg) {
     .toUpperCase()
 
   return `${normalizedOrgLevel}-${year}-${number}`
+}
+
+function formatPartnerRoleType (value) {
+  const values = Array.isArray(value) ? value : String(value || '').split(/[,\n;]/)
+  const validValues = values
+    .map((roleType) => String(roleType || '').trim())
+    .filter((roleType) => partnerRoleTypeValues.has(roleType))
+
+  return validValues.length ? _.uniq(validValues) : undefined
 }
 
 function normalizePartnerCountry (mondayOrg, unknownCountries) {


### PR DESCRIPTION
No issue, Normalize Monday partner role types during migration.

Closes Issue N/A

# Summary
Normalizes Monday export `cna_role_type` values into the `BaseOrg.partner_role_type` array format expected by the registry schema.

# Important Changes
`src/scripts/MondayHelpers.js`
- Added valid partner role type enum filtering for Monday migration data.
- Converts `cna_role_type` into a deduped array of valid `partner_role_type` values.
- Splits string values on commas, semicolons, and newlines.
- Omits invalid or unrecognized partner role values from migration output.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run `npm run migrate:dev:monday` with a Monday export containing one or more `cna_role_type` values.
- [ ] 2) Verify migrated `BaseOrg.partner_role_type` values are arrays.
- [ ] 3) Verify invalid role values are not written to `BaseOrg`.

# Notes
- This does not resolve a bug ticket.
- Valid values are limited to the existing `BaseOrg` partner role enum.