### PR TITLE
Dr conversation route validation fixes

### DIFF
--- a/src/controller/conversation.controller/conversation.controller.js
+++ b/src/controller/conversation.controller/conversation.controller.js
@@ -17,6 +17,7 @@ async function getAllConversations (req, res, next) {
 
   const options = CONSTANTS.PAGINATOR_OPTIONS
   options.sort = { posted_at: 'desc' }
+  options.page = req.ctx.query.page ? parseInt(req.ctx.query.page) : CONSTANTS.PAGINATOR_PAGE
 
   const response = await repo.getAll(options)
   return res.status(200).json(response)

--- a/src/controller/conversation.controller/conversation.middleware.js
+++ b/src/controller/conversation.controller/conversation.middleware.js
@@ -1,0 +1,37 @@
+const { validationResult } = require('express-validator')
+const utils = require('../../utils/utils')
+const errors = require('./error')
+const error = new errors.ConversationControllerError()
+
+function parseGetParams (req, res, next) {
+  utils.reqCtxMapping(req, 'query', ['page'])
+  next()
+}
+
+function parseTargetParams (req, res, next) {
+  utils.reqCtxMapping(req, 'params', ['uuid'])
+  utils.reqCtxMapping(req, 'query', ['page'])
+  next()
+}
+
+function parseUuidParams (req, res, next) {
+  utils.reqCtxMapping(req, 'params', ['uuid'])
+  next()
+}
+
+function parseError (req, res, next) {
+  const err = validationResult(req).formatWith(({ location, msg, param, value, nestedErrors }) => {
+    return { msg: msg, param: param, location: location }
+  })
+  if (!err.isEmpty()) {
+    return res.status(400).json(error.badInput(err.array()))
+  }
+  next()
+}
+
+module.exports = {
+  parseGetParams,
+  parseTargetParams,
+  parseUuidParams,
+  parseError
+}

--- a/src/controller/conversation.controller/index.js
+++ b/src/controller/conversation.controller/index.js
@@ -1,6 +1,7 @@
 const router = require('express').Router()
 const { param, query } = require('express-validator')
 const controller = require('./conversation.controller')
+const { parseGetParams, parseTargetParams, parseUuidParams, parseError } = require('./conversation.middleware')
 const mw = require('../../middleware/middleware')
 const getConstants = require('../../../src/constants').getConstants
 const CONSTANTS = getConstants()
@@ -100,6 +101,8 @@ router.get('/conversation',
   query().custom((query) => { return mw.validateQueryParameterNames(query, ['page']) }),
   query(['page']).custom((val) => { return mw.containsNoInvalidCharacters(val) }),
   query(['page']).optional().isInt({ min: CONSTANTS.PAGINATOR_PAGE }),
+  parseError,
+  parseGetParams,
   controller.getAllConversations
 )
 
@@ -199,6 +202,8 @@ router.get('/conversation/target/:uuid',
   query().custom((query) => { return mw.validateQueryParameterNames(query, ['page']) }),
   query(['page']).custom((val) => { return mw.containsNoInvalidCharacters(val) }),
   query(['page']).optional().isInt({ min: CONSTANTS.PAGINATOR_PAGE }),
+  parseError,
+  parseTargetParams,
   controller.getConversationsForTargetUUID
 )
 
@@ -301,6 +306,8 @@ router.post('/conversation/target/:uuid',
   mw.validateUser,
   mw.onlySecretariatOrAdmin,
   param(['uuid']).isUUID(4),
+  parseError,
+  parseUuidParams,
   controller.createConversationForTargetUUID
 )
 
@@ -410,6 +417,8 @@ router.put('/conversation/:uuid',
   mw.validateUser,
   mw.onlySecretariat,
   param(['uuid']).isUUID(4),
+  parseError,
+  parseUuidParams,
   controller.updateConversationByUUID
 )
 

--- a/test/integration-tests/conversation/conversationTest.js
+++ b/test/integration-tests/conversation/conversationTest.js
@@ -3,9 +3,11 @@
 const chai = require('chai')
 const expect = chai.expect
 chai.use(require('chai-http'))
+const { v4: uuidv4 } = require('uuid')
 
 const constants = require('../constants.js')
 const app = require('../../../src/index.js')
+const ConversationModel = require('../../../src/model/conversation')
 
 const namedSecretariatHeaders = {
   ...constants.headers,
@@ -140,6 +142,42 @@ describe('Testing Conversation endpoints', () => {
           })
         })
     })
+    it('Should respect the requested page when getting all conversations', async () => {
+      const paginationTargetUUID = uuidv4()
+      const conversationCount = 501
+      const conversations = Array.from({ length: conversationCount }, (_, index) => ({
+        UUID: uuidv4(),
+        target_uuid: paginationTargetUUID,
+        previous_conversation_uuid: index === 0 ? null : `pagination-conversation-${index - 1}`,
+        next_conversation_uuid: index === conversationCount - 1 ? null : `pagination-conversation-${index + 1}`,
+        author_id: secUserUUID,
+        author_name: 'Secretariat',
+        author_role: 'Secretariat',
+        visibility: 'public',
+        body: `pagination conversation ${index}`,
+        posted_at: new Date(Date.UTC(2026, 0, 1, 0, 0, index))
+      }))
+
+      try {
+        await ConversationModel.insertMany(conversations)
+
+        await chai.request(app)
+          .get('/api/conversation?page=2')
+          .set(constants.headers)
+          .then((res, err) => {
+            expect(err).to.be.undefined
+            expect(res).to.have.status(200)
+
+            expect(res.body).to.haveOwnProperty('conversations')
+            expect(res.body.conversations).to.be.an('array').that.is.not.empty
+            expect(res.body).to.have.property('itemsPerPage', 500)
+            expect(res.body).to.have.property('currentPage', 2)
+            expect(res.body).to.have.property('prevPage', 1)
+          })
+      } finally {
+        await ConversationModel.deleteMany({ target_uuid: paginationTargetUUID })
+      }
+    })
     it('Should get and see all conversations for target UUID as Secretariat', async () => {
       await chai.request(app)
         .get(`/api/conversation/target/${orgUUID}`)
@@ -208,12 +246,72 @@ describe('Testing Conversation endpoints', () => {
   })
 
   context('Negative Tests', () => {
+    it('Should fail to get all conversations with an invalid page query parameter', async () => {
+      await chai.request(app)
+        .get('/api/conversation?page=not-a-number')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body).to.have.property('error', 'BAD_INPUT')
+          expect(res.body).to.have.property('message', 'Parameters were invalid')
+          expect(res.body.details).to.be.an('array').that.is.not.empty
+          expect(res.body.details[0]).to.include({ param: 'page', location: 'query' })
+        })
+    })
+    it('Should fail to get all conversations with an unknown query parameter', async () => {
+      await chai.request(app)
+        .get('/api/conversation?unexpected=true')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body).to.have.property('error', 'BAD_INPUT')
+          expect(res.body).to.have.property('message', 'Parameters were invalid')
+          expect(res.body.details).to.be.an('array').that.is.not.empty
+          expect(res.body.details[0]).to.include({ msg: "'unexpected' is not a valid parameter name.", location: 'query' })
+        })
+    })
+    it('Should fail to post a conversation with an invalid target UUID', async () => {
+      await chai.request(app)
+        .post('/api/conversation/target/not-a-uuid')
+        .set(constants.headers)
+        .send({
+          visibility: 'public',
+          body: 'test'
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body).to.have.property('error', 'BAD_INPUT')
+          expect(res.body).to.have.property('message', 'Parameters were invalid')
+          expect(res.body.details).to.be.an('array').that.is.not.empty
+          expect(res.body.details[0]).to.include({ param: 'uuid', location: 'params' })
+        })
+    })
+    it('Should fail to update a conversation with an invalid UUID', async () => {
+      await chai.request(app)
+        .put('/api/conversation/not-a-uuid')
+        .set(constants.headers)
+        .send({
+          body: 'test updated',
+          visibility: 'private'
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body).to.have.property('error', 'BAD_INPUT')
+          expect(res.body).to.have.property('message', 'Parameters were invalid')
+          expect(res.body.details).to.be.an('array').that.is.not.empty
+          expect(res.body.details[0]).to.include({ param: 'uuid', location: 'params' })
+        })
+    })
     it('Should fail to post a conversation to a different org as a non-Secretariat Admin', async () => {
       const conversation = {
         visibility: 'public',
         body: 'test'
       }
-      const randomUUID = '123e4567-e89b-12d3-a456-426614174000'
+      const randomUUID = uuidv4()
       await chai.request(app)
         .post(`/api/conversation/target/${randomUUID}`)
         .set(constants.nonSecretariatUserHeaders2) // Admin of win_5
@@ -255,8 +353,10 @@ describe('Testing Conversation endpoints', () => {
         })
     })
     it('Should fail to update a conversation that does not exist', async () => {
+      const nonExistentConversationUUID = uuidv4()
+
       await chai.request(app)
-        .put('/api/conversation/non-existent-uuid')
+        .put(`/api/conversation/${nonExistentConversationUUID}`)
         .set(constants.headers)
         .send({
           body: 'test updated',
@@ -267,7 +367,7 @@ describe('Testing Conversation endpoints', () => {
           expect(res).to.have.status(404)
 
           expect(res.body).to.haveOwnProperty('message')
-          expect(res.body.message).to.equal('The conversation with UUID non-existent-uuid does not exist.')
+          expect(res.body.message).to.equal(`The conversation with UUID ${nonExistentConversationUUID} does not exist.`)
         })
     })
     it('Should fail to update a conversation with invalid body', async () => {


### PR DESCRIPTION
# Summary
This MR enables express-validator error handling for conversation routes and applies the requested `page` query parameter when listing conversations.

# Important Changes
`src/controller/conversation.controller/conversation.middleware.js`
- Added conversation-specific validation error handling.
- Added request-context parsing helpers for query and UUID params.

`src/controller/conversation.controller/index.js`
- Wired `parseError` into conversation routes after validators.
- Mapped validated query/path params before controller execution.

`src/controller/conversation.controller/conversation.controller.js`
- Applies `req.ctx.query.page` to paginator options.

`test/integration-tests/conversation/conversationTest.js`
- Added tests for invalid page query, unknown query params, invalid UUID params, and page-2 pagination.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run `bash -i -c "npm run test:integration"`.
- [ ] 2) Confirm `/api/conversation?page=2` returns `currentPage: 2`.
- [ ] 3) Confirm invalid conversation query/path params return `400 BAD_INPUT`.