### PR TITLE
Resolves #1884: fixes oversized JSON request handling so 413 responses do not throw

### DIFF
--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -392,7 +392,7 @@ function validateJsonSyntax (err, req, res, next) {
     if (err.message.includes('request entity too large')) {
       console.warn('Request failed validation because entity too large')
       console.info((JSON.stringify(err)))
-      return res.status(413).json(error.recordTooLarge(errors))
+      return res.status(413).json(error.recordTooLarge())
     } else if (err.status === 400) {
       console.warn('Request failed validation because JSON syntax is incorrect')
       console.info((JSON.stringify(err)))

--- a/test/integration-tests/middleware/jsonSyntaxTest.js
+++ b/test/integration-tests/middleware/jsonSyntaxTest.js
@@ -1,0 +1,48 @@
+const express = require('express')
+const chai = require('chai')
+const expect = chai.expect
+chai.use(require('chai-http'))
+
+const middleware = require('../../../src/middleware/middleware')
+
+function createJsonSyntaxTestApp () {
+  const app = express()
+
+  app.use(express.json({ limit: '1kb', inflate: false }))
+  app.post('/json', (req, res) => {
+    return res.status(200).json({ message: 'Success' })
+  })
+  app.use(middleware.validateJsonSyntax)
+
+  return app
+}
+
+describe('JSON syntax middleware integration', () => {
+  it('returns 413 for oversized JSON requests', async () => {
+    const app = createJsonSyntaxTestApp()
+    const payload = { value: 'x'.repeat(2048) }
+
+    const res = await chai.request(app)
+      .post('/json')
+      .set('content-type', 'application/json')
+      .send(payload)
+
+    expect(res).to.have.status(413)
+    expect(res.body).to.deep.equal({
+      error: 'RECORD_TOO_LARGE',
+      message: 'Records must be less than 3.8MB.'
+    })
+  })
+
+  it('keeps malformed JSON requests on the invalid syntax response path', async () => {
+    const app = createJsonSyntaxTestApp()
+
+    const res = await chai.request(app)
+      .post('/json')
+      .set('content-type', 'application/json')
+      .send('{"value":')
+
+    expect(res).to.have.status(400)
+    expect(res.body.error).to.equal('INVALID_JSON_SYNTAX')
+  })
+})


### PR DESCRIPTION
Closes #1884 

# Summary
Fixes the oversized JSON error handler by removing an undefined variable reference and adds regression coverage for over-limit JSON requests.

# Important Changes
`src/middleware/middleware.js`
- Updated the 413 handler to call `error.recordTooLarge()` without arguments.

`test/integration-tests/middleware/jsonSyntaxTest.js`
- Added an oversized JSON request regression test.
- Added a malformed JSON assertion to confirm existing 400 behavior remains unchanged.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run `bash -i -c "npm run test:integration"`.
- [ ] 2) Confirm oversized JSON requests return `413` with `RECORD_TOO_LARGE`.
- [ ] 3) Confirm malformed JSON requests still return `400` with `INVALID_JSON_SYNTAX`.