### PR TITLE
Resolves issue #1880, fixes JSON whitespace trimming for nested null values and error control flow.

### DIFF
--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -424,13 +424,13 @@ function trimJSONWhitespace (req, res, next) {
 
         if (typeof value === 'string') {
           currentObject[key] = value.trim()
-        } else if (typeof value === 'object') {
+        } else if (value !== null && typeof value === 'object') {
           queue.push(value) // Add nested objects to the queue
         }
       }
     }
   } catch (err) {
-    next(err)
+    return next(err)
   }
 
   next()

--- a/test/integration-tests/middleware/trimJSONWhitespaceTest.js
+++ b/test/integration-tests/middleware/trimJSONWhitespaceTest.js
@@ -1,0 +1,55 @@
+const express = require('express')
+const chai = require('chai')
+const expect = chai.expect
+chai.use(require('chai-http'))
+
+const middleware = require('../../../src/middleware/middleware')
+
+function createTrimJSONWhitespaceTestApp () {
+  const app = express()
+
+  app.use(express.json())
+  app.post('/trim-json-whitespace', middleware.trimJSONWhitespace, (req, res) => {
+    return res.status(200).json(req.body)
+  })
+
+  return app
+}
+
+describe('Trim JSON whitespace middleware integration', () => {
+  it('continues normally with nested null values and trims nested strings', async () => {
+    const app = createTrimJSONWhitespaceTestApp()
+
+    const res = await chai.request(app)
+      .post('/trim-json-whitespace')
+      .set('content-type', 'application/json')
+      .send({
+        field1: {
+          nestedNull: null,
+          nestedString: '   Test Name   ',
+          nestedArray: [
+            '   array value   ',
+            {
+              nestedArrayString: '   nested array object value   '
+            },
+            null
+          ]
+        }
+      })
+
+    expect(res).to.have.status(200)
+    expect(res.body).to.deep.equal({
+      field1: {
+        nestedNull: null,
+        nestedString: 'Test Name',
+        nestedArray: [
+          'array value',
+          {
+            nestedArrayString: 'nested array object value'
+          },
+          null
+        ]
+      }
+    })
+  })
+})

--- a/test/unit-tests/middleware/trimJSONWhitespaceTest.js
+++ b/test/unit-tests/middleware/trimJSONWhitespaceTest.js
@@ -24,6 +24,7 @@ describe('Testing trimJSONWhitespace middleware', () => {
     trimJSONWhitespace(req, res, next)
     expect(req.body).to.be.an('object')
     expect(req.body).to.deep.equal({ field1: 'this has whitespace', field2: 'trailing whitespace only' })
+    expect(next.calledOnceWithExactly()).to.equal(true)
   })
 
   it('Should successfully trim leading/trailing whitespace for a nested JSON object', async () => {
@@ -51,6 +52,7 @@ describe('Testing trimJSONWhitespace middleware', () => {
         }
       }
     })
+    expect(next.calledOnceWithExactly()).to.equal(true)
   })
 
   it('Should ignore non-string and non-object values', async () => {
@@ -63,5 +65,75 @@ describe('Testing trimJSONWhitespace middleware', () => {
     trimJSONWhitespace(req, res, next)
     expect(req.body).to.be.an('object')
     expect(req.body).to.deep.equal({ test: 'Test Name', numberTest: 25 })
+    expect(next.calledOnceWithExactly()).to.equal(true)
+  })
+
+  it('Should preserve nested null values while trimming strings', async () => {
+    const req = {
+      body: {
+        field1: {
+          nestedNull: null,
+          nestedString: '   Test Name   '
+        },
+        topLevelNull: null
+      }
+    }
+
+    trimJSONWhitespace(req, res, next)
+
+    expect(req.body).to.deep.equal({
+      field1: {
+        nestedNull: null,
+        nestedString: 'Test Name'
+      },
+      topLevelNull: null
+    })
+    expect(next.calledOnceWithExactly()).to.equal(true)
+  })
+
+  it('Should trim strings in arrays and nested objects', async () => {
+    const req = {
+      body: {
+        field1: [
+          '   array value   ',
+          {
+            nestedString: '   nested array object value   '
+          },
+          null,
+          25
+        ]
+      }
+    }
+
+    trimJSONWhitespace(req, res, next)
+
+    expect(req.body).to.deep.equal({
+      field1: [
+        'array value',
+        {
+          nestedString: 'nested array object value'
+        },
+        null,
+        25
+      ]
+    })
+    expect(next.calledOnceWithExactly()).to.equal(true)
+  })
+
+  it('Should call next with an error once and stop processing when trimming fails', async () => {
+    const expectedError = new Error('Unable to read value')
+    const body = {}
+    Object.defineProperty(body, 'badValue', {
+      enumerable: true,
+      get: () => {
+        throw expectedError
+      }
+    })
+    const req = { body }
+
+    trimJSONWhitespace(req, res, next)
+
+    expect(next.calledOnce).to.equal(true)
+    expect(next.firstCall.args).to.deep.equal([expectedError])
   })
 })


### PR DESCRIPTION
Closes Issue #1880 

# Summary
This PR updates `trimJSONWhitespace` to avoid queuing `null` values as objects and prevents double-calling `next` when an error occurs. It also adds regression coverage for nested null JSON, array trimming, nested object trimming, and single `next` behavior.

# Important Changes
`src/middleware/middleware.js`
- Queues only non-null objects for recursive trimming.
- Returns immediately after `next(err)` so the success path does not continue after failure.

`test/unit-tests/middleware/trimJSONWhitespaceTest.js`
- Adds nested null coverage.
- Verifies `next()` is called exactly once on success.
- Verifies `next(err)` is called exactly once on failure.
- Preserves coverage for strings, arrays, nested objects, and non-string values.

`test/integration-tests/middleware/trimJSONWhitespaceTest.js`
- Adds Express middleware regression coverage for nested null JSON and nested string trimming.
