### PR TITLE
Resolves issue #1870, hardens auth context helpers so unauthenticated requests cannot use unvalidated requester header context for identity or role decisions.

### DIFF
--- a/src/middleware/middleware.js
+++ b/src/middleware/middleware.js
@@ -31,6 +31,7 @@ function createCtxAndReqUUID (req, res, next) {
 
     req.ctx = {
       authenticated: false,
+      authenticationChecked: false,
       uuid: uuid.v4(),
       org: req.header(CONSTANTS.AUTH_HEADERS.ORG),
       orgUUID: null,
@@ -84,6 +85,7 @@ async function optionallyValidateUser (req, res, next) {
     }
 
     req.ctx.authenticated = authenticated
+    req.ctx.authenticationChecked = true
     if (authenticated) {
       logger.info({ uuid: req.ctx.uuid, message: 'SUCCESSFUL user authentication for ' + user })
     }
@@ -158,6 +160,7 @@ async function validateUser (req, res, next) {
     req.ctx.orgUUID = orgUUID
     req.ctx.userUUID = result.UUID
     req.ctx.authenticated = true
+    req.ctx.authenticationChecked = true
     logger.info({ uuid: req.ctx.uuid, message: 'SUCCESSFUL user authentication for ' + user })
     next()
   } catch (err) {

--- a/src/utils/authContext.js
+++ b/src/utils/authContext.js
@@ -48,6 +48,10 @@ function isAuthenticatedRequest (req) {
   return req?.ctx?.authenticated === true
 }
 
+function isUnauthenticatedAfterAuthenticationCheck (req) {
+  return !isAuthenticatedRequest(req) && req?.ctx?.authenticationChecked === true
+}
+
 async function findOrgByUUID (orgRepo, orgUUID, options = {}, returnLegacyFormat = false) {
   if (!orgUUID || typeof orgRepo?.findOneByUUID !== 'function') {
     return null
@@ -152,7 +156,7 @@ async function getRequesterOrgUUID (req, orgRepo, options = {}, useLegacy = fals
     return req.ctx.orgUUID
   }
 
-  if (isAuthenticatedRequest(req)) {
+  if (isAuthenticatedRequest(req) || isUnauthenticatedAfterAuthenticationCheck(req)) {
     return null
   }
 
@@ -173,7 +177,7 @@ async function getRequesterOrg (req, orgRepo, options = {}, returnLegacyFormat =
     return findOrgByUUID(orgRepo, req.ctx.orgUUID, options, returnLegacyFormat)
   }
 
-  if (isAuthenticatedRequest(req)) {
+  if (isAuthenticatedRequest(req) || isUnauthenticatedAfterAuthenticationCheck(req)) {
     return null
   }
 
@@ -189,7 +193,7 @@ async function getRequesterUser (req, userRepo, orgRepo, options = {}, isRegistr
     return findUserByUUID(userRepo, req.ctx.userUUID, options, isRegistryObject)
   }
 
-  if (isAuthenticatedRequest(req) && !req.ctx.userUUID) {
+  if (isAuthenticatedRequest(req) || isUnauthenticatedAfterAuthenticationCheck(req)) {
     return null
   }
 
@@ -215,7 +219,7 @@ async function getRequesterUserUUID (req, userRepo, orgRepo, options = {}, isReg
     return req.ctx.userUUID
   }
 
-  if (isAuthenticatedRequest(req)) {
+  if (isAuthenticatedRequest(req) || isUnauthenticatedAfterAuthenticationCheck(req)) {
     return null
   }
 
@@ -281,6 +285,10 @@ async function isRequesterSecretariat (req, orgRepo, options = {}, returnLegacyF
     return orgHasRoleByUUID(orgRepo, orgUUID, 'SECRETARIAT', options, returnLegacyFormat)
   }
 
+  if (isUnauthenticatedAfterAuthenticationCheck(req)) {
+    return false
+  }
+
   if (hasOwnMethod(orgRepo, 'isSecretariatByShortName')) {
     return orgRepo.isSecretariatByShortName(req.ctx.org, options, returnLegacyFormat)
   }
@@ -312,6 +320,10 @@ async function isRequesterBulkDownload (req, orgRepo, options = {}, returnLegacy
     return orgHasRoleByUUID(orgRepo, orgUUID, 'BULK_DOWNLOAD', options, returnLegacyFormat)
   }
 
+  if (isUnauthenticatedAfterAuthenticationCheck(req)) {
+    return false
+  }
+
   if (typeof orgRepo?.isBulkDownloadByShortname === 'function') {
     return orgRepo.isBulkDownloadByShortname(req.ctx.org, options, returnLegacyFormat)
   }
@@ -332,6 +344,10 @@ async function isRequesterAdmin (req, userRepo, orgRepo, options = {}, isRegistr
     return isUserAdminOfOrgUUID(userRepo, orgRepo, req.ctx.userUUID, req.ctx.orgUUID, options, isRegistryObject)
   }
 
+  if (isUnauthenticatedAfterAuthenticationCheck(req)) {
+    return false
+  }
+
   if (typeof userRepo?.isAdmin === 'function') {
     return userRepo.isAdmin(req.ctx.user, req.ctx.org, options, isRegistryObject)
   }
@@ -344,7 +360,7 @@ async function isRequesterAdminOfOrg (req, userRepo, orgRepo, targetOrgOrShortNa
     ? targetOrgOrShortName
     : targetOrgOrShortName?.short_name
 
-  if (isAuthenticatedRequest(req)) {
+  if (isAuthenticatedRequest(req) || (req.ctx.orgUUID && req.ctx.userUUID)) {
     if (!req.ctx.orgUUID || !req.ctx.userUUID) {
       return false
     }
@@ -376,6 +392,10 @@ async function isRequesterAdminOfOrg (req, userRepo, orgRepo, targetOrgOrShortNa
       return userHasAdminRole(user)
     }
 
+    return false
+  }
+
+  if (isUnauthenticatedAfterAuthenticationCheck(req)) {
     return false
   }
 

--- a/test/integration-tests/cve-id/getCveIdTest.js
+++ b/test/integration-tests/cve-id/getCveIdTest.js
@@ -267,6 +267,25 @@ describe('Testing Get CVE-ID endpoint', () => {
         })
     })
 
+    it('Invalid Secretariat credentials should be treated as unauthenticated for optionallyValidateUser endpoints (GET /api/cve-id/:id)', async function () {
+      const cveId = await helpers.cveIdReserveHelper(1, '2023', constants.nonSecretariatUserHeaders['CVE-API-ORG'], 'non-sequential')
+      const invalidSecretariatHeaders = {
+        ...constants.headers,
+        'CVE-API-KEY': 'invalid-secret'
+      }
+
+      await chai.request(app)
+        .get(`/api/cve-id/${cveId}`)
+        .set(invalidSecretariatHeaders)
+        .then((res, err) => {
+          expect(err).to.be.undefined
+          expect(res).to.have.status(200)
+          expect(res.body.cve_id).to.equal(cveId)
+          expect(res.body.owning_cna).to.equal('[REDACTED]')
+          expect(res.body).to.not.have.property('requested_by')
+        })
+    })
+
     it('An inactive user should be denied access for validateUser endpoints (GET /api/cve-id)', async function () {
       // Deactivate user
       await helpers.userDeactivateAsSecHelper(constants.nonSecretariatUserHeaders['CVE-API-USER'], constants.nonSecretariatUserHeaders['CVE-API-ORG'])

--- a/test/unit-tests/utils/authContextTest.js
+++ b/test/unit-tests/utils/authContextTest.js
@@ -1,0 +1,104 @@
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+const authContext = require('../../../src/utils/authContext')
+
+describe('Testing authContext requester helpers', () => {
+  let req
+  let orgRepo
+  let userRepo
+
+  beforeEach(() => {
+    req = {
+      ctx: {
+        authenticated: false,
+        authenticationChecked: true,
+        org: 'mitre',
+        orgUUID: null,
+        user: 'admin-user',
+        userUUID: null
+      }
+    }
+
+    orgRepo = {
+      getOrgUUID: sinon.stub().rejects(new Error('short-name org lookup should not be called')),
+      findOneByShortName: sinon.stub().rejects(new Error('short-name org lookup should not be called')),
+      isSecretariatByShortName: sinon.stub().rejects(new Error('short-name Secretariat check should not be called')),
+      isBulkDownloadByShortname: sinon.stub().rejects(new Error('short-name bulk download check should not be called')),
+      isSecretariat: sinon.stub().throws(new Error('short-name Secretariat check should not be called')),
+      isBulkDownload: sinon.stub().throws(new Error('short-name bulk download check should not be called')),
+      hasRoleByUUID: sinon.stub().resolves(true),
+      findOneByUUID: sinon.stub().resolves({ UUID: 'org-uuid', authority: ['SECRETARIAT'] })
+    }
+
+    userRepo = {
+      getUserUUID: sinon.stub().rejects(new Error('short-name user lookup should not be called')),
+      findOneByUsernameAndOrgShortname: sinon.stub().rejects(new Error('short-name user lookup should not be called')),
+      isAdmin: sinon.stub().rejects(new Error('short-name admin check should not be called')),
+      isAdminOrSecretariat: sinon.stub().rejects(new Error('short-name admin check should not be called')),
+      isUserAdminOfOrgUUID: sinon.stub().resolves(true),
+      findUserByUUID: sinon.stub().resolves({ UUID: 'user-uuid', role: 'ADMIN' })
+    }
+  })
+
+  it('Should not resolve requester identity or roles from unauthenticated header values', async () => {
+    expect(await authContext.getRequesterOrgUUID(req, orgRepo)).to.equal(null)
+    expect(await authContext.getRequesterOrg(req, orgRepo)).to.equal(null)
+    expect(await authContext.getRequesterUser(req, userRepo, orgRepo)).to.equal(null)
+    expect(await authContext.getRequesterUserUUID(req, userRepo, orgRepo)).to.equal(null)
+    expect(await authContext.isRequesterSecretariat(req, orgRepo)).to.equal(false)
+    expect(await authContext.isRequesterBulkDownload(req, orgRepo)).to.equal(false)
+    expect(await authContext.isRequesterAdmin(req, userRepo, orgRepo)).to.equal(false)
+    expect(await authContext.isRequesterAdminOfOrg(req, userRepo, orgRepo, 'target-org')).to.equal(false)
+
+    const context = await authContext.getRequesterContext(req, { orgRepo, userRepo })
+    expect(context).to.deep.equal({
+      org: null,
+      orgUUID: null,
+      user: null,
+      userUUID: null,
+      isSecretariat: false,
+      isBulkDownload: false,
+      isAdmin: false
+    })
+
+    expect(orgRepo.getOrgUUID.called).to.equal(false)
+    expect(orgRepo.findOneByShortName.called).to.equal(false)
+    expect(orgRepo.isSecretariatByShortName.called).to.equal(false)
+    expect(orgRepo.isBulkDownloadByShortname.called).to.equal(false)
+    expect(userRepo.getUserUUID.called).to.equal(false)
+    expect(userRepo.findOneByUsernameAndOrgShortname.called).to.equal(false)
+    expect(userRepo.isAdmin.called).to.equal(false)
+    expect(userRepo.isAdminOrSecretariat.called).to.equal(false)
+  })
+
+  it('Should resolve requester identity and roles from internal UUID context without short-name lookups', async () => {
+    req.ctx.orgUUID = 'org-uuid'
+    req.ctx.userUUID = 'user-uuid'
+
+    expect(await authContext.getRequesterOrgUUID(req, orgRepo)).to.equal('org-uuid')
+    expect(await authContext.getRequesterUserUUID(req, userRepo, orgRepo)).to.equal('user-uuid')
+    expect(await authContext.isRequesterSecretariat(req, orgRepo)).to.equal(true)
+    expect(await authContext.isRequesterAdmin(req, userRepo, orgRepo)).to.equal(true)
+
+    expect(orgRepo.getOrgUUID.called).to.equal(false)
+    expect(orgRepo.findOneByShortName.called).to.equal(false)
+    expect(userRepo.getUserUUID.called).to.equal(false)
+    expect(userRepo.isAdmin.called).to.equal(false)
+  })
+
+  it('Should resolve requester identity and roles from authenticated UUID context', async () => {
+    req.ctx.authenticated = true
+    req.ctx.orgUUID = 'org-uuid'
+    req.ctx.userUUID = 'user-uuid'
+
+    expect(await authContext.getRequesterOrgUUID(req, orgRepo)).to.equal('org-uuid')
+    expect(await authContext.getRequesterOrg(req, orgRepo)).to.deep.equal({ UUID: 'org-uuid', authority: ['SECRETARIAT'] })
+    expect(await authContext.getRequesterUserUUID(req, userRepo, orgRepo)).to.equal('user-uuid')
+    expect(await authContext.getRequesterUser(req, userRepo, orgRepo)).to.deep.equal({ UUID: 'user-uuid', role: 'ADMIN' })
+    expect(await authContext.isRequesterSecretariat(req, orgRepo)).to.equal(true)
+    expect(await authContext.isRequesterBulkDownload(req, orgRepo)).to.equal(true)
+    expect(await authContext.isRequesterAdmin(req, userRepo, orgRepo)).to.equal(true)
+    expect(await authContext.isRequesterAdminOfOrg(req, userRepo, orgRepo, { UUID: 'target-org-uuid', admins: ['user-uuid'] })).to.equal(true)
+  })
+})


### PR DESCRIPTION
Closes Issue #1870

# Summary

This change distinguishes between requests where authentication has not been evaluated and requests where authentication was evaluated and failed. Once authentication has failed, auth-context helpers no longer fall back to raw `req.ctx.org` or `req.ctx.user` values when resolving requester organization, requester user, UUIDs, Secretariat status, bulk-download status, admin status, or admin-of-org status.

# Important Changes

`src/middleware/middleware.js`
- Added `req.ctx.authenticationChecked`.
- Set the flag in both required and optional authentication middleware after auth evaluation succeeds or fails.

`src/utils/authContext.js`
- Added a helper for detecting unauthenticated requests after an auth check.
- Prevented raw requester header fallback for unauthenticated-after-check requests.
- Preserved trusted UUID-based internal context behavior.

`test/unit-tests/utils/authContextTest.js`
- Added unit coverage for unauthenticated fallback blocking.
- Added coverage for trusted internal UUID context and authenticated UUID context.

`test/integration-tests/cve-id/getCveIdTest.js`
- Added an integration regression for invalid credentials on an optionally authenticated endpoint.
