### PR TITLE
Resolves issue #1882, Prevent append-audit requests without history from returning a 500.

### DIFF
--- a/src/controller/audit.controller/audit.controller.js
+++ b/src/controller/audit.controller/audit.controller.js
@@ -133,6 +133,11 @@ async function appendToAuditHistoryForOrg (req, res, next) {
       return res.status(400).json(error.invalidUUID('target_uuid'))
     }
 
+    if (!Array.isArray(body.history) || body.history.length === 0) {
+      logger.info({ uuid: req.ctx.uuid, message: 'Missing required field: history' })
+      return res.status(400).json(error.missingRequiredField('history'))
+    }
+
     const repo = req.ctx.repositories.getAuditRepository()
     const orgRepo = req.ctx.repositories.getBaseOrgRepository()
     const session = await mongoose.startSession()

--- a/test/integration-tests/audit/auditTest.js
+++ b/test/integration-tests/audit/auditTest.js
@@ -321,6 +321,25 @@ describe('Testing Audit Org endpoints', () => {
         })
     })
 
+    it('Should fail to append audit without history', async () => {
+      const appendData = {
+        target_uuid: orgUuid
+      }
+
+      await chai.request(app)
+        .put('/api/audit/org/')
+        .set(constants.headers)
+        .send(appendData)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+
+          expect(res.body).to.haveOwnProperty('error')
+          expect(res.body.error).to.equal('MISSING_REQUIRED_FIELD')
+          expect(res.body.message).to.equal("Missing required field: 'history'.")
+        })
+    })
+
     it('Should fail to create audit when uuid is provided', async () => {
       const auditData = {
         uuid: uuid.v4(),


### PR DESCRIPTION
Closes Issue #1882

# Summary
Append-audit requests now validate `history` before iterating it. Requests without a valid, non-empty `history` array return a clear 400 validation error instead of throwing a TypeError.

# Important Changes
`src/controller/audit.controller/audit.controller.js`
- Added append-audit validation for missing, non-array, or empty `history`.
- Returns `MISSING_REQUIRED_FIELD` before opening a session or iterating entries.

`test/integration-tests/audit/auditTest.js`
- Added a regression test for append-audit requests without `history`.
- Retained existing success-path coverage for valid append-audit requests.