### PR TITLE
Resolves issue #1874, Preserve both CNA modified-date bounds in CVE query filters.

### DIFF
--- a/src/controller/cve.controller/cve.controller.js
+++ b/src/controller/cve.controller/cve.controller.js
@@ -119,12 +119,15 @@ async function getFilteredCves (req, res, next) {
     const query = {}
 
     if (timeModified.timeStamp.length > 0) {
-      if (!cnaModified) { query['time.modified'] = {} }
+      if (cnaModified) {
+        query['cve.containers.cna.providerMetadata.dateUpdated'] = {}
+      } else {
+        query['time.modified'] = {}
+      }
 
       for (let i = 0; i < timeModified.timeStamp.length; i++) {
         if (timeModified.dateOperator[i] === 'lt') {
           if (cnaModified) {
-            query['cve.containers.cna.providerMetadata.dateUpdated'] = {}
             // Due to this not being the mongo created date object, we need to actually check the "ISO String" version of this _NOT_ the date object that is being created in the middleware
             query['cve.containers.cna.providerMetadata.dateUpdated'].$lt = timeModifiedLtDateObject.toISOString()
           } else {
@@ -132,7 +135,6 @@ async function getFilteredCves (req, res, next) {
           }
         } else {
           if (cnaModified) {
-            query['cve.containers.cna.providerMetadata.dateUpdated'] = {}
             // Due to this not being the mongo created date object, we need to actually check the "ISO String" version of this _NOT_ the date object that is being created in the middleware
             query['cve.containers.cna.providerMetadata.dateUpdated'].$gt = timeModifiedGtDateObject.toISOString()
           } else {
@@ -294,12 +296,15 @@ async function getFilteredCvesCursor (req, res, next) {
     const query = {}
 
     if (timeModified.timeStamp.length > 0) {
-      if (!cnaModified) { query['time.modified'] = {} }
+      if (cnaModified) {
+        query['cve.containers.cna.providerMetadata.dateUpdated'] = {}
+      } else {
+        query['time.modified'] = {}
+      }
 
       for (let i = 0; i < timeModified.timeStamp.length; i++) {
         if (timeModified.dateOperator[i] === 'lt') {
           if (cnaModified) {
-            query['cve.containers.cna.providerMetadata.dateUpdated'] = {}
             // Due to this not being the mongo created date object, we need to actually check the "ISO String" version of this _NOT_ the date object that is being created in the middleware
             query['cve.containers.cna.providerMetadata.dateUpdated'].$lt = timeModifiedLtDateObject.toISOString()
           } else {
@@ -307,7 +312,6 @@ async function getFilteredCvesCursor (req, res, next) {
           }
         } else {
           if (cnaModified) {
-            query['cve.containers.cna.providerMetadata.dateUpdated'] = {}
             // Due to this not being the mongo created date object, we need to actually check the "ISO String" version of this _NOT_ the date object that is being created in the middleware
             query['cve.containers.cna.providerMetadata.dateUpdated'].$gt = timeModifiedGtDateObject.toISOString()
           } else {

--- a/test/integration-tests/cve/getCveCnaModifiedTest.js
+++ b/test/integration-tests/cve/getCveCnaModifiedTest.js
@@ -11,11 +11,66 @@ const _ = require('lodash')
 
 const shortName = 'win_5'
 
+function wait (milliseconds) {
+  return new Promise(resolve => setTimeout(resolve, milliseconds))
+}
+
+function addMilliseconds (dateString, milliseconds) {
+  return new Date(Date.parse(dateString) + milliseconds).toISOString()
+}
+
+async function createCveAndGetCnaUpdatedDate (cveId) {
+  return await chai.request(app)
+    .post(`/api/cve/${cveId}/cna`)
+    .set(constants.nonSecretariatUserHeaders)
+    .send(constants.testCve)
+    .then((res, err) => {
+      expect(err).to.be.undefined
+      expect(res).to.have.status(200)
+      return res.body.created.containers.cna.providerMetadata.dateUpdated
+    })
+}
+
 describe('Test cna_modified parameter for get CVE', () => {
   let cveId
+  let beforeWindowCveId
+  let insideWindowCveId
+  let afterWindowCveId
+  let cnaModifiedLowerBound
+  let cnaModifiedUpperBound
+
+  function cnaModifiedWindowQuery () {
+    return `time_modified.gt=${encodeURIComponent(cnaModifiedLowerBound)}&time_modified.lt=${encodeURIComponent(cnaModifiedUpperBound)}&cna_modified=true`
+  }
+
+  function expectOnlyCvesInsideCnaModifiedWindow (records) {
+    expect(_.some(records, { cveMetadata: { cveId: insideWindowCveId } })).to.be.true
+    expect(_.some(records, { cveMetadata: { cveId: beforeWindowCveId } })).to.be.false
+    expect(_.some(records, { cveMetadata: { cveId: afterWindowCveId } })).to.be.false
+
+    records.forEach(record => {
+      const cnaDateUpdated = Date.parse(record.containers.cna.providerMetadata.dateUpdated)
+      expect(cnaDateUpdated).to.be.greaterThan(Date.parse(cnaModifiedLowerBound))
+      expect(cnaDateUpdated).to.be.lessThan(Date.parse(cnaModifiedUpperBound))
+    })
+  }
+
   before(async () => {
     cveId = await helpers.cveIdReserveHelper(1, '2023', shortName, 'non-sequential')
     await helpers.cveRequestAsCnaHelper(cveId)
+
+    beforeWindowCveId = await helpers.cveIdReserveHelper(1, '2023', shortName, 'non-sequential')
+    const beforeWindowDate = await createCveAndGetCnaUpdatedDate(beforeWindowCveId)
+    cnaModifiedLowerBound = addMilliseconds(beforeWindowDate, 1)
+
+    await wait(20)
+    insideWindowCveId = await helpers.cveIdReserveHelper(1, '2023', shortName, 'non-sequential')
+    const insideWindowDate = await createCveAndGetCnaUpdatedDate(insideWindowCveId)
+    cnaModifiedUpperBound = addMilliseconds(insideWindowDate, 1)
+
+    await wait(20)
+    afterWindowCveId = await helpers.cveIdReserveHelper(1, '2023', shortName, 'non-sequential')
+    await createCveAndGetCnaUpdatedDate(afterWindowCveId)
   })
   context('Positive Test', () => {
     it('Get CVE with cna_modified set to true AND date.gt should return when searched with a known earlier than date', async () => {
@@ -57,6 +112,28 @@ describe('Test cna_modified parameter for get CVE', () => {
           expect(err).to.be.undefined
           expect(res).to.have.status(200)
           expect(_.some(res.body.cveRecords, { cveMetadata: { cveId: cveId } })).to.be.false
+        })
+    })
+
+    it('Get CVE with cna_modified set to true AND date.gt/date.lt should only return records inside the CNA modified date window', async () => {
+      await chai.request(app)
+        .get(`/api/cve/?${cnaModifiedWindowQuery()}`)
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expectOnlyCvesInsideCnaModifiedWindow(res.body.cveRecords)
+        })
+    })
+
+    it('Get cve_cursor with cna_modified set to true AND date.gt/date.lt should only return records inside the CNA modified date window', async () => {
+      await chai.request(app)
+        .get(`/api/cve_cursor?${cnaModifiedWindowQuery()}`)
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expectOnlyCvesInsideCnaModifiedWindow(res.body.cveRecords)
         })
     })
   })

--- a/test/unit-tests/cve/cveGetAllTest.js
+++ b/test/unit-tests/cve/cveGetAllTest.js
@@ -19,6 +19,110 @@ const cveParams = require('../../../src/controller/cve.controller/cve.middleware
 
 describe('Testing the GET /cve endpoint in Cve Controller', () => {
   context('Positive Tests', () => {
+    it('Builds a cna_modified query with both time_modified bounds', async () => {
+      const lowerBound = new Date('2026-01-01T00:00:00.000Z')
+      const upperBound = new Date('2026-02-01T00:00:00.000Z')
+      let builtQuery = null
+
+      class MyCvePositiveTests {
+        async aggregatePaginate (aggregation) {
+          builtQuery = aggregation[0].$match
+
+          return {
+            itemsList: [],
+            itemCount: 0,
+            itemsPerPage: 500,
+            currentPage: 1,
+            pageCount: 1,
+            prevPage: null,
+            nextPage: null
+          }
+        }
+      }
+
+      const req = {
+        ctx: {
+          uuid: 'unit-test',
+          query: {
+            'time_modified.gt': lowerBound,
+            'time_modified.lt': upperBound,
+            cna_modified: 'true'
+          },
+          repositories: {
+            getCveRepository: () => { return new MyCvePositiveTests() }
+          }
+        }
+      }
+
+      let statusCode = null
+      const res = {
+        status: (code) => {
+          statusCode = code
+          return res
+        },
+        json: () => {}
+      }
+
+      await cveController.CVE_GET_FILTERED(req, res, (err) => { throw err })
+
+      expect(statusCode).to.equal(200)
+      expect(builtQuery['cve.containers.cna.providerMetadata.dateUpdated']).to.deep.equal({
+        $gt: lowerBound.toISOString(),
+        $lt: upperBound.toISOString()
+      })
+    })
+
+    it('Builds a cna_modified cursor query with both time_modified bounds', async () => {
+      const lowerBound = new Date('2026-01-01T00:00:00.000Z')
+      const upperBound = new Date('2026-02-01T00:00:00.000Z')
+      let builtQuery = null
+
+      class MyCvePositiveTests {
+        async cursorPaginate (query) {
+          builtQuery = query
+
+          return {
+            results: [],
+            hasNext: false,
+            hasPrevious: false,
+            next: null,
+            previous: null
+          }
+        }
+      }
+
+      const req = {
+        ctx: {
+          uuid: 'unit-test',
+          query: {
+            'time_modified.gt': lowerBound,
+            'time_modified.lt': upperBound,
+            cna_modified: 'true'
+          },
+          repositories: {
+            getCveRepository: () => { return new MyCvePositiveTests() }
+          }
+        }
+      }
+
+      let statusCode = null
+      const res = {
+        status: (code) => {
+          statusCode = code
+          return res
+        },
+        json: () => {}
+      }
+
+      await cveController.CVE_GET_FILTERED_CURSOR(req, res, (err) => { throw err })
+
+      expect(statusCode).to.equal(200)
+      expect(builtQuery['cve.containers.cna.providerMetadata.dateUpdated']).to.deep.equal({
+        $gt: lowerBound.toISOString(),
+        $lt: upperBound.toISOString()
+      })
+    })
+
     it('JSON schema v5.0 returned: The secretariat gets a list of non-paginated cve records', (done) => {
       const itemsPerPage = 500
 


### PR DESCRIPTION
Closes Issue #1874 and #1328

# Summary
Fixes `cna_modified=true` filtering so `time_modified.gt` and `time_modified.lt` are both preserved in the Mongo query for `/api/cve` and `/api/cve_cursor`.

# Important Changes
`src/controller/cve.controller/cve.controller.js`
- Initializes the CNA provider metadata date query object once per request.
- Adds `$gt` and `$lt` to the same query object instead of overwriting one bound.

`test/unit-tests/cve/cveGetAllTest.js`
- Added query-construction regression tests for `/api/cve` and `/api/cve_cursor`.

`test/integration-tests/cve/getCveCnaModifiedTest.js`
- Added endpoint coverage proving only CVEs inside the requested CNA modified-date window are returned.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Call `/api/cve?time_modified.gt=<start>&time_modified.lt=<end>&cna_modified=true` and verify only in-window CNA modified records return.
- [ ] 2) Call `/api/cve_cursor?time_modified.gt=<start>&time_modified.lt=<end>&cna_modified=true` and verify only in-window CNA modified records return.
