### PR TITLE
Resolves issue #1875, fixes the CNA provider metadata `dateUpdated` index for CVE records.

### DIFF
--- a/src/model/cve.js
+++ b/src/model/cve.js
@@ -28,7 +28,7 @@ CveSchema.query.byCveId = function (id) {
 
 CveSchema.index({ 'cve.cveMetadata.cveId': 1 })
 CveSchema.index({ 'cve.cveMetadata.dateUpdated': 1 })
-CveSchema.index({ 'cve.containers.cna.provderMetadata.dateUpdated': 1 })
+CveSchema.index({ 'cve.containers.cna.providerMetadata.dateUpdated': 1 })
 CveSchema.index({ 'time.modified': 1 })
 CveSchema.index({ 'time.created': 1 })
 

--- a/src/scripts/populate.js
+++ b/src/scripts/populate.js
@@ -40,7 +40,11 @@ const populateTheseCollections = {
 }
 
 const indexesToCreate = {
-  Cve: [{ 'cve.cveMetadata.cveId': 1 }, { 'cve.cveMetadata.dateUpdated': 1 }],
+  Cve: [
+    { 'cve.cveMetadata.cveId': 1 },
+    { 'cve.cveMetadata.dateUpdated': 1 },
+    { 'cve.containers.cna.providerMetadata.dateUpdated': 1 }
+  ],
   'Cve-Id': [{ cve_id: 1 }, { owning_cna: 1, state: 1 }, { reserved: 1 }],
   User: [{ UUID: 1 }],
   Org: [{ UUID: 1 }, { 'authority.active_roles': 1 }],

--- a/test/integration-tests/cve/cveIndexesTest.js
+++ b/test/integration-tests/cve/cveIndexesTest.js
@@ -1,0 +1,43 @@
+const chai = require('chai')
+const expect = chai.expect
+const mongoose = require('mongoose')
+
+require('../../../src/index.js')
+
+function waitForMongoConnection () {
+  if (mongoose.connection.readyState === 1) {
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Timed out waiting for MongoDB connection'))
+    }, 10000)
+
+    mongoose.connection.once('open', () => {
+      clearTimeout(timeout)
+      resolve()
+    })
+
+    mongoose.connection.once('error', err => {
+      clearTimeout(timeout)
+      reject(err)
+    })
+  })
+}
+
+describe('Test CVE collection indexes', () => {
+  it('Creates the CNA provider metadata dateUpdated index', async () => {
+    await waitForMongoConnection()
+
+    const indexes = await mongoose.connection.db.collection('Cve').indexes()
+    const indexFields = indexes.map(index => index.key)
+
+    expect(indexFields).to.deep.include({
+      'cve.containers.cna.providerMetadata.dateUpdated': 1
+    })
+    expect(indexFields).to.not.deep.include({
+      'cve.containers.cna.provderMetadata.dateUpdated': 1
+    })
+  })
+})

--- a/test/unit-tests/cve/cveModelIndexesTest.js
+++ b/test/unit-tests/cve/cveModelIndexesTest.js
@@ -1,0 +1,17 @@
+const chai = require('chai')
+const expect = chai.expect
+
+const Cve = require('../../../src/model/cve')
+
+describe('Testing the Cve model indexes', () => {
+  it('Defines the CNA provider metadata dateUpdated index', () => {
+    const indexFields = Cve.schema.indexes().map(([fields]) => fields)
+
+    expect(indexFields).to.deep.include({
+      'cve.containers.cna.providerMetadata.dateUpdated': 1
+    })
+    expect(indexFields).to.not.deep.include({
+      'cve.containers.cna.provderMetadata.dateUpdated': 1
+    })
+  })
+})


### PR DESCRIPTION
Closes Issue #1875

# Summary
Corrects a misspelled CVE model index so queries against `cve.containers.cna.providerMetadata.dateUpdated` can use the intended MongoDB index. Also updates test population index creation and adds coverage to prevent the typo from returning.

# Important Changes
`src/model/cve.js`
- Fixed the misspelled `provderMetadata` index path to `providerMetadata`.

`src/scripts/populate.js`
- Added the CNA provider metadata `dateUpdated` index to the CVE indexes created during population.

`test/unit-tests/cve/cveModelIndexesTest.js`
- Added unit coverage verifying the correct index exists and the misspelled index does not.

`test/integration-tests/cve/cveIndexesTest.js`
- Added integration coverage verifying MongoDB creates the expected CVE collection index.

# Testing

Steps to manually test updated functionality, if possible
- [ ] 1) Run `npm run action:test`.
- [ ] 2) Run `npm run test:integration`.
- [ ] 3) Confirm the CVE collection indexes include `cve.containers.cna.providerMetadata.dateUpdated`.
