### PR TITLE
Resolves issue #1877, validates cursor pagination limits as numeric request input.

### DIFF
--- a/src/controller/cve.controller/index.js
+++ b/src/controller/cve.controller/index.js
@@ -413,7 +413,7 @@ router.get('/cve_cursor',
   query(['assigner']).optional().isString().trim().notEmpty(),
   query(['cna_modified']).optional().isBoolean({ loose: true }).withMessage(errorMsgs.CNA_MODIFIED),
   query(['adp_short_name']).optional().isString().trim().notEmpty().isLength({ min: CONSTANTS.MIN_SHORTNAME_LENGTH, max: CONSTANTS.MAX_SHORTNAME_LENGTH }),
-  query(['limit']).optional().isString().trim().notEmpty().isLength({ min: 1, max: CONSTANTS.PAGINATOR_OPTIONS.limit }),
+  query(['limit']).optional().not().isArray().trim().isInt({ min: 1, max: CONSTANTS.PAGINATOR_OPTIONS.limit }).toInt(),
   parseError,
   parseGetParams,
   controller.CVE_GET_FILTERED_CURSOR)

--- a/test/integration-tests/cve/cursorPaginationTest.js
+++ b/test/integration-tests/cve/cursorPaginationTest.js
@@ -7,8 +7,10 @@ const helpers = require('../helpers.js')
 const expect = chai.expect
 
 const constants = require('../constants.js')
+const getConstants = require('../../../src/constants').getConstants
 const app = require('../../../src/index.js')
 const currentDate = new Date().toISOString()
+const PAGINATOR_LIMIT = getConstants().PAGINATOR_OPTIONS.limit
 
 describe('Testing Get cve_cursor endpoint', () => {
   let cveIds = []
@@ -210,5 +212,49 @@ describe('Testing Get cve_cursor endpoint', () => {
 
       requester.close()
     }).timeout(1000000)
+  })
+
+  context('Negative Tests', () => {
+    it('Get cve_cursor should reject non-numeric limit parameter', async () => {
+      await chai.request(app)
+        .get('/api/cve_cursor?limit=abc')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body).to.have.property('error', 'BAD_INPUT')
+          expect(res.body).to.have.property('message', 'Parameters were invalid')
+          expect(res.body.details).to.be.an('array').that.is.not.empty
+          expect(res.body.details[0]).to.include({ param: 'limit', location: 'query' })
+        })
+    })
+
+    it('Get cve_cursor should reject limit parameter below the minimum', async () => {
+      await chai.request(app)
+        .get('/api/cve_cursor?limit=0')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body).to.have.property('error', 'BAD_INPUT')
+          expect(res.body).to.have.property('message', 'Parameters were invalid')
+          expect(res.body.details).to.be.an('array').that.is.not.empty
+          expect(res.body.details[0]).to.include({ param: 'limit', location: 'query' })
+        })
+    })
+
+    it('Get cve_cursor should reject limit parameter above the maximum', async () => {
+      await chai.request(app)
+        .get(`/api/cve_cursor?limit=${PAGINATOR_LIMIT + 1}`)
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body).to.have.property('error', 'BAD_INPUT')
+          expect(res.body).to.have.property('message', 'Parameters were invalid')
+          expect(res.body.details).to.be.an('array').that.is.not.empty
+          expect(res.body.details[0]).to.include({ param: 'limit', location: 'query' })
+        })
+    })
   })
 })

--- a/test/unit-tests/cve/cveGetAllTest.js
+++ b/test/unit-tests/cve/cveGetAllTest.js
@@ -123,6 +123,51 @@ describe('Testing the GET /cve endpoint in Cve Controller', () => {
       })
     })
 
+    it('Passes sanitized numeric cursor limit to pagination', async () => {
+      let paginationLimit = null
+
+      class MyCvePositiveTests {
+        async cursorPaginate (query, limit) {
+          paginationLimit = limit
+
+          return {
+            results: [],
+            hasNext: false,
+            hasPrevious: false,
+            next: null,
+            previous: null
+          }
+        }
+      }
+
+      const req = {
+        ctx: {
+          uuid: 'unit-test',
+          query: {
+            limit: 2
+          },
+          repositories: {
+            getCveRepository: () => { return new MyCvePositiveTests() }
+          }
+        }
+      }
+
+      let statusCode = null
+      const res = {
+        status: (code) => {
+          statusCode = code
+          return res
+        },
+        json: () => {}
+      }
+
+      await cveController.CVE_GET_FILTERED_CURSOR(req, res, (err) => { throw err })
+
+      expect(statusCode).to.equal(200)
+      expect(paginationLimit).to.equal(2)
+      expect(paginationLimit).to.be.a('number')
+    })
+
     it('JSON schema v5.0 returned: The secretariat gets a list of non-paginated cve records', (done) => {
       const itemsPerPage = 500
 


### PR DESCRIPTION
Closes Issue #1877

# Summary
This MR fixes `GET /api/cve_cursor` limit validation so non-numeric and out-of-range values fail request validation before reaching pagination logic.

# Important Changes
`src/controller/cve.controller/index.js`
- Changed `limit` validation from string length checking to integer range validation.
- Converts valid `limit` values to numbers with `toInt()`.
- Rejects repeated/array `limit` query params.

`test/integration-tests/cve/cursorPaginationTest.js`
- Added validation coverage for non-numeric, below-minimum, and above-maximum `limit` values.

`test/unit-tests/cve/cveGetAllTest.js`
- Added coverage confirming sanitized numeric `limit` reaches cursor pagination.
