### PR TITLE
Resolves issue #1881, future-proofs registry-only user org reassignment.

### DIFF
--- a/src/repositories/baseUserRepository.js
+++ b/src/repositories/baseUserRepository.js
@@ -676,8 +676,11 @@ class BaseUserRepository extends BaseRepository {
         const baseOrgRepository = new BaseOrgRepository()
         const { createAuditLogEntry } = require('./baseOrgRepositoryHelpers')
 
-        // Grab current org UUID using whichever document is real
-        const currentOrgUUID = legacyUser ? legacyUser.org_UUID : registryUser?.org_UUID // Fallback if schema supports it
+        // Prefer the legacy association while dual-write is active, then fall back to registry org membership.
+        let currentOrgUUID = legacyUser?.org_UUID || registryUser?.org_UUID
+        if (!currentOrgUUID) {
+          currentOrgUUID = await baseOrgRepository.getOrgUUIDByUserUUID(identifier, options)
+        }
         const currentOrg = currentOrgUUID ? await baseOrgRepository.findOneByUUID(currentOrgUUID) : null
         const newOrg = await baseOrgRepository.findOneByShortName(incomingUser.org_short_name)
         const wasAdmin = currentOrg?.admins?.includes(identifier) ?? false

--- a/test/integration-tests/user/updateUserTest.js
+++ b/test/integration-tests/user/updateUserTest.js
@@ -4,9 +4,70 @@ const chai = require('chai')
 chai.use(require('chai-http'))
 
 const expect = chai.expect
+const { v4: uuidv4 } = require('uuid')
 
 const constants = require('../constants.js')
 const app = require('../../../src/index.js')
+const BaseOrgModel = require('../../../src/model/baseorg')
+const UserModel = require('../../../src/model/user')
+
+const makeShortName = (prefix) => `${prefix}_${uuidv4().replace(/-/g, '').slice(0, 16)}`
+
+const postRegistryOrg = async (shortName) => {
+  await chai.request(app)
+    .post('/api/registry/org')
+    .set(constants.headers)
+    .send({
+      short_name: shortName,
+      long_name: `${shortName} Organization`,
+      authority: ['CNA'],
+      id_quota: 1000
+    })
+    .then(res => {
+      expect(res.status).to.equal(200, JSON.stringify(res.body))
+    })
+}
+
+const postRegistryUser = async (orgShortName, username, role) => {
+  const body = {
+    username,
+    name: {
+      first: 'Registry',
+      last: 'Only'
+    },
+    status: 'active'
+  }
+
+  if (role) {
+    body.role = role
+  }
+
+  await chai.request(app)
+    .post(`/api/registry/org/${orgShortName}/user`)
+    .set(constants.headers)
+    .send(body)
+    .then(res => {
+      expect(res.status).to.equal(200, JSON.stringify(res.body))
+    })
+}
+
+const getRegistryUser = async (orgShortName, username) => {
+  let user
+  await chai.request(app)
+    .get(`/api/registry/org/${orgShortName}/user/${username}`)
+    .set(constants.headers)
+    .then(res => {
+      expect(res.status).to.equal(200, JSON.stringify(res.body))
+      user = res.body
+    })
+
+  delete user.created
+  delete user.created_by
+  delete user.last_updated
+  return user
+}
+
+const countOccurrences = (values = [], value) => values.filter(item => item === value).length
 
 describe('Testing Edit user endpoint', () => {
   context('Positive Tests', () => {
@@ -58,7 +119,6 @@ describe('Testing Edit user endpoint', () => {
           expect(res.status).to.equal(200, JSON.stringify(res.body))
         })
       // Verify user is in orgA's admins array
-      const BaseOrgModel = require('../../../src/model/baseorg')
       const orgARecordBefore = await BaseOrgModel.findOne({ short_name: orgA })
       expect(orgARecordBefore.admins).to.be.an('array')
       // We need the user's UUID
@@ -90,6 +150,79 @@ describe('Testing Edit user endpoint', () => {
       // Verify user is in orgB's admins array
       const orgBRecordAfter = await BaseOrgModel.findOne({ short_name: orgB })
       expect(orgBRecordAfter.admins).to.include(userUUID)
+    })
+
+    it('Should reassign a registry-only user without leaving old organization membership', async () => {
+      const orgA = makeShortName('regonlya')
+      const orgB = makeShortName('regonlyb')
+      const username = `registryonly_${uuidv4().replace(/-/g, '').slice(0, 16)}@example.com`
+
+      await postRegistryOrg(orgA)
+      await postRegistryOrg(orgB)
+      await postRegistryUser(orgA, username)
+
+      const userResponse = await getRegistryUser(orgA, username)
+      const userUUID = userResponse.UUID
+      const orgARecordBefore = await BaseOrgModel.findOne({ short_name: orgA })
+      expect(orgARecordBefore.users).to.include(userUUID)
+
+      const deleteResult = await UserModel.deleteOne({ UUID: userUUID })
+      expect(deleteResult.deletedCount).to.equal(1)
+
+      await chai.request(app)
+        .put(`/api/registry/org/${orgA}/user/${username}`)
+        .set(constants.headers)
+        .send({
+          ...userResponse,
+          org_short_name: orgB
+        })
+        .then((res) => {
+          expect(res.status).to.equal(200, JSON.stringify(res.body))
+        })
+
+      const orgARecordAfter = await BaseOrgModel.findOne({ short_name: orgA })
+      const orgBRecordAfter = await BaseOrgModel.findOne({ short_name: orgB })
+      expect(orgARecordAfter.users).to.not.include(userUUID)
+      expect(orgARecordAfter.admins || []).to.not.include(userUUID)
+      expect(countOccurrences(orgBRecordAfter.users, userUUID)).to.equal(1)
+      expect(orgBRecordAfter.admins || []).to.not.include(userUUID)
+    })
+
+    it('Should reassign a registry-only admin without leaving old organization admin membership', async () => {
+      const orgA = makeShortName('regadmina')
+      const orgB = makeShortName('regadminb')
+      const username = `registryadmin_${uuidv4().replace(/-/g, '').slice(0, 16)}@example.com`
+
+      await postRegistryOrg(orgA)
+      await postRegistryOrg(orgB)
+      await postRegistryUser(orgA, username, 'ADMIN')
+
+      const userResponse = await getRegistryUser(orgA, username)
+      const userUUID = userResponse.UUID
+      const orgARecordBefore = await BaseOrgModel.findOne({ short_name: orgA })
+      expect(orgARecordBefore.users).to.include(userUUID)
+      expect(orgARecordBefore.admins).to.include(userUUID)
+
+      const deleteResult = await UserModel.deleteOne({ UUID: userUUID })
+      expect(deleteResult.deletedCount).to.equal(1)
+
+      await chai.request(app)
+        .put(`/api/registry/org/${orgA}/user/${username}`)
+        .set(constants.headers)
+        .send({
+          ...userResponse,
+          org_short_name: orgB
+        })
+        .then((res) => {
+          expect(res.status).to.equal(200, JSON.stringify(res.body))
+        })
+
+      const orgARecordAfter = await BaseOrgModel.findOne({ short_name: orgA })
+      const orgBRecordAfter = await BaseOrgModel.findOne({ short_name: orgB })
+      expect(orgARecordAfter.users).to.not.include(userUUID)
+      expect(orgARecordAfter.admins).to.not.include(userUUID)
+      expect(countOccurrences(orgBRecordAfter.users, userUUID)).to.equal(1)
+      expect(countOccurrences(orgBRecordAfter.admins, userUUID)).to.equal(1)
     })
 
     it('Should return 200 when only name changes are done', async () => {


### PR DESCRIPTION
Closes Issue #1881 

# Summary
This PR adds defensive handling for a future registry-only user state during organization reassignment.

This was **not a bug in current production behavior**, because users are currently dual-written to both legacy `User` and registry `BaseUser`, and legacy `User.org_UUID` is available for reassignment cleanup.

# Important Changes

`src/repositories/baseUserRepository.js`
- Preserves existing legacy-backed lookup behavior.
- Adds fallback lookup from registry organization membership when no legacy org association exists.

`test/integration-tests/user/updateUserTest.js`
- Adds integration coverage for simulated registry-only reassignment.
- Covers both regular user membership and admin membership cleanup.
- Verifies users/admins are removed from the old org and added to the new org exactly once.

# Notes
- Current code is not affected by the reported issue because users are still created in both legacy and registry stores.
- This change is fallback-only and intended to reduce risk ahead of legacy removal.