### PR TITLE
Resolves #1883: Fixing hung sessions

### DIFF
--- a/src/controller/audit.controller/audit.controller.js
+++ b/src/controller/audit.controller/audit.controller.js
@@ -10,9 +10,6 @@ const validateUUID = require('uuid').validate
  */
 async function createAuditDocumentForOrg (req, res, next) {
   try {
-    const session = await mongoose.startSession()
-    const repo = req.ctx.repositories.getAuditRepository()
-    const orgRepo = req.ctx.repositories.getBaseOrgRepository()
     const body = req.ctx.body
     let returnValue
 
@@ -29,6 +26,10 @@ async function createAuditDocumentForOrg (req, res, next) {
       logger.info({ uuid: req.ctx.uuid, message: 'Invalid target_uuid format' })
       return res.status(400).json(error.invalidUUID('target_uuid'))
     }
+
+    const repo = req.ctx.repositories.getAuditRepository()
+    const orgRepo = req.ctx.repositories.getBaseOrgRepository()
+    const session = await mongoose.startSession()
 
     try {
       session.startTransaction()
@@ -117,9 +118,6 @@ async function createAuditDocumentForOrg (req, res, next) {
  */
 async function appendToAuditHistoryForOrg (req, res, next) {
   try {
-    const session = await mongoose.startSession()
-    const repo = req.ctx.repositories.getAuditRepository()
-    const orgRepo = req.ctx.repositories.getBaseOrgRepository()
     const body = req.ctx.body
     let returnValue
 
@@ -134,6 +132,10 @@ async function appendToAuditHistoryForOrg (req, res, next) {
       logger.info({ uuid: req.ctx.uuid, message: 'Invalid target_uuid format' })
       return res.status(400).json(error.invalidUUID('target_uuid'))
     }
+
+    const repo = req.ctx.repositories.getAuditRepository()
+    const orgRepo = req.ctx.repositories.getBaseOrgRepository()
+    const session = await mongoose.startSession()
 
     try {
       session.startTransaction()
@@ -207,8 +209,8 @@ async function appendToAuditHistoryForOrg (req, res, next) {
  */
 async function getAllOrgAuditDocuments (req, res, next) {
   try {
-    const session = await mongoose.startSession()
     const repo = req.ctx.repositories.getAuditRepository()
+    const session = await mongoose.startSession()
     let returnValue
 
     try {
@@ -230,8 +232,6 @@ async function getAllOrgAuditDocuments (req, res, next) {
  */
 async function getOrgAuditByDocumentUUID (req, res, next) {
   try {
-    const session = await mongoose.startSession()
-    const repo = req.ctx.repositories.getAuditRepository()
     const documentUUID = req.ctx.params.document_uuid
     let returnValue
 
@@ -244,6 +244,9 @@ async function getOrgAuditByDocumentUUID (req, res, next) {
       logger.info({ uuid: req.ctx.uuid, message: 'Invalid document_uuid format' })
       return res.status(400).json(error.invalidUUID('document_uuid'))
     }
+
+    const session = await mongoose.startSession()
+    const repo = req.ctx.repositories.getAuditRepository()
 
     try {
       returnValue = await repo.findOneByUUID(documentUUID, { session })
@@ -269,16 +272,17 @@ async function getOrgAuditByDocumentUUID (req, res, next) {
  */
 async function getOrgAuditByOrgIdentifier (req, res, next) {
   try {
-    const session = await mongoose.startSession()
-    const repo = req.ctx.repositories.getAuditRepository()
-    const orgRepo = req.ctx.repositories.getBaseOrgRepository()
     const identifier = req.ctx.params.org_identifier
-    const identifierIsUUID = validateUUID(identifier)
     let returnValue
 
     if (!identifier) {
       return res.status(400).json(error.missingRequiredField('identifier'))
     }
+
+    const identifierIsUUID = validateUUID(identifier)
+    const repo = req.ctx.repositories.getAuditRepository()
+    const orgRepo = req.ctx.repositories.getBaseOrgRepository()
+    const session = await mongoose.startSession()
 
     try {
       session.startTransaction()
@@ -335,11 +339,7 @@ async function getOrgAuditByOrgIdentifier (req, res, next) {
  */
 async function getLastXChanges (req, res, next) {
   try {
-    const session = await mongoose.startSession()
-    const repo = req.ctx.repositories.getAuditRepository()
-    const orgRepo = req.ctx.repositories.getBaseOrgRepository()
     const identifier = req.ctx.params.org_identifier
-    const identifierIsUUID = validateUUID(identifier)
     const numberOfChanges = parseInt(req.ctx.params.number_of_changes)
     let returnValue
 
@@ -351,6 +351,11 @@ async function getLastXChanges (req, res, next) {
       logger.info({ uuid: req.ctx.uuid, message: 'Invalid number_of_changes parameter' })
       return res.status(400).json(error.invalidNumberOfChanges())
     }
+
+    const identifierIsUUID = validateUUID(identifier)
+    const repo = req.ctx.repositories.getAuditRepository()
+    const orgRepo = req.ctx.repositories.getBaseOrgRepository()
+    const session = await mongoose.startSession()
 
     try {
       session.startTransaction()

--- a/src/controller/conversation.controller/conversation.controller.js
+++ b/src/controller/conversation.controller/conversation.controller.js
@@ -45,6 +45,7 @@ async function createConversationForTargetUUID (req, res, next) {
     const user = await authContext.getRequesterUser(req, userRepo, orgRepo, { session })
 
     if (typeof body !== 'object' || !body.body || !repo.validateConversation(body)) {
+      await session.abortTransaction()
       return res.status(400).json(error.invalidConversationObject())
     }
 
@@ -53,6 +54,7 @@ async function createConversationForTargetUUID (req, res, next) {
     if (!isSecretariat) {
       const orgUUID = await authContext.getRequesterOrgUUID(req, orgRepo, { session })
       if (targetUUID !== orgUUID) {
+        await session.abortTransaction()
         return res.status(403).json({ error: 'UNAUTHORIZED', message: 'Unauthorized' })
       }
     }
@@ -98,12 +100,14 @@ async function updateConversationByUUID (req, res, next) {
     const conversation = await repo.findOneByUUID(conversationUUID, { session })
     if (!conversation) {
       logger.info({ uuid: req.ctx.uuid, message: `No conversation found with UUID ${conversationUUID}` })
+      await session.abortTransaction()
       return res.status(404).json(error.conversationDne(conversationUUID))
     }
 
     // Validate body
     if (typeof body !== 'object' || !(body.body || body.visibility) || !repo.validateConversation(body)) {
       logger.info({ uuid: req.ctx.uuid, message: 'The conversation could not be edited because the request body was invalid.' })
+      await session.abortTransaction()
       return res.status(400).json(error.invalidConversationEditObject())
     }
 

--- a/src/controller/org.controller/org.controller.js
+++ b/src/controller/org.controller/org.controller.js
@@ -253,12 +253,13 @@ async function getOrgIdQuota (req, res, next) {
  */
 async function createOrg (req, res, next) {
   try {
-    const session = await mongoose.startSession()
     const repo = req.ctx.repositories.getBaseOrgRepository()
     const body = req.ctx.body
     let returnValue
     // Do not allow the user to pass in a UUID
     if ((body?.UUID ?? null) || (body?.uuid ?? null)) return res.status(400).json(error.uuidProvided('org'))
+
+    const session = await mongoose.startSession()
 
     try {
       session.startTransaction()
@@ -369,10 +370,12 @@ async function updateOrg (req, res, next) {
 
       if (!(await orgRepository.orgExists(shortNameUrlParameter, { session }))) {
         logger.info({ uuid: req.ctx.uuid, message: `Organization ${shortNameUrlParameter} not found.` })
+        await session.abortTransaction()
         return res.status(404).json(error.orgDnePathParam(shortNameUrlParameter))
       }
 
       if (Object.hasOwn(queryParametersJson, 'new_short_name') && (await orgRepository.orgExists(queryParametersJson.new_short_name, { session }))) {
+        await session.abortTransaction()
         return res.status(403).json(error.duplicateShortname(queryParametersJson.new_short_name))
       }
 
@@ -438,7 +441,6 @@ async function updateOrg (req, res, next) {
  * @returns {Promise<void>}
  */
 async function createUser (req, res, next) {
-  const session = await mongoose.startSession()
   try {
     const body = req.ctx.body
     const userRepo = req.ctx.repositories.getBaseUserRepository()
@@ -463,14 +465,18 @@ async function createUser (req, res, next) {
       return res.status(400).json(error.uuidProvided('org'))
     }
 
+    const session = await mongoose.startSession()
+
     try {
       session.startTransaction()
       if (req.useRegistry) {
         const result = await userRepo.validateUser(body)
         if (body?.role && typeof body?.role !== 'string') {
+          await session.abortTransaction()
           return res.status(400).json({ message: 'Parameters were invalid', details: [{ param: 'role', msg: 'Parameter must be a string' }] })
         }
         if (body?.role && !constants.USER_ROLES.includes(body?.role)) {
+          await session.abortTransaction()
           return res.status(400).json({ message: 'Parameters were invalid', details: [{ param: 'role', msg: `Role must be one of the following: ${constants.USER_ROLES}` }] })
         }
         if (!result.isValid) {
@@ -480,6 +486,7 @@ async function createUser (req, res, next) {
         }
       } else {
         if (!body?.username || typeof body?.username !== 'string') {
+          await session.abortTransaction()
           return res.status(400).json({ message: 'Parameters were invalid', details: [{ param: 'username', msg: 'Parameter must be a non empty string' }] })
         }
       }

--- a/src/controller/registry-org.controller/registry-org.controller.js
+++ b/src/controller/registry-org.controller/registry-org.controller.js
@@ -247,16 +247,16 @@ async function getOrg (req, res, next) {
  */
 async function createOrg (req, res, next) {
   try {
-    const session = await mongoose.startSession({ causalConsistency: false })
     const repo = req.ctx.repositories.getBaseOrgRepository()
     const body = req.ctx.body
-    const isSecretariat = await authContext.isRequesterSecretariat(req, repo, { session })
     let createdOrg
 
     // Do not allow the user to pass in a UUID
     if ((body?.UUID ?? null) || (body?.uuid ?? null)) {
       return res.status(400).json(error.uuidProvided('org'))
     }
+
+    const isSecretariat = await authContext.isRequesterSecretariat(req, repo)
 
     if (!isSecretariat) {
       const secretariatOnlyFields = getConstants().SECRETARIAT_ONLY_FIELDS
@@ -266,6 +266,8 @@ async function createOrg (req, res, next) {
         return res.status(403).json(error.secretariatOnlyEditing(restrictedFieldsSent))
       }
     }
+
+    const session = await mongoose.startSession({ causalConsistency: false })
 
     try {
       session.startTransaction()
@@ -730,7 +732,6 @@ async function getUsers (req, res, next) {
  *              Called by POST /api/registryOrg/:shortname/user
  */
 async function createUserByOrg (req, res, next) {
-  const session = await mongoose.startSession({ causalConsistency: false })
   try {
     const body = req.ctx.body
     const userRepo = req.ctx.repositories.getBaseUserRepository()
@@ -754,10 +755,13 @@ async function createUserByOrg (req, res, next) {
       return res.status(400).json(error.uuidProvided('org'))
     }
 
+    const session = await mongoose.startSession({ causalConsistency: false })
+
     try {
       session.startTransaction()
       const result = await userRepo.validateUser(body)
       if (body?.role && typeof body?.role !== 'string') {
+        await session.abortTransaction()
         return res.status(400).json({ message: 'Parameters were invalid', details: [{ param: 'role', msg: 'Parameter must be a string' }] })
       }
       if (!result.isValid) {

--- a/src/controller/registry-user.controller/registry-user.controller.js
+++ b/src/controller/registry-user.controller/registry-user.controller.js
@@ -166,7 +166,6 @@ async function getUser (req, res, next) {
 }
 
 async function createUser (req, res, next) {
-  const session = await mongoose.startSession({ causalConsistency: false })
   try {
     const orgRepo = req.ctx.repositories.getBaseOrgRepository()
     const userRepo = req.ctx.repositories.getBaseUserRepository()
@@ -189,11 +188,14 @@ async function createUser (req, res, next) {
       return res.status(400).json(error.uuidProvided('org'))
     }
 
+    const session = await mongoose.startSession({ causalConsistency: false })
+
     try {
       session.startTransaction()
 
       const result = await userRepo.validateUser(body)
       if (body?.role && typeof body?.role !== 'string') {
+        await session.abortTransaction()
         return res.status(400).json({ message: 'Parameters were invalid', details: [{ param: 'role', msg: 'Parameter must be a string' }] })
       }
       if (!result.isValid) {
@@ -243,7 +245,6 @@ async function updateUser (req, res, next) {
 
     We need to make sure that either way we convert to one or the other. For now, I am going shortname / username
   */
-  const session = await mongoose.startSession({ causalConsistency: false })
   // Check to see if identifier is set
   const identifier = req.ctx.params.identifier
 
@@ -275,7 +276,7 @@ async function updateUser (req, res, next) {
     username: req.ctx.params.username
   }
 
-  const isSecretariat = await authContext.isRequesterSecretariat(req, orgRepo, { session })
+  const isSecretariat = await authContext.isRequesterSecretariat(req, orgRepo)
 
   // TODO: This will need to be atomic at some point like revoke or grant
   // Specific check for org_short_name (Secretariat only)
@@ -283,7 +284,7 @@ async function updateUser (req, res, next) {
   let userToEdit
   let org
   if (identifier) {
-    userToEdit = await userRepo.findUserByUUID(identifier, { session })
+    userToEdit = await userRepo.findUserByUUID(identifier)
     if (!userToEdit) {
       logger.info({ uuid: req.ctx.uuid, message: identifier + ' user could not be found.' })
       return res.status(404).json(error.userDne(identifier))
@@ -295,11 +296,11 @@ async function updateUser (req, res, next) {
       return res.status(404).json(error.orgDnePathParam(identifier))
     }
 
-    org = await orgRepo.findOneByUUID(orgUUID, { session })
+    org = await orgRepo.findOneByUUID(orgUUID)
     userToEditParameters.org = org.short_name
     userToEditParameters.username = userToEdit.username
   } else {
-    userToEdit = await userRepo.findOneByUsernameAndOrgShortname(userToEditParameters.username, userToEditParameters.org, { session })
+    userToEdit = await userRepo.findOneByUsernameAndOrgShortname(userToEditParameters.username, userToEditParameters.org)
     org = await orgRepo.findOneByShortName(userToEditParameters.org)
     if (!org) {
       logger.info({ uuid: req.ctx.uuid, message: `Target organization ${userToEditParameters.org} does not exist.` })
@@ -307,8 +308,8 @@ async function updateUser (req, res, next) {
     }
   }
 
-  const isAdmin = await authContext.isRequesterAdminOfOrg(req, userRepo, orgRepo, org, { session })
-  const requesterUserUUID = await authContext.getRequesterUserUUID(req, userRepo, orgRepo, { session })
+  const isAdmin = await authContext.isRequesterAdminOfOrg(req, userRepo, orgRepo, org)
+  const requesterUserUUID = await authContext.getRequesterUserUUID(req, userRepo, orgRepo)
 
   // Allow existing UUIDs to be passed, but block any attempts to mutate them
   if (userToEdit) {
@@ -346,7 +347,7 @@ async function updateUser (req, res, next) {
     return res.status(404).json(error.orgDnePathParam(userToEditParameters.org))
   }
 
-  const requesterSameOrg = await authContext.isRequesterSameOrg(req, orgRepo, org, { session })
+  const requesterSameOrg = await authContext.isRequesterSameOrg(req, orgRepo, org)
   if (!isSecretariat && !isAdmin && !requesterSameOrg) {
     logger.info({ uuid: req.ctx.uuid, message: requestingUserParameters.org + ' user can only be updated by the user or admins of the same organization or the Secretariat.' })
     return res.status(403).json(error.notSameOrgOrSecretariat())
@@ -375,6 +376,7 @@ async function updateUser (req, res, next) {
   let result
   let updatedUser
   let updatedUserUUID
+  const session = await mongoose.startSession({ causalConsistency: false })
   try {
     session.startTransaction()
     try {
@@ -480,7 +482,6 @@ async function deleteUser (req, res, next) {
 
 async function grantRole (req, res, next) {
   // Explicitly configuring causalConsistency flag for clear DocumentDB context documentation
-  const session = await mongoose.startSession({ causalConsistency: false })
   try {
     const orgShortName = req.ctx.params.shortname
     const username = req.ctx.params.username
@@ -522,6 +523,8 @@ async function grantRole (req, res, next) {
       return res.status(403).json(error.notOrgAdminOrSecretariatUpdate())
     }
 
+    const session = await mongoose.startSession({ causalConsistency: false })
+
     try {
       session.startTransaction()
       const requestingUserUUID = await authContext.getRequesterUserUUID(req, userRepo, orgRepo, { session })
@@ -543,7 +546,6 @@ async function grantRole (req, res, next) {
 
 async function revokeRole (req, res, next) {
   // Explicitly configuring causalConsistency flag for clear DocumentDB context documentation
-  const session = await mongoose.startSession({ causalConsistency: false })
   try {
     const orgShortName = req.ctx.params.shortname
     const username = req.ctx.params.username
@@ -590,6 +592,8 @@ async function revokeRole (req, res, next) {
     if (callingUserUUID === targetUser.UUID) {
       return res.status(403).json({ error: 'NOT_ALLOWED_TO_SELF_DEMOTE', message: 'You cannot remove the ADMIN role from yourself.' })
     }
+
+    const session = await mongoose.startSession({ causalConsistency: false })
 
     try {
       session.startTransaction()

--- a/src/controller/review-object.controller/review-object.controller.js
+++ b/src/controller/review-object.controller/review-object.controller.js
@@ -88,17 +88,17 @@ async function approveReviewObject (req, res, next) {
   const isPendingReview = true
   const UUID = req.params.uuid
   const body = req.body
-  const session = await mongoose.startSession({ causalConsistency: false })
   let updatedOrgObj
+
+  const bodyValidation = (body && Object.keys(body).length) ? baseOrgRepo.validateOrg(body) : { isValid: true }
+  if (!bodyValidation.isValid) {
+    return res.status(400).json({ message: 'Invalid body parameters', errors: bodyValidation.errors })
+  }
+
+  const session = await mongoose.startSession({ causalConsistency: false })
 
   try {
     session.startTransaction()
-
-    const bodyValidation = (body && Object.keys(body).length) ? baseOrgRepo.validateOrg(body) : { isValid: true }
-    if (!bodyValidation.isValid) {
-      await session.abortTransaction()
-      return res.status(400).json({ message: 'Invalid body parameters', errors: bodyValidation.errors })
-    }
 
     const reviewObject = await reviewRepo.findOneByUUIDWithConversation(UUID, isSecretariat, isPendingReview, { session })
     if (!reviewObject) {
@@ -145,13 +145,14 @@ async function updateReviewObjectByReviewUUID (req, res, next) {
   const UUID = req.params.uuid
   const orgRepo = req.ctx.repositories.getBaseOrgRepository()
   const body = req.body
-  const session = await mongoose.startSession({ causalConsistency: false })
   let updatedReviewObj
 
   const result = orgRepo.validateOrg(body)
   if (!result.isValid) {
     return res.status(400).json({ message: 'Invalid new_review_data', errors: result.errors })
   }
+
+  const session = await mongoose.startSession({ causalConsistency: false })
 
   try {
     session.startTransaction()
@@ -179,16 +180,17 @@ async function createReviewObject (req, res, next) {
   const baseOrgRepo = req.ctx.repositories.getBaseOrgRepository()
   const repo = req.ctx.repositories.getReviewObjectRepository()
   const body = req.body
-  const session = await mongoose.startSession({ causalConsistency: false })
   let createdReviewObj
+
+  const bodyValidation = (body && Object.keys(body).length) ? baseOrgRepo.validateOrg(body) : { isValid: false }
+  if (!bodyValidation.isValid) {
+    return res.status(400).json({ message: 'Invalid body parameters', errors: bodyValidation.errors })
+  }
+
+  const session = await mongoose.startSession({ causalConsistency: false })
 
   try {
     session.startTransaction()
-    const bodyValidation = (body && Object.keys(body).length) ? baseOrgRepo.validateOrg(body, { session }) : { isValid: false }
-    if (!bodyValidation.isValid) {
-      await session.abortTransaction()
-      return res.status(400).json({ message: 'Invalid body parameters', errors: bodyValidation.errors })
-    }
     createdReviewObj = await repo.createReviewOrgObject(body, req.ctx.user, { session })
     await session.commitTransaction()
   } catch (createErr) {
@@ -246,13 +248,12 @@ async function rejectReviewObject (req, res, next) {
   const UUID = req.params.uuid
   const session = await mongoose.startSession({ causalConsistency: false })
 
-  const isSecretariat = await authContext.isRequesterSecretariat(req, baseOrgRepo, { session })
-
   const isPendingReview = true
   let value
 
   try {
     session.startTransaction()
+    const isSecretariat = await authContext.isRequesterSecretariat(req, baseOrgRepo, { session })
 
     const reviewObject = await reviewRepo.findOneByUUIDWithConversation(UUID, isSecretariat, isPendingReview, { session })
     if (!reviewObject) {

--- a/test/unit-tests/controllerSessionCleanupTest.js
+++ b/test/unit-tests/controllerSessionCleanupTest.js
@@ -1,0 +1,211 @@
+/* global describe, afterEach, it */
+
+const { expect } = require('chai')
+const sinon = require('sinon')
+const mongoose = require('mongoose')
+
+const auditController = require('../../src/controller/audit.controller/audit.controller')
+const registryUserController = require('../../src/controller/registry-user.controller/registry-user.controller')
+const reviewObjectController = require('../../src/controller/review-object.controller/review-object.controller')
+const orgController = require('../../src/controller/org.controller/org.controller')
+const registryOrgController = require('../../src/controller/registry-org.controller/registry-org.controller')
+const conversationController = require('../../src/controller/conversation.controller/conversation.controller')
+const authContext = require('../../src/utils/authContext')
+
+function mockResponse () {
+  const res = {}
+  res.status = sinon.stub().returns(res)
+  res.json = sinon.stub().returns(res)
+  return res
+}
+
+function mockSession () {
+  return {
+    id: { id: 'session-id' },
+    startTransaction: sinon.stub(),
+    abortTransaction: sinon.stub().resolves(),
+    commitTransaction: sinon.stub().resolves(),
+    endSession: sinon.stub().resolves(),
+    inTransaction: sinon.stub().returns(true)
+  }
+}
+
+describe('Controller Mongoose session cleanup', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('does not create an audit session when create validation fails', async () => {
+    sinon.stub(mongoose, 'startSession').resolves(mockSession())
+    const res = mockResponse()
+    const req = {
+      ctx: {
+        uuid: 'request-uuid',
+        body: { target_uuid: 'not-a-uuid' }
+      }
+    }
+
+    await auditController.AUDIT_CREATE_SINGLE(req, res, sinon.stub())
+
+    expect(res.status.calledOnceWith(400)).to.equal(true)
+    expect(mongoose.startSession.notCalled).to.equal(true)
+  })
+
+  it('does not create a registry-user session when the target org is missing', async () => {
+    sinon.stub(mongoose, 'startSession').resolves(mockSession())
+    const res = mockResponse()
+    const req = {
+      ctx: {
+        uuid: 'request-uuid',
+        body: { username: 'created_user@example.org' },
+        params: { shortname: 'missing_org' },
+        repositories: {
+          getBaseOrgRepository: () => ({ getOrgUUID: sinon.stub().resolves(null) }),
+          getBaseUserRepository: () => ({})
+        }
+      }
+    }
+
+    await registryUserController.CREATE_USER(req, res, sinon.stub())
+
+    expect(res.status.calledOnceWith(404)).to.equal(true)
+    expect(mongoose.startSession.notCalled).to.equal(true)
+  })
+
+  it('aborts and ends a registry-user create transaction when role validation fails', async () => {
+    const session = mockSession()
+    sinon.stub(mongoose, 'startSession').resolves(session)
+    const res = mockResponse()
+    const req = {
+      ctx: {
+        uuid: 'request-uuid',
+        body: { username: 'created_user@example.org', role: 42 },
+        params: { shortname: 'range_4' },
+        repositories: {
+          getBaseOrgRepository: () => ({ getOrgUUID: sinon.stub().resolves('org-uuid') }),
+          getBaseUserRepository: () => ({ validateUser: sinon.stub().resolves({ isValid: true }) })
+        }
+      }
+    }
+
+    await registryUserController.CREATE_USER(req, res, sinon.stub())
+
+    expect(res.status.calledOnceWith(400)).to.equal(true)
+    expect(session.abortTransaction.calledOnce).to.equal(true)
+    expect(session.endSession.calledOnce).to.equal(true)
+  })
+
+  it('does not create a review-object session when update validation fails', async () => {
+    sinon.stub(mongoose, 'startSession').resolves(mockSession())
+    const res = mockResponse()
+    const req = {
+      params: { uuid: 'review-uuid' },
+      body: { short_name: 'bad' },
+      ctx: {
+        repositories: {
+          getReviewObjectRepository: () => ({}),
+          getBaseOrgRepository: () => ({
+            validateOrg: sinon.stub().returns({ isValid: false, errors: [{ message: 'invalid' }] })
+          })
+        }
+      }
+    }
+
+    await reviewObjectController.updateReviewObjectByReviewUUID(req, res, sinon.stub())
+
+    expect(res.status.calledOnceWith(400)).to.equal(true)
+    expect(mongoose.startSession.notCalled).to.equal(true)
+  })
+
+  it('aborts and ends an org update transaction when the target org is missing', async () => {
+    const session = mockSession()
+    sinon.stub(mongoose, 'startSession').resolves(session)
+    const res = mockResponse()
+    const req = {
+      ctx: {
+        uuid: 'request-uuid',
+        params: { shortname: 'missing_org' },
+        query: {},
+        repositories: {
+          getBaseOrgRepository: () => ({ orgExists: sinon.stub().resolves(false) }),
+          getBaseUserRepository: () => ({})
+        }
+      }
+    }
+
+    await orgController.ORG_UPDATE_SINGLE(req, res, sinon.stub())
+
+    expect(res.status.calledOnceWith(404)).to.equal(true)
+    expect(session.abortTransaction.calledOnce).to.equal(true)
+    expect(session.endSession.calledOnce).to.equal(true)
+  })
+
+  it('does not create a registry-org user session when the target org is missing', async () => {
+    sinon.stub(mongoose, 'startSession').resolves(mockSession())
+    const res = mockResponse()
+    const req = {
+      ctx: {
+        uuid: 'request-uuid',
+        body: { username: 'created_user@example.org' },
+        params: { shortname: 'missing_org' },
+        repositories: {
+          getBaseOrgRepository: () => ({ getOrgUUID: sinon.stub().resolves(null) }),
+          getBaseUserRepository: () => ({})
+        }
+      }
+    }
+
+    await registryOrgController.USER_CREATE_SINGLE(req, res, sinon.stub())
+
+    expect(res.status.calledOnceWith(404)).to.equal(true)
+    expect(mongoose.startSession.notCalled).to.equal(true)
+  })
+
+  it('aborts and ends a registry-org user create transaction when role validation fails', async () => {
+    const session = mockSession()
+    sinon.stub(mongoose, 'startSession').resolves(session)
+    const res = mockResponse()
+    const req = {
+      ctx: {
+        uuid: 'request-uuid',
+        body: { username: 'created_user@example.org', role: 42 },
+        params: { shortname: 'range_4' },
+        repositories: {
+          getBaseOrgRepository: () => ({ getOrgUUID: sinon.stub().resolves('org-uuid') }),
+          getBaseUserRepository: () => ({ validateUser: sinon.stub().resolves({ isValid: true }) })
+        }
+      }
+    }
+
+    await registryOrgController.USER_CREATE_SINGLE(req, res, sinon.stub())
+
+    expect(res.status.calledOnceWith(400)).to.equal(true)
+    expect(session.abortTransaction.calledOnce).to.equal(true)
+    expect(session.endSession.calledOnce).to.equal(true)
+  })
+
+  it('aborts and ends a conversation create transaction when body validation fails', async () => {
+    const session = mockSession()
+    sinon.stub(mongoose, 'startSession').resolves(session)
+    sinon.stub(authContext, 'getRequesterUser').resolves({ UUID: 'user-uuid' })
+    const res = mockResponse()
+    const req = {
+      params: { uuid: 'target-uuid' },
+      body: {},
+      ctx: {
+        uuid: 'request-uuid',
+        repositories: {
+          getConversationRepository: () => ({ validateConversation: sinon.stub().returns(false) }),
+          getBaseUserRepository: () => ({}),
+          getBaseOrgRepository: () => ({})
+        }
+      }
+    }
+
+    await conversationController.createConversationForTargetUUID(req, res, sinon.stub())
+
+    expect(res.status.calledOnceWith(400)).to.equal(true)
+    expect(session.abortTransaction.calledOnce).to.equal(true)
+    expect(session.endSession.calledOnce).to.equal(true)
+  })
+})


### PR DESCRIPTION
Closes #1883 

# Summary
Fixes controller paths that created Mongoose sessions before validation or returned from active transactions without aborting. Adds regression coverage for invalid and unauthorized-style early-return paths.

# Important Changes
`src/controller/audit.controller/audit.controller.js`
- Moved request validation before session creation for audit create, append, document lookup, org lookup, and last-change lookup paths.

`src/controller/registry-user.controller/registry-user.controller.js`
- Deferred session creation until after preflight validation and authorization checks.
- Added missing transaction abort before role-validation early returns.

`src/controller/review-object.controller/review-object.controller.js`
- Moved org body validation before session creation where possible.
- Kept reject authorization inside the managed transaction/session lifetime.

`src/controller/org.controller/org.controller.js`
- Added missing transaction aborts before early returns in update/create-user paths.
- Avoids unnecessary session creation for create preflight validation.

`src/controller/registry-org.controller/registry-org.controller.js`
- Avoids unnecessary session creation in create org/user preflight failures.
- Added missing transaction abort for role validation failure.

`src/controller/conversation.controller/conversation.controller.js`
- Added missing transaction aborts before validation and authorization early returns.

`test/unit-tests/controllerSessionCleanupTest.js`
- Added focused session cleanup regression tests for audit, registry-user, review-object, org, registry-org, and conversation controllers.
