### PR TITLE
Resolves issue #1868, hardens CVE ID modification against unauthenticated org short-name fallback.

### DIFF
--- a/src/controller/cve-id.controller/cve-id.controller.js
+++ b/src/controller/cve-id.controller/cve-id.controller.js
@@ -341,10 +341,14 @@ async function modifyCveId (req, res, next) {
     const cveIdRepo = req.ctx.repositories.getCveIdRepository()
     const userRepo = req.ctx.repositories.getUserRepository()
     const cveRepo = req.ctx.repositories.getCveRepository()
+    if (!req.ctx.authenticated) {
+      return res.status(403).json(error.orgCannotReserveForOther())
+    }
+
     const requesterOrgUUID = await authContext.getRequesterOrgUUID(req, orgRepo)
     const org = requesterOrgUUID && typeof orgRepo.findOneByUUID === 'function'
       ? await orgRepo.findOneByUUID(requesterOrgUUID)
-      : (!req.ctx.authenticated ? await orgRepo.findOneByShortName(req.ctx.org) : null)
+      : null
     if (!org) {
       return res.status(403).json(error.orgCannotReserveForOther())
     }

--- a/test/integration-tests/cve-id/cveIdUpdateTest.js
+++ b/test/integration-tests/cve-id/cveIdUpdateTest.js
@@ -15,6 +15,20 @@ describe('Text PUT CVE-ID/:id', () => {
   before(async () => {
     cveId = await helpers.cveIdReserveHelper(1, '2023', shortName, 'non-sequential')
   })
+  context('Authentication Tests', () => {
+    it('Endpoint should reject invalid authentication before updating a CVE ID', async () => {
+      await chai.request(app)
+        .put(`/api/cve-id/${cveId}?state=REJECTED`)
+        .set({
+          ...constants.nonSecretariatUserHeaders2,
+          'CVE-API-Key': 'invalid-api-key'
+        })
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(401)
+        })
+    })
+  })
   context('State parameter Tests', () => {
     it('Endpoint should return a 400 when state org is set to published', async () => {
       await chai.request(app)

--- a/test/unit-tests/cve-id/cveIdUpdateTest.js
+++ b/test/unit-tests/cve-id/cveIdUpdateTest.js
@@ -44,9 +44,19 @@ class UserModifyCveIdOrgAndStateModified {
   }
 }
 
+function authenticateAsSecretariat (req) {
+  req.ctx.authenticated = true
+  req.ctx.orgUUID = cveIdFixtures.secretariatOrg.UUID
+  req.ctx.userUUID = cveIdFixtures.secretariatUser.UUID
+}
+
 class OrgModifyCveIdOrgAndStateModified {
   async getOrgUUID () {
     return cveIdFixtures.org.UUID
+  }
+
+  async findOneByUUID () {
+    return cveIdFixtures.secretariatOrg
   }
 
   async findOneByShortName (shortName) {
@@ -82,6 +92,53 @@ class CveIdModifyCveIdOrgAndStateModified {
 
 describe('Testing the PUT /cve-id/:id endpoint in CveId Controller', () => {
   context('Negative Tests', () => {
+    it('Unauthenticated direct controller requests do not resolve the org short name', (done) => {
+      let shortNameLookupCalled = false
+
+      class OrgModifyCveIdUnauthenticated {
+        async getOrgUUID () {
+          return cveIdFixtures.secretariatOrg.UUID
+        }
+
+        async findOneByUUID () {
+          return cveIdFixtures.secretariatOrg
+        }
+
+        async findOneByShortName () {
+          shortNameLookupCalled = true
+          return cveIdFixtures.secretariatOrg
+        }
+      }
+
+      app.route('/cve-id-modify-unauthenticated/:id')
+        .put((req, res, next) => {
+          const factory = {
+            getCveIdRepository: () => { return new CveIdModifyCveIdOrgAndStateModified() },
+            getOrgRepository: () => { return new OrgModifyCveIdUnauthenticated() },
+            getUserRepository: () => { return new NullUserRepo() },
+            getCveRepository: () => { return new NullCveRepo() }
+          }
+          req.ctx.repositories = factory
+          next()
+        }, cveIdParams.parsePostParams, cveIdController.CVEID_UPDATE_SINGLE)
+
+      chai.request(app)
+        .put(`/cve-id-modify-unauthenticated/${cveIdFixtures.cveId}?state=REJECTED`)
+        .set(cveIdFixtures.secretariatHeader)
+        .end((err, res) => {
+          if (err) {
+            done(err)
+          }
+
+          expect(res).to.have.status(403)
+          expect(shortNameLookupCalled).to.equal(false)
+          const errObj = error.orgCannotReserveForOther()
+          expect(res.body.error).to.equal(errObj.error)
+          expect(res.body.message).to.equal(errObj.message)
+          done()
+        })
+    })
+
     it('CVE ID does not exist', (done) => {
       class CveIdModifyCveIdDoesntExist {
         async findOneByCveId () {
@@ -99,6 +156,10 @@ describe('Testing the PUT /cve-id/:id endpoint in CveId Controller', () => {
           return null
         }
 
+        async findOneByUUID () {
+          return cveIdFixtures.secretariatOrg
+        }
+
         async findOneByShortName (shortName) {
           return cveIdFixtures.org
         }
@@ -112,6 +173,7 @@ describe('Testing the PUT /cve-id/:id endpoint in CveId Controller', () => {
             getUserRepository: () => { return new NullUserRepo() },
             getCveRepository: () => { return new NullCveRepo() }
           }
+          authenticateAsSecretariat(req)
           req.ctx.repositories = factory
           next()
         }, cveIdParams.parsePostParams, cveIdController.CVEID_UPDATE_SINGLE)
@@ -139,6 +201,10 @@ describe('Testing the PUT /cve-id/:id endpoint in CveId Controller', () => {
           return null
         }
 
+        async findOneByUUID () {
+          return cveIdFixtures.secretariatOrg
+        }
+
         async findOneByShortName (shortName) {
           return cveIdFixtures.org
         }
@@ -152,6 +218,7 @@ describe('Testing the PUT /cve-id/:id endpoint in CveId Controller', () => {
             getUserRepository: () => { return new NullUserRepo() },
             getCveRepository: () => { return new NullCveRepo() }
           }
+          authenticateAsSecretariat(req)
           req.ctx.repositories = factory
           next()
         }, cveIdParams.parsePostParams, cveIdController.CVEID_UPDATE_SINGLE)
@@ -219,6 +286,7 @@ describe('Testing the PUT /cve-id/:id endpoint in CveId Controller', () => {
             getUserRepository: () => { return new UserModifyCveIdOrgAndStateModified() },
             getCveRepository: () => { return new NullCveRepo() }
           }
+          authenticateAsSecretariat(req)
           req.ctx.repositories = factory
           next()
         }, cveIdParams.parsePostParams, cveIdController.CVEID_UPDATE_SINGLE)
@@ -279,6 +347,7 @@ describe('Testing the PUT /cve-id/:id endpoint in CveId Controller', () => {
             getUserRepository: () => { return new UserModifyCveIdOrgAndStateModified() },
             getCveRepository: () => { return new NullCveRepo() }
           }
+          authenticateAsSecretariat(req)
           req.ctx.repositories = factory
           next()
         }, cveIdParams.parsePostParams, cveIdController.CVEID_UPDATE_SINGLE)


### PR DESCRIPTION
Closes Issue #1868 

# Summary
This PR updates CVE ID modification so `modifyCveId` requires authenticated request context and no longer falls back to resolving `req.ctx.org` by short name when unauthenticated.

# Important Changes
`src/controller/cve-id.controller/cve-id.controller.js`
- Added a fail-closed authentication guard in `modifyCveId`.
- Removed the unauthenticated `findOneByShortName(req.ctx.org)` fallback.

`test/unit-tests/cve-id/cveIdUpdateTest.js`
- Added regression coverage proving unauthenticated direct controller calls do not resolve org short names.
- Updated controller tests to model authenticated middleware context.

`test/integration-tests/cve-id/cveIdUpdateTest.js`
- Added route-level coverage that invalid auth is rejected before CVE ID update.