### PR TITLE
Resolves issue #1879, fixes date-only query filter sanitization.

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -201,9 +201,11 @@ function toDate (val) {
     }
   } else {
     value = val.match(/^\d{4}-\d{2}-\d{2}$/)
-    /* eslint-disable-next-line */
-    if ((value) && DateTime.fromISO(dateStr.toString()).isValid) {
-      result = new Date(`${value[0]}T00:00:00.000+00:00`)
+    if (value) {
+      const dateStr = value[0]
+      if (DateTime.fromISO(dateStr.toString()).isValid) {
+        result = new Date(`${dateStr}T00:00:00.000+00:00`)
+      }
     }
   }
   return result

--- a/test/integration-tests/cve-id/getCveIdTest.js
+++ b/test/integration-tests/cve-id/getCveIdTest.js
@@ -37,6 +37,16 @@ describe('Testing Get CVE-ID endpoint', () => {
           expect(res.body.cve_ids).to.have.length(0)
         })
     })
+    it('Get CVE-ID should accept a valid date-only time_modified.gt filter', async () => {
+      await chai.request(app)
+        .get('/api/cve-id?time_modified.gt=2100-01-01')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.cve_ids).to.have.length(0)
+        })
+    })
     // Need a better way to test each individual cve-id's time_modified
     it('Get all CVE-IDs modified within a given timeframe', async () => {
       await chai.request(app)
@@ -277,6 +287,17 @@ describe('Testing Get CVE-ID endpoint', () => {
     it('Feb 29 2100 should not be valid', async () => {
       await chai.request(app)
         .get('/api/cve-id?time_modified.gt=2100-02-29T00:00:00Z')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.contain('BAD_INPUT')
+        })
+    })
+
+    it('Date-only Feb 29 2100 should not be valid', async () => {
+      await chai.request(app)
+        .get('/api/cve-id?time_modified.gt=2100-02-29')
         .set(constants.headers)
         .then((res, err) => {
           expect(err).to.be.undefined

--- a/test/integration-tests/cve/getCveDateTest.js
+++ b/test/integration-tests/cve/getCveDateTest.js
@@ -8,7 +8,32 @@ const constants = require('../constants.js')
 const app = require('../../../src/index.js')
 
 describe('Test time_modified for get CVE', () => {
+  context('Positive Tests', () => {
+    it('Get CVE should accept a valid date-only time_modified.gt filter', async () => {
+      await chai.request(app)
+        .get('/api/cve?time_modified.gt=2100-01-01')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.cveRecords).to.be.an('array')
+        })
+    })
+  })
+
   context('Negative Tests', () => {
+    it('Get CVE should fail cleanly if time_modified.gt is given an invalid date-only value', async () => {
+      await chai.request(app)
+        .get('/api/cve?time_modified.gt=2026-02-29')
+        .set(constants.headers)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(400)
+          expect(res.body.error).to.equal('BAD_INPUT')
+          expect(res.body.message).to.contain('Parameters were invalid')
+        })
+    })
+
     it('Get CVE should fail if time_modified.gt is given a date with an invalid month', async () => {
       await chai.request(app)
         .get('/api/cve?time_modified.gt=2022-13-01T00:00:00Z')

--- a/test/unit-tests/utils/utilsTest.js
+++ b/test/unit-tests/utils/utilsTest.js
@@ -32,8 +32,19 @@ describe('Testing shared utility helpers', () => {
       expect(result.toISOString()).to.equal('2026-06-04T12:30:00.000Z')
     })
 
+    it('Should convert valid date-only strings to UTC midnight Date objects', () => {
+      const result = toDate('2026-06-04')
+
+      expect(result).to.be.instanceOf(Date)
+      expect(result.toISOString()).to.equal('2026-06-04T00:00:00.000Z')
+    })
+
     it('Should return null for invalid timestamp strings', () => {
       expect(toDate('2026-13-04T12:30:00Z')).to.equal(null)
+    })
+
+    it('Should return null for invalid date-only strings', () => {
+      expect(toDate('2026-02-29')).to.equal(null)
     })
   })
 


### PR DESCRIPTION
Closes Issue #1879 

# Summary
This MR fixes `toDate()` date-only parsing so valid `YYYY-MM-DD` filters no longer throw `ReferenceError`, while invalid date-only values return the normal validation error.

# Important Changes
`src/utils/utils.js`
- Defines a local `dateStr` in the date-only branch.
- Validates date-only strings with Luxon before converting them to UTC midnight.

`test/unit-tests/utils/utilsTest.js`
- Adds valid and invalid date-only sanitizer coverage.

`test/integration-tests/cve/getCveDateTest.js`
- Adds CVE endpoint regression coverage for date-only filters.

`test/integration-tests/cve-id/getCveIdTest.js`
- Adds CVE ID endpoint regression coverage for date-only filters.